### PR TITLE
Evaluate histogram variables from metadata definitions

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -20,7 +20,6 @@ import topcoffea.modules.event_selection as tc_es
 import topcoffea.modules.object_selection as tc_os
 import topcoffea.modules.corrections as tc_cor
 
-from topeft.modules.axes import info as axes_info
 from topeft.modules.paths import topeft_path
 from topeft.modules.corrections import ApplyJetCorrections, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, ApplyRochesterCorrections, ApplyJetSystematics, GetTriggerSF
 import topeft.modules.event_selection as te_es
@@ -59,7 +58,7 @@ def construct_cat_name(chan_str,njet_str=None,flav_str=None):
 
 class AnalysisProcessor(processor.ProcessorABC):
 
-    def __init__(self, sample, wc_names_lst=[], hist_key=None, ecut_threshold=None, do_errors=False, do_systematics=False, split_by_lepton_flavor=False, skip_signal_regions=False, skip_control_regions=False, muonSyst='nominal', dtype=np.float32, rebin=False, offZ_split=False, tau_h_analysis=False, fwd_analysis=False):
+    def __init__(self, sample, wc_names_lst=[], hist_key=None, var_info=None, ecut_threshold=None, do_errors=False, do_systematics=False, split_by_lepton_flavor=False, skip_signal_regions=False, skip_control_regions=False, muonSyst='nominal', dtype=np.float32, rebin=False, offZ_split=False, tau_h_analysis=False, fwd_analysis=False):
 
         self._sample = sample
         self._wc_names_lst = wc_names_lst
@@ -74,10 +73,14 @@ class AnalysisProcessor(processor.ProcessorABC):
         with open(metadata_path, "r") as f:
             metadata = yaml.safe_load(f)
 
-        if hist_key is None:
-            raise ValueError("hist_key must be provided and cannot be None")
+        if hist_key is None or var_info is None:
+            raise ValueError("hist_key and var_info must be provided and cannot be None")
 
-        sample, var, ch, appl, syst = hist_key
+        var, ch, appl, sample_name, syst = hist_key
+        info = var_info
+        self._var_def = info.get("definition")
+        if self._var_def is None:
+            raise ValueError(f"No definition provided for variable {var}")
 
         if var not in metadata["variables"]:
             raise ValueError(f"Unknown variable {var}")
@@ -88,22 +91,21 @@ class AnalysisProcessor(processor.ProcessorABC):
         if syst not in metadata["systematics"]:
             raise ValueError(f"Unknown systematic {syst}")
 
-        sumw2_key = (var + "_sumw2", sample, ch, appl, syst)
-        
-        info = axes_info[var]
+        sumw2_key = (var + "_sumw2", ch, appl, sample_name, syst)
+
         if not rebin and "variable" in info:
             dense_axis = hist.axis.Variable(
-                info["variable"], name=hist_key[0], label=info["label"]
+                info["variable"], name=var, label=info["label"]
             )
             sumw2_axis = hist.axis.Variable(
-                info["variable"], name=hist_key[0]+"_sumw2", label=info["label"] + " sum of w^2"
+                info["variable"], name=var+"_sumw2", label=info["label"] + " sum of w^2"
             )
         else:
             dense_axis = hist.axis.Regular(
-                *info["regular"], name=hist_key[0], label=info["label"]
+                *info["regular"], name=var, label=info["label"]
             )
             sumw2_axis = hist.axis.Regular(
-                *info["regular"], name=hist_key[0]+"_sumw2", label=info["label"] + " sum of w^2"
+                *info["regular"], name=var+"_sumw2", label=info["label"] + " sum of w^2"
             )
 
         histogram[hist_key] = HistEFT(
@@ -473,8 +475,10 @@ class AnalysisProcessor(processor.ProcessorABC):
             # Count jets
             njets = ak.num(goodJets)
             nfwdj = ak.num(fwdJets)
-            ht = ak.sum(goodJets.pt,axis=-1)
-            j0 = goodJets[ak.argmax(goodJets.pt,axis=-1,keepdims=True)]
+            if "ht" in self._var_def:
+                ht = ak.sum(goodJets.pt, axis=-1)
+            if "j0" in self._var_def:
+                j0 = goodJets[ak.argmax(goodJets.pt, axis=-1, keepdims=True)]
 
             # Loose DeepJet WP
             loose_tag = "btag_wp_loose_" + year.replace("201", "UL1")
@@ -866,82 +870,58 @@ class AnalysisProcessor(processor.ProcessorABC):
             selections.add("isSR_4l",  events.is4l_SR)
 
 
+
             ######### Variables for the dense axes of the hists ##########
 
-            # Calculate ptbl
-            ptbl_bjet = goodJets[(isBtagJetsMedium | isBtagJetsLoose)]
-            ptbl_bjet = ptbl_bjet[ak.argmax(ptbl_bjet.pt,axis=-1,keepdims=True)] # Only save hardest b-jet
-            ptbl_lep = l_fo_conept_sorted
-            ptbl = (ptbl_bjet.nearest(ptbl_lep) + ptbl_bjet).pt
-            ptbl = ak.values_astype(ak.fill_none(ptbl, -1), np.float32)
+            var_def = self._var_def
 
-            # Z pt (pt of the ll pair that form the Z for the onZ categories)
-            ptz = te_es.get_Z_pt(l_fo_conept_sorted_padded[:,0:3],10.0)
-            if self.tau_h_analysis:
+            if ("ptbl" in var_def) or ("b0pt" in var_def) or ("bl0pt" in var_def):
+                ptbl_bjet = goodJets[(isBtagJetsMedium | isBtagJetsLoose)]
+                ptbl_bjet = ptbl_bjet[ak.argmax(ptbl_bjet.pt, axis=-1, keepdims=True)]
+                ptbl_lep = l_fo_conept_sorted
+                ptbl = (ptbl_bjet.nearest(ptbl_lep) + ptbl_bjet).pt
+                ptbl = ak.values_astype(ak.fill_none(ptbl, -1), np.float32)
+
+            if "ptz" in var_def:
+                ptz = te_es.get_Z_pt(l_fo_conept_sorted_padded[:,0:3],10.0)
+                if self.offZ_3l_split:
+                    ptz = te_es.get_ll_pt(l_fo_conept_sorted_padded[:,0:3],10.0)
+            if "ptz_wtau" in var_def:
                 ptz_wtau = te_es.get_Zlt_pt(l0, l1, tau0)
 
-            if self.offZ_3l_split:
-                ptz = te_es.get_ll_pt(l_fo_conept_sorted_padded[:,0:3],10.0)
-            # Leading (b+l) pair pt
-            bjetsl = goodJets[isBtagJetsLoose][ak.argsort(goodJets[isBtagJetsLoose].pt, axis=-1, ascending=False)]
-            bl_pairs = ak.cartesian({"b":bjetsl,"l":l_fo_conept_sorted})
-            blpt = (bl_pairs["b"] + bl_pairs["l"]).pt
-            bl0pt = ak.flatten(blpt[ak.argmax(blpt,axis=-1,keepdims=True)])
+            if "bl0pt" in var_def:
+                bjetsl = goodJets[isBtagJetsLoose][ak.argsort(goodJets[isBtagJetsLoose].pt, axis=-1, ascending=False)]
+                bl_pairs = ak.cartesian({"b": bjetsl, "l": l_fo_conept_sorted})
+                blpt = (bl_pairs["b"] + bl_pairs["l"]).pt
+                bl0pt = ak.flatten(blpt[ak.argmax(blpt, axis=-1, keepdims=True)])
 
-            # Collection of all objects (leptons and jets)
-            if self.tau_h_analysis:
-                l_j_collection = ak.with_name(ak.concatenate([l_fo_conept_sorted,goodJets,cleaning_taus], axis=1),"PtEtaPhiMCollection")
-            else:
-                l_j_collection = ak.with_name(ak.concatenate([l_fo_conept_sorted,goodJets], axis=1),"PtEtaPhiMCollection")
+            need_lj_collection = any(t in var_def for t in ["o0pt", "lj0pt", "ljptsum"]) or (self._ecut_threshold is not None)
+            if need_lj_collection:
+                if self.tau_h_analysis:
+                    l_j_collection = ak.with_name(ak.concatenate([l_fo_conept_sorted, goodJets, cleaning_taus], axis=1), "PtEtaPhiMCollection")
+                else:
+                    l_j_collection = ak.with_name(ak.concatenate([l_fo_conept_sorted, goodJets], axis=1), "PtEtaPhiMCollection")
+                if "o0pt" in var_def:
+                    o0pt = ak.max(l_j_collection.pt, axis=-1)
+                if ("ljptsum" in var_def) or (self._ecut_threshold is not None):
+                    ljptsum = ak.sum(l_j_collection.pt, axis=-1)
+                if "lj0pt" in var_def:
+                    l_j_pairs = ak.combinations(l_j_collection, 2, fields=["o0","o1"])
+                    l_j_pairs_pt = (l_j_pairs.o0 + l_j_pairs.o1).pt
+                    lj0pt = ak.max(l_j_pairs_pt, axis=-1)
 
-            # Leading object (j or l) pt
-            o0pt = ak.max(l_j_collection.pt,axis=-1)
+            if "lt" in var_def:
+                lt = ak.sum(l_fo_conept_sorted_padded.pt, axis=-1) + met.pt
 
-            # Pairs of l+j
-            l_j_pairs = ak.combinations(l_j_collection,2,fields=["o0","o1"])
-            l_j_pairs_pt = (l_j_pairs.o0 + l_j_pairs.o1).pt
-            l_j_pairs_mass = (l_j_pairs.o0 + l_j_pairs.o1).mass
-            lj0pt = ak.max(l_j_pairs_pt,axis=-1)
+            if "mll_0_1" in var_def:
+                mll_0_1 = (l0 + l1).mass
 
-            # LT
-            lt = ak.sum(l_fo_conept_sorted_padded.pt, axis=-1) + met.pt
-
-            # Define invariant mass hists
-            mll_0_1 = (l0+l1).mass # Invmass for leading two leps
-
-            # ST (but "st" is too hard to search in the code, so call it ljptsum)
-            ljptsum = ak.sum(l_j_collection.pt,axis=-1)
             if self._ecut_threshold is not None:
-                ecut_mask = (ljptsum<self._ecut_threshold)
+                if "ljptsum" not in locals():
+                    ljptsum = ak.sum(l_j_collection.pt, axis=-1)
+                ecut_mask = (ljptsum < self._ecut_threshold)
 
-            # Counts
             counts = np.ones_like(events['event'])
-
-            # Variables we will loop over when filling hists
-            varnames = {}
-            varnames["ht"]      = ht
-            varnames["met"]     = met.pt
-            varnames["ljptsum"] = ljptsum
-            varnames["l0pt"]    = l0.conept
-            varnames["l0eta"]   = l0.eta
-            varnames["l1pt"]    = l1.conept
-            varnames["l1eta"]   = l1.eta
-            varnames["j0pt"]    = ak.flatten(j0.pt)
-            varnames["j0eta"]   = ak.flatten(j0.eta)
-            varnames["njets"]   = njets
-            varnames["nbtagsl"] = nbtagsl
-            varnames["invmass"] = mll_0_1
-            varnames["ptbl"]    = ak.flatten(ptbl)
-            varnames["ptz"]     = ptz
-            varnames["b0pt"]    = ak.flatten(ptbl_bjet.pt)
-            varnames["bl0pt"]   = bl0pt
-            varnames["o0pt"]    = o0pt
-            varnames["lj0pt"]   = lj0pt
-            varnames["lt"]      = lt
-            if self.tau_h_analysis:
-
-                varnames["ptz_wtau"] = ptz_wtau
-                varnames["tau0pt"] = tau0.pt
 
             ########## Fill the histograms ##########
             cat_dict = {}
@@ -1012,7 +992,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
             # Loop over the hists we want to fill
             dense_axis_name = self._var
-            dense_axis_vals = varnames[dense_axis_name]
+            dense_axis_vals = eval(self._var_def, {"ak": ak, "np": np}, locals())
 
             # Set up the list of syst wgt variations to loop over
             wgt_var_lst = ["nominal"]

--- a/analysis/topeft_run2/comp.py
+++ b/analysis/topeft_run2/comp.py
@@ -19,10 +19,16 @@ import mplhep as hep
 import argparse
 import time
 import json
+import os
 from topcoffea.modules.get_param_from_jsons import GetParam
 from topcoffea.modules.paths import topcoffea_path
 get_tc_param = GetParam(topcoffea_path("params/params.json"))
-from topeft.modules.axes import info as axes_info
+import yaml
+
+metadata_path = os.path.join(os.path.dirname(__file__), "metadata.yml")
+with open(metadata_path, "r") as f:
+    metadata = yaml.safe_load(f)
+axes_info = metadata["variables"]
 
 BINNING = {k: v['variable'] for k,v in axes_info.items() if 'variable' in v}
 

--- a/analysis/topeft_run2/make_cr_and_sr_plots.py
+++ b/analysis/topeft_run2/make_cr_and_sr_plots.py
@@ -3,6 +3,7 @@ import os
 import copy
 import datetime
 import argparse
+import yaml
 import matplotlib as mpl
 mpl.use('Agg')
 import matplotlib.pyplot as plt
@@ -11,7 +12,11 @@ from cycler import cycler
 import mplhep as hep
 import hist
 from topcoffea.modules.histEFT import HistEFT
-from topeft.modules.axes import info as axes_info
+
+metadata_path = os.path.join(os.path.dirname(__file__), "metadata.yml")
+with open(metadata_path, "r") as f:
+    metadata = yaml.safe_load(f)
+axes_info = metadata["variables"]
 
 from topcoffea.scripts.make_html import make_html
 import topcoffea.modules.utils as utils

--- a/analysis/topeft_run2/metadata.yml
+++ b/analysis/topeft_run2/metadata.yml
@@ -1,83 +1,317 @@
 channels:
-  - 2lss_m_4j
-  - 2lss_m_5j
-  - 2lss_m_6j
-  - 2lss_m_7j
-  - 2lss_p_4j
-  - 2lss_p_5j
-  - 2lss_p_6j
-  - 2lss_p_7j
-  - 3l_onZ_1b
-  - 3l_onZ_2b
-  - 3l_m_offZ_1b
-  - 3l_m_offZ_2b
-  - 3l_p_offZ_1b
-  - 3l_p_offZ_2b
-  - 4l
+- 2lss_m_4j
+- 2lss_m_5j
+- 2lss_m_6j
+- 2lss_m_7j
+- 2lss_p_4j
+- 2lss_p_5j
+- 2lss_p_6j
+- 2lss_p_7j
+- 3l_onZ_1b
+- 3l_onZ_2b
+- 3l_m_offZ_1b
+- 3l_m_offZ_2b
+- 3l_p_offZ_1b
+- 3l_p_offZ_2b
+- 4l
 applications:
+- isAR_2lSS_OS
+- isSR_2lSS
+- isAR_2lSS
+- isSR_3l
+- isAR_3l
+- isSR_4l
+channel_applications:
+  2lss_m_4j:
   - isAR_2lSS_OS
   - isSR_2lSS
   - isAR_2lSS
+  2lss_m_5j:
+  - isAR_2lSS_OS
+  - isSR_2lSS
+  - isAR_2lSS
+  2lss_m_6j:
+  - isAR_2lSS_OS
+  - isSR_2lSS
+  - isAR_2lSS
+  2lss_m_7j:
+  - isAR_2lSS_OS
+  - isSR_2lSS
+  - isAR_2lSS
+  2lss_p_4j:
+  - isAR_2lSS_OS
+  - isSR_2lSS
+  - isAR_2lSS
+  2lss_p_5j:
+  - isAR_2lSS_OS
+  - isSR_2lSS
+  - isAR_2lSS
+  2lss_p_6j:
+  - isAR_2lSS_OS
+  - isSR_2lSS
+  - isAR_2lSS
+  2lss_p_7j:
+  - isAR_2lSS_OS
+  - isSR_2lSS
+  - isAR_2lSS
+  3l_onZ_1b:
   - isSR_3l
   - isAR_3l
+  3l_onZ_2b:
+  - isSR_3l
+  - isAR_3l
+  3l_m_offZ_1b:
+  - isSR_3l
+  - isAR_3l
+  3l_m_offZ_2b:
+  - isSR_3l
+  - isAR_3l
+  3l_p_offZ_1b:
+  - isSR_3l
+  - isAR_3l
+  3l_p_offZ_2b:
+  - isSR_3l
+  - isAR_3l
+  4l:
   - isSR_4l
-channel_applications:
-  2lss_m_4j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
-  2lss_m_5j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
-  2lss_m_6j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
-  2lss_m_7j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
-  2lss_p_4j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
-  2lss_p_5j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
-  2lss_p_6j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
-  2lss_p_7j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
-  3l_onZ_1b: [isSR_3l, isAR_3l]
-  3l_onZ_2b: [isSR_3l, isAR_3l]
-  3l_m_offZ_1b: [isSR_3l, isAR_3l]
-  3l_m_offZ_2b: [isSR_3l, isAR_3l]
-  3l_p_offZ_1b: [isSR_3l, isAR_3l]
-  3l_p_offZ_2b: [isSR_3l, isAR_3l]
-  4l: [isSR_4l]
 systematics:
-  - nominal
-  - lepSF_muonUp
-  - lepSF_muonDown
-  - lepSF_elecUp
-  - lepSF_elecDown
-  - btagSFbc_corrUp
-  - btagSFbc_corrDown
-  - btagSFlight_corrUp
-  - btagSFlight_corrDown
-  - PUUp
-  - PUDown
-  - PreFiringUp
-  - PreFiringDown
-  - FSRUp
-  - FSRDown
-  - ISRUp
-  - ISRDown
-  - renormUp
-  - renormDown
-  - factUp
-  - factDown
+- nominal
+- lepSF_muonUp
+- lepSF_muonDown
+- lepSF_elecUp
+- lepSF_elecDown
+- btagSFbc_corrUp
+- btagSFbc_corrDown
+- btagSFlight_corrUp
+- btagSFlight_corrDown
+- PUUp
+- PUDown
+- PreFiringUp
+- PreFiringDown
+- FSRUp
+- FSRDown
+- ISRUp
+- ISRDown
+- renormUp
+- renormDown
+- factUp
+- factDown
 variables:
-  - invmass
-  - ptbl
-  - ptz
-  - njets
-  - nbtagsl
-  - l0pt
-  - l1pt
-  - l1eta
-  - j0pt
-  - b0pt
-  - l0eta
-  - j0eta
-  - ht
-  - met
-  - ljptsum
-  - o0pt
-  - bl0pt
-  - lj0pt
-  - ptz_wtau
-  - tau0pt
-  - lt
+  invmass:
+    regular:
+    - 20
+    - 0
+    - 1000
+    label: '$m_{\ell\ell}$ (GeV) '
+    definition: mll_0_1
+  ptbl:
+    regular:
+    - 40
+    - 0
+    - 1000
+    variable:
+    - 0
+    - 100
+    - 200
+    - 400
+    label: '$p_{T}^{b\mathrm{-}jet+\ell_{min(dR)}}$ (GeV) '
+    definition: ak.flatten(ptbl)
+  ptz:
+    regular:
+    - 12
+    - 0
+    - 600
+    variable:
+    - 0
+    - 200
+    - 300
+    - 400
+    - 500
+    label: '$p_{T}$ Z (GeV) '
+    definition: ptz
+  njets:
+    regular:
+    - 10
+    - 0
+    - 10
+    variable_multi:
+      2l:
+      - 4
+      - 5
+      - 6
+      - 7
+      3l:
+      - 2
+      - 3
+      - 4
+      - 5
+      4l:
+      - 2
+      - 3
+      - 4
+    label: 'Jet multiplicity '
+    definition: njets
+  nbtagsl:
+    regular:
+    - 5
+    - 0
+    - 5
+    label: 'Loose btag multiplicity '
+    definition: nbtagsl
+  l0pt:
+    regular:
+    - 10
+    - 0
+    - 500
+    variable:
+    - 0
+    - 50
+    - 100
+    - 200
+    label: 'Leading lep $p_{T}$ (GeV) '
+    definition: l0.conept
+  l1pt:
+    regular:
+    - 10
+    - 0
+    - 100
+    label: 'Subleading lep $p_{T}$ (GeV) '
+    definition: l1.conept
+  l1eta:
+    regular:
+    - 20
+    - -2.5
+    - 2.5
+    label: 'Subleading $\eta$ '
+    definition: l1.eta
+  j0pt:
+    regular:
+    - 10
+    - 0
+    - 500
+    label: 'Leading jet  $p_{T}$ (GeV) '
+    definition: ak.flatten(j0.pt)
+  b0pt:
+    regular:
+    - 10
+    - 0
+    - 500
+    label: 'Leading b jet  $p_{T}$ (GeV) '
+    definition: ak.flatten(ptbl_bjet.pt)
+  l0eta:
+    regular:
+    - 20
+    - -2.5
+    - 2.5
+    label: 'Leading lep $\eta$ '
+    definition: l0.eta
+  j0eta:
+    regular:
+    - 30
+    - -3
+    - 3
+    label: 'Leading jet  $\eta$ '
+    definition: ak.flatten(j0.eta)
+  ht:
+    regular:
+    - 20
+    - 0
+    - 1000
+    variable:
+    - 0
+    - 300
+    - 500
+    - 800
+    label: 'H$_{T}$ (GeV) '
+    definition: ht
+  met:
+    regular:
+    - 20
+    - 0
+    - 400
+    label: MET (GeV)
+    definition: met.pt
+  ljptsum:
+    regular:
+    - 11
+    - 0
+    - 1100
+    variable:
+    - 0
+    - 400
+    - 600
+    - 1000
+    label: 'S$_{T}$ (GeV) '
+    definition: ljptsum
+  o0pt:
+    regular:
+    - 10
+    - 0
+    - 500
+    variable:
+    - 0
+    - 100
+    - 200
+    - 400
+    label: Leading l or b jet $p_{T}$ (GeV)
+    definition: o0pt
+  bl0pt:
+    regular:
+    - 10
+    - 0
+    - 500
+    variable:
+    - 0
+    - 100
+    - 200
+    - 400
+    label: 'Leading (b+l) $p_{T}$ (GeV) '
+    definition: bl0pt
+  lj0pt:
+    regular:
+    - 12
+    - 0
+    - 600
+    variable:
+    - 0
+    - 150
+    - 250
+    - 500
+    label: 'Leading pt of pair from l+j collection (GeV) '
+    definition: lj0pt
+  ptz_wtau:
+    regular:
+    - 12
+    - 0
+    - 600
+    variable:
+    - 0
+    - 150
+    - 250
+    - 500
+    label: 'pt of lepton hadronic tau pair (GeV) '
+    definition: ptz_wtau
+  tau0pt:
+    regular:
+    - 12
+    - 0
+    - 600
+    variable:
+    - 0
+    - 150
+    - 250
+    - 500
+    label: 'pt of leading hadronic tau (GeV) '
+    definition: tau0.pt
+  lt:
+    regular:
+    - 12
+    - 0
+    - 600
+    variable:
+    - 0
+    - 150
+    - 250
+    - 500
+    label: Scalar sum of met at leading leptons (GeV)
+    definition: lt

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -17,7 +17,6 @@ import topcoffea.modules.remote_environment as remote_environment
 from topeft.modules.dataDrivenEstimation import DataDrivenProducer
 from topeft.modules.get_renormfact_envelope import get_renormfact_envelope
 import analysis_processor
-from topeft.modules.axes import info as axes_info
 
 LST_OF_KNOWN_EXECUTORS = ["futures", "work_queue", "taskvine"]
 
@@ -455,13 +454,14 @@ if __name__ == "__main__":
     key_lst = []
 
     samples_lst = list(samplesdict.keys())
-    
+
     for sample in samples_lst:
         for var in var_lst:
+            var_info = metadata["variables"][var].copy()
             for ch in ch_lst:
                 for appl in ch_app_map.get(ch, []):
                     for syst in syst_lst:
-                        key_lst.append((sample, var, ch, appl, syst))
+                        key_lst.append((sample, var, ch, appl, syst, var_info))
 
     if executor in ["work_queue", "taskvine"]:
         executor_args = {
@@ -567,14 +567,17 @@ if __name__ == "__main__":
     output = {}
     key_lst = key_lst[:1]
     for key in key_lst:
-        sample = key[0]
+        sample, var, ch, appl, syst, var_info = key
         sample_dict = samplesdict[sample]
         sample_flist = flist[sample]
+
+        hist_key = (var, ch, appl, sample, syst)
 
         processor_instance = analysis_processor.AnalysisProcessor(
             sample_dict,
             wc_lst,
-            key,
+            hist_key,
+            var_info,
             ecut_threshold,
             do_errors,
             do_systs,

--- a/topeft/modules/axes.py
+++ b/topeft/modules/axes.py
@@ -1,78 +1,140 @@
-info = {
-    "invmass": {
-        "regular": (20, 0, 1000),
-        "label": r"$m_{\ell\ell}$ (GeV) ",
-    },
-    "ptbl": {
-        "regular": (40, 0, 1000),
-        "variable": [0, 100, 200, 400],
-        "label": r"$p_{T}^{b\mathrm{-}jet+\ell_{min(dR)}}$ (GeV) ",
-    },
-    "ptz": {
-        "regular": (12, 0, 600),
-        "variable": [0, 200, 300, 400, 500],
-        "label": r"$p_{T}$ Z (GeV) ",
-    },
-    "njets": {
-        "regular": (10, 0, 10),
-        "variable_multi": {
-            "2l": [4, 5, 6, 7],
-            "3l": [2, 3, 4, 5],
-            "4l": [2, 3, 4],
-        },
-        "label": r"Jet multiplicity ",
-    },
-    "nbtagsl": {"regular": (5, 0, 5), "label": r"Loose btag multiplicity "},
-    "l0pt": {
-        "regular": (10, 0, 500),
-        "variable": [0, 50, 100, 200],
-        "label": r"Leading lep $p_{T}$ (GeV) ",
-    },
-    "l1pt": {"regular": (10, 0, 100), "label": r"Subleading lep $p_{T}$ (GeV) "},
-    "l1eta": {"regular": (20, -2.5, 2.5), "label": r"Subleading $\eta$ "},
-    "j0pt": {"regular": (10, 0, 500), "label": r"Leading jet  $p_{T}$ (GeV) "},
-    "b0pt": {"regular": (10, 0, 500), "label": r"Leading b jet  $p_{T}$ (GeV) "},
-    "l0eta": {"regular": (20, -2.5, 2.5), "label": r"Leading lep $\eta$ "},
-    "j0eta": {"regular": (30, -3, 3), "label": r"Leading jet  $\eta$ "},
-    "ht": {
-        "regular": (20, 0, 1000),
-        "variable": [0, 300, 500, 800],
-        "label": r"H$_{T}$ (GeV) ",
-    },
-    "met": {"regular": (20, 0, 400), "label": r"MET (GeV)"},
-    "ljptsum": {
-        "regular": (11, 0, 1100),
-        "variable": [0, 400, 600, 1000],
-        "label": r"S$_{T}$ (GeV) ",
-    },
-    "o0pt": {
-        "regular": (10, 0, 500),
-        "variable": [0, 100, 200, 400],
-        "label": r"Leading l or b jet $p_{T}$ (GeV)",
-    },
-    "bl0pt": {
-        "regular": (10, 0, 500),
-        "variable": [0, 100, 200, 400],
-        "label": r"Leading (b+l) $p_{T}$ (GeV) ",
-    },
-    "lj0pt": {
-        "regular": (12, 0, 600),
-        "variable": [0, 150, 250, 500],
-        "label": r"Leading pt of pair from l+j collection (GeV) ",
-    },
-    "ptz_wtau": {
-        "regular": (12, 0, 600),
-        "variable": [0, 150, 250, 500],
-        "label": r"pt of lepton hadronic tau pair (GeV) ",
-    },
-    "tau0pt": {
-        "regular": (12, 0, 600),
-        "variable": [0, 150, 250, 500],
-        "label": r"pt of leading hadronic tau (GeV) ",
-    },
-    "lt": {
-        "regular": (12, 0, 600),
-        "variable": [0,150,250,500],
-        "label": r"Scalar sum of met at leading leptons (GeV)",
-    },
-}
+channels:
+  - 2lss_m_4j
+  - 2lss_m_5j
+  - 2lss_m_6j
+  - 2lss_m_7j
+  - 2lss_p_4j
+  - 2lss_p_5j
+  - 2lss_p_6j
+  - 2lss_p_7j
+  - 3l_onZ_1b
+  - 3l_onZ_2b
+  - 3l_m_offZ_1b
+  - 3l_m_offZ_2b
+  - 3l_p_offZ_1b
+  - 3l_p_offZ_2b
+  - 4l
+applications:
+  - isAR_2lSS_OS
+  - isSR_2lSS
+  - isAR_2lSS
+  - isSR_3l
+  - isAR_3l
+  - isSR_4l
+channel_applications:
+  2lss_m_4j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
+  2lss_m_5j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
+  2lss_m_6j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
+  2lss_m_7j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
+  2lss_p_4j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
+  2lss_p_5j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
+  2lss_p_6j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
+  2lss_p_7j: [isAR_2lSS_OS, isSR_2lSS, isAR_2lSS]
+  3l_onZ_1b: [isSR_3l, isAR_3l]
+  3l_onZ_2b: [isSR_3l, isAR_3l]
+  3l_m_offZ_1b: [isSR_3l, isAR_3l]
+  3l_m_offZ_2b: [isSR_3l, isAR_3l]
+  3l_p_offZ_1b: [isSR_3l, isAR_3l]
+  3l_p_offZ_2b: [isSR_3l, isAR_3l]
+  4l: [isSR_4l]
+systematics:
+  - nominal
+  - lepSF_muonUp
+  - lepSF_muonDown
+  - lepSF_elecUp
+  - lepSF_elecDown
+  - btagSFbc_corrUp
+  - btagSFbc_corrDown
+  - btagSFlight_corrUp
+  - btagSFlight_corrDown
+  - PUUp
+  - PUDown
+  - PreFiringUp
+  - PreFiringDown
+  - FSRUp
+  - FSRDown
+  - ISRUp
+  - ISRDown
+  - renormUp
+  - renormDown
+  - factUp
+  - factDown
+variables:
+  invmass:
+    regular: [20, 0, 1000]
+    label: '$m_{\ell\ell}$ (GeV) '
+  ptbl:
+    regular: [40, 0, 1000]
+    variable: [0, 100, 200, 400]
+    label: '$p_{T}^{b\mathrm{-}jet+\ell_{min(dR)}}$ (GeV) '
+  ptz:
+    regular: [12, 0, 600]
+    variable: [0, 200, 300, 400, 500]
+    label: '$p_{T}$ Z (GeV) '
+  njets:
+    regular: [10, 0, 10]
+    variable_multi:
+      '2l': [4, 5, 6, 7]
+      '3l': [2, 3, 4, 5]
+      '4l': [2, 3, 4]
+    label: 'Jet multiplicity '
+  nbtagsl:
+    regular: [5, 0, 5]
+    label: 'Loose btag multiplicity '
+  l0pt:
+    regular: [10, 0, 500]
+    variable: [0, 50, 100, 200]
+    label: 'Leading lep $p_{T}$ (GeV) '
+  l1pt:
+    regular: [10, 0, 100]
+    label: 'Subleading lep $p_{T}$ (GeV) '
+  l1eta:
+    regular: [20, -2.5, 2.5]
+    label: 'Subleading $\eta$ '
+  j0pt:
+    regular: [10, 0, 500]
+    label: 'Leading jet  $p_{T}$ (GeV) '
+  b0pt:
+    regular: [10, 0, 500]
+    label: 'Leading b jet  $p_{T}$ (GeV) '
+  l0eta:
+    regular: [20, -2.5, 2.5]
+    label: 'Leading lep $\eta$ '
+  j0eta:
+    regular: [30, -3, 3]
+    label: 'Leading jet  $\eta$ '
+  ht:
+    regular: [20, 0, 1000]
+    variable: [0, 300, 500, 800]
+    label: 'H$_{T}$ (GeV) '
+  met:
+    regular: [20, 0, 400]
+    label: 'MET (GeV)'
+  ljptsum:
+    regular: [11, 0, 1100]
+    variable: [0, 400, 600, 1000]
+    label: 'S$_{T}$ (GeV) '
+  o0pt:
+    regular: [10, 0, 500]
+    variable: [0, 100, 200, 400]
+    label: 'Leading l or b jet $p_{T}$ (GeV)'
+  bl0pt:
+    regular: [10, 0, 500]
+    variable: [0, 100, 200, 400]
+    label: 'Leading (b+l) $p_{T}$ (GeV) '
+  lj0pt:
+    regular: [12, 0, 600]
+    variable: [0, 150, 250, 500]
+    label: 'Leading pt of pair from l+j collection (GeV) '
+  ptz_wtau:
+    regular: [12, 0, 600]
+    variable: [0, 150, 250, 500]
+    label: 'pt of lepton hadronic tau pair (GeV) '
+  tau0pt:
+    regular: [12, 0, 600]
+    variable: [0, 150, 250, 500]
+    label: 'pt of leading hadronic tau (GeV) '
+  lt:
+    regular: [12, 0, 600]
+    variable: [0, 150, 250, 500]
+    label: 'Scalar sum of met at leading leptons (GeV)'

--- a/topeft/modules/datacard_tools.py
+++ b/topeft/modules/datacard_tools.py
@@ -8,13 +8,18 @@ import os
 import re
 import json
 import time
+import yaml
 
 from collections import defaultdict
 
 from topcoffea.modules.utils import regex_match
 from topeft.modules.paths import topeft_path
-from topeft.modules.axes import info as axes_info
 from topeft.modules.compatibility import add_sumw2_stub
+
+metadata_path = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "..", "analysis", "topeft_run2", "metadata.yml"))
+with open(metadata_path, "r") as f:
+    metadata = yaml.safe_load(f)
+axes_info = metadata["variables"]
 
 
 PRECISION = 6   # Decimal point precision in the text datacard output


### PR DESCRIPTION
## Summary
- define each analysis variable in metadata.yml with an evaluable expression
- propagate per-variable definitions to the processor and compute required objects only when referenced
- evaluate the histogram axis data from the definition string instead of a hard-coded map

## Testing
- `pip install -e .`
- `pip install numpy hist awkward cloudpickle uproot numba`
- `pip install ndcctools` *(fails: No matching distribution found for ndcctools)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'ndcctools')*


------
https://chatgpt.com/codex/tasks/task_e_68b9681cb2688323aa13bae6bbff784f