### PR TITLE
Process each dataset per histogram key

### DIFF
--- a/analysis/topeft_run2/metadata.yml
+++ b/analysis/topeft_run2/metadata.yml
@@ -1,0 +1,83 @@
+channels:
+  - 2lss_m_4j
+  - 2lss_m_5j
+  - 2lss_m_6j
+  - 2lss_m_7j
+  - 2lss_p_4j
+  - 2lss_p_5j
+  - 2lss_p_6j
+  - 2lss_p_7j
+  - 3l_onZ_1b
+  - 3l_onZ_2b
+  - 3l_m_offZ_1b
+  - 3l_m_offZ_2b
+  - 3l_p_offZ_1b
+  - 3l_p_offZ_2b
+  - 4l
+applications:
+  - isAR_2lSS_OS
+  - isSR_2lSS
+  - isAR_2lSS
+  - isSR_3l
+  - isAR_3l
+  - isSR_4l
+channel_applications:
+  2lss_m_4j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
+  2lss_m_5j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
+  2lss_m_6j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
+  2lss_m_7j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
+  2lss_p_4j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
+  2lss_p_5j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
+  2lss_p_6j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
+  2lss_p_7j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
+  3l_onZ_1b: [isSR_3l, isAR_3l]
+  3l_onZ_2b: [isSR_3l, isAR_3l]
+  3l_m_offZ_1b: [isSR_3l, isAR_3l]
+  3l_m_offZ_2b: [isSR_3l, isAR_3l]
+  3l_p_offZ_1b: [isSR_3l, isAR_3l]
+  3l_p_offZ_2b: [isSR_3l, isAR_3l]
+  4l: [isSR_4l]
+systematics:
+  - nominal
+  - lepSF_muonUp
+  - lepSF_muonDown
+  - lepSF_elecUp
+  - lepSF_elecDown
+  - btagSFbc_corrUp
+  - btagSFbc_corrDown
+  - btagSFlight_corrUp
+  - btagSFlight_corrDown
+  - PUUp
+  - PUDown
+  - PreFiringUp
+  - PreFiringDown
+  - FSRUp
+  - FSRDown
+  - ISRUp
+  - ISRDown
+  - renormUp
+  - renormDown
+  - factUp
+  - factDown
+variables:
+  - invmass
+  - ptbl
+  - ptz
+  - njets
+  - nbtagsl
+  - l0pt
+  - l1pt
+  - l1eta
+  - j0pt
+  - b0pt
+  - l0eta
+  - j0eta
+  - ht
+  - met
+  - ljptsum
+  - o0pt
+  - bl0pt
+  - lj0pt
+  - ptz_wtau
+  - tau0pt
+  - lt

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -6,6 +6,7 @@ import time
 import cloudpickle
 import gzip
 import os
+import yaml
 
 from coffea import processor
 from coffea.nanoevents import NanoAODSchema
@@ -16,6 +17,7 @@ import topcoffea.modules.remote_environment as remote_environment
 from topeft.modules.dataDrivenEstimation import DataDrivenProducer
 from topeft.modules.get_renormfact_envelope import get_renormfact_envelope
 import analysis_processor
+from topeft.modules.axes import info as axes_info
 
 LST_OF_KNOWN_EXECUTORS = ["futures", "work_queue", "taskvine"]
 
@@ -443,20 +445,22 @@ if __name__ == "__main__":
     else:
         print("No Wilson coefficients specified")
 
-    processor_instance = analysis_processor.AnalysisProcessor(
-        samplesdict,
-        wc_lst,
-        hist_lst,
-        ecut_threshold,
-        do_errors,
-        do_systs,
-        split_lep_flavor,
-        skip_sr,
-        skip_cr,
-        offZ_split=offZ_split,
-        tau_h_analysis=tau_h_analysis,
-        fwd_analysis=fwd_analysis,
-    )
+    metadata_path = os.path.join(os.path.dirname(__file__), "metadata.yml")
+    with open(metadata_path, "r") as f:
+        metadata = yaml.safe_load(f)
+
+    ch_lst = metadata["channels"]
+    ch_app_map = metadata.get("channel_applications", {})
+    syst_lst = metadata["systematics"]
+    var_lst = hist_lst if hist_lst is not None else metadata["variables"]
+    sample_lst = list(samplesdict.keys())
+    key_lst = []
+    for var in var_lst:
+        for ch in ch_lst:
+            for appl in ch_app_map.get(ch, []):
+                for sample in sample_lst:
+                    for syst in syst_lst:
+                        key_lst.append((var, ch, appl, sample, syst))
 
     if executor in ["work_queue", "taskvine"]:
         executor_args = {
@@ -558,7 +562,28 @@ if __name__ == "__main__":
             xrootdtimeout=300,
         )
 
-    output = runner(flist, treename, processor_instance)
+    output = {}
+    for key in key_lst:
+        sample = key[3]
+        sample_dict = {sample: samplesdict[sample]}
+        sample_flist = {sample: flist[sample]}
+        processor_instance = analysis_processor.AnalysisProcessor(
+            sample_dict,
+            wc_lst,
+            key,
+            ecut_threshold,
+            do_errors,
+            do_systs,
+            split_lep_flavor,
+            skip_sr,
+            skip_cr,
+            offZ_split=offZ_split,
+            tau_h_analysis=tau_h_analysis,
+            fwd_analysis=fwd_analysis,
+        )
+        out = runner(sample_flist, treename, processor_instance)
+        output.update(out)
+
 
     dt = time.time() - tstart
 
@@ -568,10 +593,6 @@ if __name__ == "__main__":
                 nevts_total, dt, nevts_total / dt
             )
         )
-
-    # nbins = sum(sum(arr.size for arr in h.eval({}).values()) for h in output.values() if isinstance(h, hist.Hist))
-    # nfilled = sum(sum(np.sum(arr > 0) for arr in h.eval({}).values()) for h in output.values() if isinstance(h, hist.Hist))
-    # print("Filled %.0f bins, nonzero bins: %1.1f %%" % (nbins, 100*nfilled/nbins,))
 
     if executor == "futures":
         print(


### PR DESCRIPTION
## Summary
- Build histogram keys per variable, channel, application, sample, and systematic
- Run `AnalysisProcessor` on a single dataset per key and merge outputs
- Remove stray `topcoffea/` rule from `.gitignore`

## Testing
- `python -m py_compile analysis/topeft_run2/analysis_processor.py analysis/topeft_run2/run_analysis.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'topeft'; ModuleNotFoundError: No module named 'ndcctools')*

------
https://chatgpt.com/codex/tasks/task_e_68b5c0c540e08323bfee071c48102dbe