### PR TITLE
Ensure PyYAML available for work_queue runs

### DIFF
--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -473,6 +473,7 @@ if __name__ == "__main__":
             "tasks_accum_log": "tasks.log",
             "environment_file": remote_environment.get_environment(
                 extra_pip_local={"topeft": ["topeft", "setup.py"]},
+                extra_conda=["pyyaml"],
             ),
             "extra_input_files": ["analysis_processor.py"],
             "retries": 15,


### PR DESCRIPTION
## Summary
- Include `pyyaml` when creating remote Work Queue environments so analysis scripts can load YAML files

## Testing
- `pytest tests/test_make_1d_quad_plots.py -q`
- `pytest tests/test_futures.py -q` *(fails: Command '['time', 'python', ...] returned non-zero exit status 1)*
- `pytest tests/test_workqueue.py -q` *(fails: ModuleNotFoundError: No module named 'ndcctools')*


------
https://chatgpt.com/codex/tasks/task_e_68b6e8a9a8e08323a18c43ddb6d8b13c