### PR TITLE
Add tuple-aware runner and propagate tuple metadata

### DIFF
--- a/analysis/btagMCeff/run.py
+++ b/analysis/btagMCeff/run.py
@@ -8,6 +8,7 @@ import os
 import numpy as np
 from coffea import hist, processor
 from coffea.nanoevents import NanoAODSchema
+from topeft.custom_runner import TupleRunner
 
 import btagMCeff
 
@@ -124,7 +125,7 @@ if __name__ == '__main__':
     processor_instance = btagMCeff.AnalysisProcessor(samplesdict)
 
     executor = processor.futures_executor(workers=nworkers)
-    runner = processor.Runner(executor, schema=NanoAODSchema, chunksize=chunksize, maxchunks=nchunks)
+    runner = TupleRunner(executor, schema=NanoAODSchema, chunksize=chunksize, maxchunks=nchunks)
 
     tstart = time.time()
     output = runner(flist, treename, processor_instance)

--- a/analysis/extreme_events_study/run_extreme_events.py
+++ b/analysis/extreme_events_study/run_extreme_events.py
@@ -7,6 +7,7 @@ import argparse
 
 from coffea import processor
 from coffea.nanoevents import NanoAODSchema
+from topeft.custom_runner import TupleRunner
 import topcoffea.modules.remote_environment as remote_environment
 
 import extreme_events
@@ -150,7 +151,7 @@ elif executor ==  "work_queue":
 else:
     raise Exception(f"Executor \"{executor}\" is not known.")
 
-runner = processor.Runner(exec_instance, schema=NanoAODSchema, chunksize=chunksize, maxchunks=nchunks, skipbadfiles=False, xrootdtimeout=180)
+runner = TupleRunner(exec_instance, schema=NanoAODSchema, chunksize=chunksize, maxchunks=nchunks, skipbadfiles=False, xrootdtimeout=180)
 output = runner(flist, treename, processor_instance)
 
 dt = time.time() - tstart

--- a/analysis/flip_measurement/run_flip.py
+++ b/analysis/flip_measurement/run_flip.py
@@ -7,6 +7,7 @@ import argparse
 
 from coffea import processor
 from coffea.nanoevents import NanoAODSchema
+from topeft.custom_runner import TupleRunner
 import topcoffea.modules.remote_environment as remote_environment
 
 import flip_mr_processor
@@ -161,7 +162,7 @@ elif executor ==  "work_queue":
 else:
     raise Exception(f"Executor \"{executor}\" is not known.")
 
-runner = processor.Runner(exec_instance, schema=NanoAODSchema, chunksize=chunksize, maxchunks=nchunks, skipbadfiles=False, xrootdtimeout=180)
+runner = TupleRunner(exec_instance, schema=NanoAODSchema, chunksize=chunksize, maxchunks=nchunks, skipbadfiles=False, xrootdtimeout=180)
 output = runner(flist, treename, processor_instance)
 
 dt = time.time() - tstart

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -10,6 +10,7 @@ import yaml
 
 from coffea import processor
 from coffea.nanoevents import NanoAODSchema
+from topeft.custom_runner import TupleRunner
 
 import topcoffea.modules.utils as utils
 import topcoffea.modules.remote_environment as remote_environment
@@ -538,12 +539,12 @@ if __name__ == "__main__":
 
     if executor == "futures":
         exec_instance = processor.futures_executor(workers=nworkers)
-        runner = processor.Runner(
+        runner = TupleRunner(
             exec_instance, schema=NanoAODSchema, chunksize=chunksize, maxchunks=nchunks
         )
     elif executor == "work_queue":
         executor = processor.WorkQueueExecutor(**executor_args)
-        runner = processor.Runner(
+        runner = TupleRunner(
             executor,
             schema=NanoAODSchema,
             chunksize=chunksize,
@@ -556,7 +557,7 @@ if __name__ == "__main__":
             executor = processor.TaskVineExecutor(**executor_args)
         except AttributeError:
             raise RuntimeError("TaskVineExecutor not available.")
-        runner = processor.Runner(
+        runner = TupleRunner(
             executor,
             schema=NanoAODSchema,
             chunksize=chunksize,

--- a/analysis/topeft_run2/run_sow.py
+++ b/analysis/topeft_run2/run_sow.py
@@ -8,6 +8,7 @@ import argparse
 # import uproot
 from coffea import processor
 from coffea.nanoevents import NanoAODSchema
+from topeft.custom_runner import TupleRunner
 import topcoffea.modules.remote_environment as remote_environment
 
 import sow_processor
@@ -170,7 +171,7 @@ elif executor ==  "work_queue":
 else:
     raise Exception(f"Executor \"{executor}\" is not known.")
 
-runner = processor.Runner(exec_instance, schema=NanoAODSchema, chunksize=chunksize, maxchunks=nchunks, skipbadfiles=False, xrootdtimeout=900)
+runner = TupleRunner(exec_instance, schema=NanoAODSchema, chunksize=chunksize, maxchunks=nchunks, skipbadfiles=False, xrootdtimeout=900)
 output = runner(flist, treename, processor_instance)
 
 dt = time.time() - tstart

--- a/analysis/training/simple_run.py
+++ b/analysis/training/simple_run.py
@@ -8,6 +8,7 @@ import os
 import numpy as np
 from coffea import hist, processor
 from coffea.nanoevents import NanoAODSchema
+from topeft.custom_runner import TupleRunner
 
 import simple_processor
 
@@ -91,7 +92,7 @@ if __name__ == '__main__':
     flist = {}
     for sname in samplesdict.keys():
         redirector = samplesdict[sname]['redirector']
-        flist[sname] = [(redirector+f) for f in samplesdict[sname]['files']]
+        flist[(sname, 'nominal')] = [(redirector+f) for f in samplesdict[sname]['files']]
         samplesdict[sname]['year'] = samplesdict[sname]['year']
         samplesdict[sname]['xsec'] = float(samplesdict[sname]['xsec'])
         samplesdict[sname]['nEvents'] = int(samplesdict[sname]['nEvents'])
@@ -135,7 +136,7 @@ if __name__ == '__main__':
     processor_instance = simple_processor.AnalysisProcessor(samplesdict,wc_lst,do_errors,)
 
     exec_instance = processor.FuturesExecutor(workers=nworkers)
-    runner = processor.Runner(exec_instance, schema=NanoAODSchema, chunksize=chunksize, maxchunks=nchunks)
+    runner = TupleRunner(exec_instance, schema=NanoAODSchema, chunksize=chunksize, maxchunks=nchunks)
 
     # Run the processor and get the output
     tstart = time.time()

--- a/topeft/custom_runner.py
+++ b/topeft/custom_runner.py
@@ -1,0 +1,34 @@
+from collections.abc import Mapping
+from coffea import processor
+
+
+class TupleRunner(processor.Runner):
+    """Runner variant that propagates tuple keys to processor metadata."""
+
+    def run(self, fileset, processor_instance, treename=None, uproot_options=None, iteritems_options=None):
+        if uproot_options is None:
+            uproot_options = {}
+        if iteritems_options is None:
+            iteritems_options = {}
+
+        # Allow fileset keys to be tuples and pass them through in metadata
+        if isinstance(fileset, Mapping):
+            tuple_map = {}
+            normalized = {}
+            for key, val in fileset.items():
+                if isinstance(key, tuple):
+                    dataset_name = key[0]
+                    normalized[dataset_name] = val
+                    tuple_map[dataset_name] = key
+                else:
+                    normalized[key] = val
+            chunks = list(super().preprocess(normalized, treename))
+            for chunk in chunks:
+                ds = chunk.dataset
+                tup = tuple_map.get(ds, ds)
+                if chunk.usermeta is None:
+                    chunk.usermeta = {}
+                chunk.usermeta["tuple"] = tup
+            return super().run(chunks, processor_instance, treename, uproot_options, iteritems_options)
+        # fall back to default behaviour
+        return super().run(fileset, processor_instance, treename, uproot_options, iteritems_options)


### PR DESCRIPTION
## Summary
- introduce `TupleRunner` that forwards tuple keys to processor metadata
- record tuple information in `AnalysisProcessor` and fill a dedicated histogram
- switch analysis scripts to use the new runner and demonstrate tuple-keyed filesets