### PR TITLE
Replace axes module with analysis metadata

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -20,7 +20,6 @@ import topcoffea.modules.event_selection as tc_es
 import topcoffea.modules.object_selection as tc_os
 import topcoffea.modules.corrections as tc_cor
 
-from topeft.modules.axes import info as axes_info
 from topeft.modules.paths import topeft_path
 from topeft.modules.corrections import ApplyJetCorrections, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, ApplyRochesterCorrections, ApplyJetSystematics, GetTriggerSF
 import topeft.modules.event_selection as te_es
@@ -77,7 +76,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         if hist_key is None:
             raise ValueError("hist_key must be provided and cannot be None")
 
-        sample, var, ch, appl, syst = hist_key
+        sample, var, info, ch, appl, syst = hist_key
 
         if var not in metadata["variables"]:
             raise ValueError(f"Unknown variable {var}")
@@ -89,21 +88,20 @@ class AnalysisProcessor(processor.ProcessorABC):
             raise ValueError(f"Unknown systematic {syst}")
 
         sumw2_key = (var + "_sumw2", sample, ch, appl, syst)
-        
-        info = axes_info[var]
+
         if not rebin and "variable" in info:
             dense_axis = hist.axis.Variable(
-                info["variable"], name=hist_key[0], label=info["label"]
+                info["variable"], name=var, label=info["label"]
             )
             sumw2_axis = hist.axis.Variable(
-                info["variable"], name=hist_key[0]+"_sumw2", label=info["label"] + " sum of w^2"
+                info["variable"], name=var+"_sumw2", label=info["label"] + " sum of w^2"
             )
         else:
             dense_axis = hist.axis.Regular(
-                *info["regular"], name=hist_key[0], label=info["label"]
+                *info["regular"], name=var, label=info["label"]
             )
             sumw2_axis = hist.axis.Regular(
-                *info["regular"], name=hist_key[0]+"_sumw2", label=info["label"] + " sum of w^2"
+                *info["regular"], name=var+"_sumw2", label=info["label"] + " sum of w^2"
             )
 
         histogram[hist_key] = HistEFT(

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -58,7 +58,7 @@ def construct_cat_name(chan_str,njet_str=None,flav_str=None):
 
 class AnalysisProcessor(processor.ProcessorABC):
 
-    def __init__(self, sample, wc_names_lst=[], hist_key=None, ecut_threshold=None, do_errors=False, do_systematics=False, split_by_lepton_flavor=False, skip_signal_regions=False, skip_control_regions=False, muonSyst='nominal', dtype=np.float32, rebin=False, offZ_split=False, tau_h_analysis=False, fwd_analysis=False):
+    def __init__(self, sample, wc_names_lst=[], hist_key=None, var_info=None, ecut_threshold=None, do_errors=False, do_systematics=False, split_by_lepton_flavor=False, skip_signal_regions=False, skip_control_regions=False, muonSyst='nominal', dtype=np.float32, rebin=False, offZ_split=False, tau_h_analysis=False, fwd_analysis=False):
 
         self._sample = sample
         self._wc_names_lst = wc_names_lst
@@ -73,10 +73,11 @@ class AnalysisProcessor(processor.ProcessorABC):
         with open(metadata_path, "r") as f:
             metadata = yaml.safe_load(f)
 
-        if hist_key is None:
-            raise ValueError("hist_key must be provided and cannot be None")
+        if hist_key is None or var_info is None:
+            raise ValueError("hist_key and var_info must be provided and cannot be None")
 
-        sample, var, info, ch, appl, syst = hist_key
+        var, ch, appl, sample_name, syst = hist_key
+        info = var_info
 
         if var not in metadata["variables"]:
             raise ValueError(f"Unknown variable {var}")
@@ -87,7 +88,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         if syst not in metadata["systematics"]:
             raise ValueError(f"Unknown systematic {syst}")
 
-        sumw2_key = (var + "_sumw2", sample, ch, appl, syst)
+        sumw2_key = (var + "_sumw2", ch, appl, sample_name, syst)
 
         if not rebin and "variable" in info:
             dense_axis = hist.axis.Variable(

--- a/analysis/topeft_run2/comp.py
+++ b/analysis/topeft_run2/comp.py
@@ -19,10 +19,16 @@ import mplhep as hep
 import argparse
 import time
 import json
+import os
 from topcoffea.modules.get_param_from_jsons import GetParam
 from topcoffea.modules.paths import topcoffea_path
 get_tc_param = GetParam(topcoffea_path("params/params.json"))
-from topeft.modules.axes import info as axes_info
+import yaml
+
+metadata_path = os.path.join(os.path.dirname(__file__), "metadata.yml")
+with open(metadata_path, "r") as f:
+    metadata = yaml.safe_load(f)
+axes_info = metadata["variables"]
 
 BINNING = {k: v['variable'] for k,v in axes_info.items() if 'variable' in v}
 

--- a/analysis/topeft_run2/make_cr_and_sr_plots.py
+++ b/analysis/topeft_run2/make_cr_and_sr_plots.py
@@ -3,6 +3,7 @@ import os
 import copy
 import datetime
 import argparse
+import yaml
 import matplotlib as mpl
 mpl.use('Agg')
 import matplotlib.pyplot as plt
@@ -11,7 +12,11 @@ from cycler import cycler
 import mplhep as hep
 import hist
 from topcoffea.modules.histEFT import HistEFT
-from topeft.modules.axes import info as axes_info
+
+metadata_path = os.path.join(os.path.dirname(__file__), "metadata.yml")
+with open(metadata_path, "r") as f:
+    metadata = yaml.safe_load(f)
+axes_info = metadata["variables"]
 
 from topcoffea.scripts.make_html import make_html
 import topcoffea.modules.utils as utils

--- a/analysis/topeft_run2/metadata.yml
+++ b/analysis/topeft_run2/metadata.yml
@@ -60,24 +60,81 @@ systematics:
   - factUp
   - factDown
 variables:
-  - invmass
-  - ptbl
-  - ptz
-  - njets
-  - nbtagsl
-  - l0pt
-  - l1pt
-  - l1eta
-  - j0pt
-  - b0pt
-  - l0eta
-  - j0eta
-  - ht
-  - met
-  - ljptsum
-  - o0pt
-  - bl0pt
-  - lj0pt
-  - ptz_wtau
-  - tau0pt
-  - lt
+  invmass:
+    regular: [20, 0, 1000]
+    label: '$m_{\ell\ell}$ (GeV) '
+  ptbl:
+    regular: [40, 0, 1000]
+    variable: [0, 100, 200, 400]
+    label: '$p_{T}^{b\mathrm{-}jet+\ell_{min(dR)}}$ (GeV) '
+  ptz:
+    regular: [12, 0, 600]
+    variable: [0, 200, 300, 400, 500]
+    label: '$p_{T}$ Z (GeV) '
+  njets:
+    regular: [10, 0, 10]
+    variable_multi:
+      '2l': [4, 5, 6, 7]
+      '3l': [2, 3, 4, 5]
+      '4l': [2, 3, 4]
+    label: 'Jet multiplicity '
+  nbtagsl:
+    regular: [5, 0, 5]
+    label: 'Loose btag multiplicity '
+  l0pt:
+    regular: [10, 0, 500]
+    variable: [0, 50, 100, 200]
+    label: 'Leading lep $p_{T}$ (GeV) '
+  l1pt:
+    regular: [10, 0, 100]
+    label: 'Subleading lep $p_{T}$ (GeV) '
+  l1eta:
+    regular: [20, -2.5, 2.5]
+    label: 'Subleading $\eta$ '
+  j0pt:
+    regular: [10, 0, 500]
+    label: 'Leading jet  $p_{T}$ (GeV) '
+  b0pt:
+    regular: [10, 0, 500]
+    label: 'Leading b jet  $p_{T}$ (GeV) '
+  l0eta:
+    regular: [20, -2.5, 2.5]
+    label: 'Leading lep $\eta$ '
+  j0eta:
+    regular: [30, -3, 3]
+    label: 'Leading jet  $\eta$ '
+  ht:
+    regular: [20, 0, 1000]
+    variable: [0, 300, 500, 800]
+    label: 'H$_{T}$ (GeV) '
+  met:
+    regular: [20, 0, 400]
+    label: 'MET (GeV)'
+  ljptsum:
+    regular: [11, 0, 1100]
+    variable: [0, 400, 600, 1000]
+    label: 'S$_{T}$ (GeV) '
+  o0pt:
+    regular: [10, 0, 500]
+    variable: [0, 100, 200, 400]
+    label: 'Leading l or b jet $p_{T}$ (GeV)'
+  bl0pt:
+    regular: [10, 0, 500]
+    variable: [0, 100, 200, 400]
+    label: 'Leading (b+l) $p_{T}$ (GeV) '
+  lj0pt:
+    regular: [12, 0, 600]
+    variable: [0, 150, 250, 500]
+    label: 'Leading pt of pair from l+j collection (GeV) '
+  ptz_wtau:
+    regular: [12, 0, 600]
+    variable: [0, 150, 250, 500]
+    label: 'pt of lepton hadronic tau pair (GeV) '
+  tau0pt:
+    regular: [12, 0, 600]
+    variable: [0, 150, 250, 500]
+    label: 'pt of leading hadronic tau (GeV) '
+  lt:
+    regular: [12, 0, 600]
+    variable: [0, 150, 250, 500]
+    label: 'Scalar sum of met at leading leptons (GeV)'

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -17,7 +17,6 @@ import topcoffea.modules.remote_environment as remote_environment
 from topeft.modules.dataDrivenEstimation import DataDrivenProducer
 from topeft.modules.get_renormfact_envelope import get_renormfact_envelope
 import analysis_processor
-from topeft.modules.axes import info as axes_info
 
 LST_OF_KNOWN_EXECUTORS = ["futures", "work_queue", "taskvine"]
 
@@ -455,13 +454,14 @@ if __name__ == "__main__":
     key_lst = []
 
     samples_lst = list(samplesdict.keys())
-    
+
     for sample in samples_lst:
         for var in var_lst:
+            var_info = metadata["variables"][var]
             for ch in ch_lst:
                 for appl in ch_app_map.get(ch, []):
                     for syst in syst_lst:
-                        key_lst.append((sample, var, ch, appl, syst))
+                        key_lst.append((sample, var, var_info, ch, appl, syst))
 
     if executor in ["work_queue", "taskvine"]:
         executor_args = {

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -461,7 +461,7 @@ if __name__ == "__main__":
             for ch in ch_lst:
                 for appl in ch_app_map.get(ch, []):
                     for syst in syst_lst:
-                        key_lst.append((sample, var, var_info, ch, appl, syst))
+                        key_lst.append((sample, var, ch, appl, syst, var_info))
 
     if executor in ["work_queue", "taskvine"]:
         executor_args = {
@@ -567,14 +567,17 @@ if __name__ == "__main__":
     output = {}
     key_lst = key_lst[:1]
     for key in key_lst:
-        sample = key[0]
+        sample, var, ch, appl, syst, var_info = key
         sample_dict = samplesdict[sample]
         sample_flist = flist[sample]
+
+        hist_key = (var, ch, appl, sample, syst)
 
         processor_instance = analysis_processor.AnalysisProcessor(
             sample_dict,
             wc_lst,
-            key,
+            hist_key,
+            var_info,
             ecut_threshold,
             do_errors,
             do_systs,

--- a/topeft/modules/axes.py
+++ b/topeft/modules/axes.py
@@ -1,78 +1,140 @@
-info = {
-    "invmass": {
-        "regular": (20, 0, 1000),
-        "label": r"$m_{\ell\ell}$ (GeV) ",
-    },
-    "ptbl": {
-        "regular": (40, 0, 1000),
-        "variable": [0, 100, 200, 400],
-        "label": r"$p_{T}^{b\mathrm{-}jet+\ell_{min(dR)}}$ (GeV) ",
-    },
-    "ptz": {
-        "regular": (12, 0, 600),
-        "variable": [0, 200, 300, 400, 500],
-        "label": r"$p_{T}$ Z (GeV) ",
-    },
-    "njets": {
-        "regular": (10, 0, 10),
-        "variable_multi": {
-            "2l": [4, 5, 6, 7],
-            "3l": [2, 3, 4, 5],
-            "4l": [2, 3, 4],
-        },
-        "label": r"Jet multiplicity ",
-    },
-    "nbtagsl": {"regular": (5, 0, 5), "label": r"Loose btag multiplicity "},
-    "l0pt": {
-        "regular": (10, 0, 500),
-        "variable": [0, 50, 100, 200],
-        "label": r"Leading lep $p_{T}$ (GeV) ",
-    },
-    "l1pt": {"regular": (10, 0, 100), "label": r"Subleading lep $p_{T}$ (GeV) "},
-    "l1eta": {"regular": (20, -2.5, 2.5), "label": r"Subleading $\eta$ "},
-    "j0pt": {"regular": (10, 0, 500), "label": r"Leading jet  $p_{T}$ (GeV) "},
-    "b0pt": {"regular": (10, 0, 500), "label": r"Leading b jet  $p_{T}$ (GeV) "},
-    "l0eta": {"regular": (20, -2.5, 2.5), "label": r"Leading lep $\eta$ "},
-    "j0eta": {"regular": (30, -3, 3), "label": r"Leading jet  $\eta$ "},
-    "ht": {
-        "regular": (20, 0, 1000),
-        "variable": [0, 300, 500, 800],
-        "label": r"H$_{T}$ (GeV) ",
-    },
-    "met": {"regular": (20, 0, 400), "label": r"MET (GeV)"},
-    "ljptsum": {
-        "regular": (11, 0, 1100),
-        "variable": [0, 400, 600, 1000],
-        "label": r"S$_{T}$ (GeV) ",
-    },
-    "o0pt": {
-        "regular": (10, 0, 500),
-        "variable": [0, 100, 200, 400],
-        "label": r"Leading l or b jet $p_{T}$ (GeV)",
-    },
-    "bl0pt": {
-        "regular": (10, 0, 500),
-        "variable": [0, 100, 200, 400],
-        "label": r"Leading (b+l) $p_{T}$ (GeV) ",
-    },
-    "lj0pt": {
-        "regular": (12, 0, 600),
-        "variable": [0, 150, 250, 500],
-        "label": r"Leading pt of pair from l+j collection (GeV) ",
-    },
-    "ptz_wtau": {
-        "regular": (12, 0, 600),
-        "variable": [0, 150, 250, 500],
-        "label": r"pt of lepton hadronic tau pair (GeV) ",
-    },
-    "tau0pt": {
-        "regular": (12, 0, 600),
-        "variable": [0, 150, 250, 500],
-        "label": r"pt of leading hadronic tau (GeV) ",
-    },
-    "lt": {
-        "regular": (12, 0, 600),
-        "variable": [0,150,250,500],
-        "label": r"Scalar sum of met at leading leptons (GeV)",
-    },
-}
+channels:
+  - 2lss_m_4j
+  - 2lss_m_5j
+  - 2lss_m_6j
+  - 2lss_m_7j
+  - 2lss_p_4j
+  - 2lss_p_5j
+  - 2lss_p_6j
+  - 2lss_p_7j
+  - 3l_onZ_1b
+  - 3l_onZ_2b
+  - 3l_m_offZ_1b
+  - 3l_m_offZ_2b
+  - 3l_p_offZ_1b
+  - 3l_p_offZ_2b
+  - 4l
+applications:
+  - isAR_2lSS_OS
+  - isSR_2lSS
+  - isAR_2lSS
+  - isSR_3l
+  - isAR_3l
+  - isSR_4l
+channel_applications:
+  2lss_m_4j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
+  2lss_m_5j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
+  2lss_m_6j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
+  2lss_m_7j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
+  2lss_p_4j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
+  2lss_p_5j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
+  2lss_p_6j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
+  2lss_p_7j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
+  3l_onZ_1b: [isSR_3l, isAR_3l]
+  3l_onZ_2b: [isSR_3l, isAR_3l]
+  3l_m_offZ_1b: [isSR_3l, isAR_3l]
+  3l_m_offZ_2b: [isSR_3l, isAR_3l]
+  3l_p_offZ_1b: [isSR_3l, isAR_3l]
+  3l_p_offZ_2b: [isSR_3l, isAR_3l]
+  4l: [isSR_4l]
+systematics:
+  - nominal
+  - lepSF_muonUp
+  - lepSF_muonDown
+  - lepSF_elecUp
+  - lepSF_elecDown
+  - btagSFbc_corrUp
+  - btagSFbc_corrDown
+  - btagSFlight_corrUp
+  - btagSFlight_corrDown
+  - PUUp
+  - PUDown
+  - PreFiringUp
+  - PreFiringDown
+  - FSRUp
+  - FSRDown
+  - ISRUp
+  - ISRDown
+  - renormUp
+  - renormDown
+  - factUp
+  - factDown
+variables:
+  invmass:
+    regular: [20, 0, 1000]
+    label: '$m_{\ell\ell}$ (GeV) '
+  ptbl:
+    regular: [40, 0, 1000]
+    variable: [0, 100, 200, 400]
+    label: '$p_{T}^{b\mathrm{-}jet+\ell_{min(dR)}}$ (GeV) '
+  ptz:
+    regular: [12, 0, 600]
+    variable: [0, 200, 300, 400, 500]
+    label: '$p_{T}$ Z (GeV) '
+  njets:
+    regular: [10, 0, 10]
+    variable_multi:
+      '2l': [4, 5, 6, 7]
+      '3l': [2, 3, 4, 5]
+      '4l': [2, 3, 4]
+    label: 'Jet multiplicity '
+  nbtagsl:
+    regular: [5, 0, 5]
+    label: 'Loose btag multiplicity '
+  l0pt:
+    regular: [10, 0, 500]
+    variable: [0, 50, 100, 200]
+    label: 'Leading lep $p_{T}$ (GeV) '
+  l1pt:
+    regular: [10, 0, 100]
+    label: 'Subleading lep $p_{T}$ (GeV) '
+  l1eta:
+    regular: [20, -2.5, 2.5]
+    label: 'Subleading $\eta$ '
+  j0pt:
+    regular: [10, 0, 500]
+    label: 'Leading jet  $p_{T}$ (GeV) '
+  b0pt:
+    regular: [10, 0, 500]
+    label: 'Leading b jet  $p_{T}$ (GeV) '
+  l0eta:
+    regular: [20, -2.5, 2.5]
+    label: 'Leading lep $\eta$ '
+  j0eta:
+    regular: [30, -3, 3]
+    label: 'Leading jet  $\eta$ '
+  ht:
+    regular: [20, 0, 1000]
+    variable: [0, 300, 500, 800]
+    label: 'H$_{T}$ (GeV) '
+  met:
+    regular: [20, 0, 400]
+    label: 'MET (GeV)'
+  ljptsum:
+    regular: [11, 0, 1100]
+    variable: [0, 400, 600, 1000]
+    label: 'S$_{T}$ (GeV) '
+  o0pt:
+    regular: [10, 0, 500]
+    variable: [0, 100, 200, 400]
+    label: 'Leading l or b jet $p_{T}$ (GeV)'
+  bl0pt:
+    regular: [10, 0, 500]
+    variable: [0, 100, 200, 400]
+    label: 'Leading (b+l) $p_{T}$ (GeV) '
+  lj0pt:
+    regular: [12, 0, 600]
+    variable: [0, 150, 250, 500]
+    label: 'Leading pt of pair from l+j collection (GeV) '
+  ptz_wtau:
+    regular: [12, 0, 600]
+    variable: [0, 150, 250, 500]
+    label: 'pt of lepton hadronic tau pair (GeV) '
+  tau0pt:
+    regular: [12, 0, 600]
+    variable: [0, 150, 250, 500]
+    label: 'pt of leading hadronic tau (GeV) '
+  lt:
+    regular: [12, 0, 600]
+    variable: [0, 150, 250, 500]
+    label: 'Scalar sum of met at leading leptons (GeV)'

--- a/topeft/modules/datacard_tools.py
+++ b/topeft/modules/datacard_tools.py
@@ -8,13 +8,18 @@ import os
 import re
 import json
 import time
+import yaml
 
 from collections import defaultdict
 
 from topcoffea.modules.utils import regex_match
 from topeft.modules.paths import topeft_path
-from topeft.modules.axes import info as axes_info
 from topeft.modules.compatibility import add_sumw2_stub
+
+metadata_path = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "..", "analysis", "topeft_run2", "metadata.yml"))
+with open(metadata_path, "r") as f:
+    metadata = yaml.safe_load(f)
+axes_info = metadata["variables"]
 
 
 PRECISION = 6   # Decimal point precision in the text datacard output


### PR DESCRIPTION
## Summary
- Preserve variable axis details by embedding original sub-dictionaries into YAML metadata and axes module
- Replace direct `axes` imports in analysis scripts with metadata-driven binning
- Pass per-variable metadata directly to `AnalysisProcessor` through the histogram key