### PR TITLE
Refactor weight handling per systematic variation

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -932,7 +932,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             lep_flav_iter = self._channel_dict["lep_flav_lst"] if self._split_by_lepton_flavor else [None]
 
             for wgt_fluct in wgt_var_lst:
-                if wgt_fluct == "nominal":
+                if wgt_fluct == "nominal" or wgt_fluct in obj_correction_syst_lst:
                     weight = weights_object.weight(None)
                 elif wgt_fluct in weights_object.variations:
                     weight = weights_object.weight(wgt_fluct)


### PR DESCRIPTION
## Summary
- Retrieve the lepton-category weights object from a dictionary once per systematic variation
- Simplify weight selection loop to use `weights_object.weight` for nominal and available variations
- Keep data-only systematic guards before filling histograms
- Treat object kinematic systematics as nominal weight variations so histograms are filled for JES/JER/TES

## Testing
- `pytest tests/test_futures.py topcoffea/tests/test_histEFT.py topcoffea/tests/test_histEFT_add.py topcoffea/tests/test_histEFT_unit.py topcoffea/tests/test_mre.py topcoffea/tests/test_sparse_hist.py topcoffea/tests/test_update_json.py -q` *(fails: No module named 'topeft', 'hist', 'numpy', 'awkward', 'cloudpickle')*
- `pytest tests/test_workqueue.py -q` *(fails: No module named 'ndcctools')*

------
https://chatgpt.com/codex/tasks/task_e_68bfe8de704883238fe8fbd2fae763cf