### PR TITLE
Refactor systematic configuration handling

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -77,6 +77,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         fwd_analysis=False,
         channel_dict=None,
         golden_json_path=None,
+        systematic_info=None,
     ):
 
         self._sample = sample
@@ -94,6 +95,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         # nested structure with several loops in ``process``.  The new logic
         # operates directly on the flat dictionary, so simply store it.
         self._channel_dict = channel_dict
+        self._systematic_info = systematic_info
 
         histogram = {}
 
@@ -192,6 +194,10 @@ class AnalysisProcessor(processor.ProcessorABC):
         return self._syst
 
     @property
+    def systematic_info(self):
+        return self._systematic_info
+
+    @property
     def columns(self):
         return self._columns
 
@@ -219,34 +225,54 @@ class AnalysisProcessor(processor.ProcessorABC):
         if isData:
             run_era = self._sample["path"].split("/")[2].split("-")[0][-1]
 
-        # Get up down weights from input dict
-        sow_variation_key_map = {
-            "ISRUp": "nSumOfWeights_ISRUp",
-            "ISRDown": "nSumOfWeights_ISRDown",
-            "FSRUp": "nSumOfWeights_FSRUp",
-            "FSRDown": "nSumOfWeights_FSRDown",
-            "renormUp": "nSumOfWeights_renormUp",
-            "renormDown": "nSumOfWeights_renormDown",
-            "factUp": "nSumOfWeights_factUp",
-            "factDown": "nSumOfWeights_factDown",
-            "renormfactUp": "nSumOfWeights_renormfactUp",
-            "renormfactDown": "nSumOfWeights_renormfactDown",
-        }
+        # Get up/down sum of weights needed for the current systematic.
+        sow_variation_key_map = {}
+        requested_sow_variations = set()
+
+        if self._systematic_info is not None and self._do_systematics and not isData:
+            group_info = self._systematic_info.group or {}
+            if not group_info and self._systematic_info.metadata.get("sum_of_weights"):
+                group_info = {
+                    self._systematic_info.name: {
+                        "sum_of_weights": self._systematic_info.metadata["sum_of_weights"]
+                    }
+                }
+            if group_info:
+                requested_sow_variations = set(group_info.keys())
+                sow_variation_key_map = {
+                    name: info.get("sum_of_weights")
+                    for name, info in group_info.items()
+                    if info.get("sum_of_weights")
+                }
+
+        if not sow_variation_key_map:
+            sow_variation_key_map = {
+                "ISRUp": "nSumOfWeights_ISRUp",
+                "ISRDown": "nSumOfWeights_ISRDown",
+                "FSRUp": "nSumOfWeights_FSRUp",
+                "FSRDown": "nSumOfWeights_FSRDown",
+                "renormUp": "nSumOfWeights_renormUp",
+                "renormDown": "nSumOfWeights_renormDown",
+                "factUp": "nSumOfWeights_factUp",
+                "factDown": "nSumOfWeights_factDown",
+                "renormfactUp": "nSumOfWeights_renormfactUp",
+                "renormfactDown": "nSumOfWeights_renormfactDown",
+            }
+
+        if not requested_sow_variations and self._do_systematics:
+            variation_groups = {
+                "ISR": {"ISRUp", "ISRDown"},
+                "FSR": {"FSRUp", "FSRDown"},
+                "renorm": {"renormUp", "renormDown"},
+                "fact": {"factUp", "factDown"},
+                "renormfact": {"renormfactUp", "renormfactDown"},
+            }
+
+            for variations in variation_groups.values():
+                if current_syst in variations:
+                    requested_sow_variations.update(variations)
 
         sow_variations = {"nominal": sow}
-
-        requested_sow_variations = set()
-        variation_groups = {
-            "ISR": {"ISRUp", "ISRDown"},
-            "FSR": {"FSRUp", "FSRDown"},
-            "renorm": {"renormUp", "renormDown"},
-            "fact": {"factUp", "factDown"},
-            "renormfact": {"renormfactUp", "renormfactDown"},
-        }
-
-        for variations in variation_groups.values():
-            if current_syst in variations:
-                requested_sow_variations.update(variations)
 
         is_lo_sample = histAxisName in get_te_param("lo_xsec_samples")
 

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -579,9 +579,22 @@ class AnalysisProcessor(processor.ProcessorABC):
         ######### The rest of the processor is inside this loop over systs that affect object kinematics  ###########
 
         # If we're doing systematics and this isn't data, we will loop over the obj_correction_syst_lst list
-        if self._do_systematics and not isData: syst_var_list = ["nominal"] + obj_correction_syst_lst
-        # Otherwise loop juse once, for nominal
-        else: syst_var_list = ['nominal']
+        if self._systematic_info is not None:
+            syst_name = self._systematic_info.name
+            syst_type = getattr(self._systematic_info, "type", None)
+            if syst_name == "nominal":
+                syst_var_list = ["nominal"]
+            elif (
+                syst_type == "object"
+                and syst_name in obj_correction_syst_lst
+            ):
+                syst_var_list = [syst_name]
+            else:
+                syst_var_list = ["nominal"]
+        elif self._do_systematics and not isData:
+            syst_var_list = ["nominal"] + obj_correction_syst_lst
+        else:
+            syst_var_list = ['nominal']
 
         # Loop over the list of systematic variations we've constructed
         met_raw=met

--- a/topeft/modules/systematics.py
+++ b/topeft/modules/systematics.py
@@ -1,0 +1,289 @@
+"""Utilities for expanding and filtering systematic variations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+from typing import Dict, Iterable, List, Optional, Sequence, Set
+
+from topeft.modules.paths import topeft_path
+
+
+@dataclass
+class SystematicVariation:
+    """Representation of a single systematic variation.
+
+    Attributes
+    ----------
+    name:
+        Unique identifier for the variation (e.g. ``JER_2018Up``).
+    base:
+        Logical group the variation belongs to (``jer``, ``isr``, etc.).
+    type:
+        Category of the systematic (``object``, ``weight``, ``theory``, ...).
+    applies_to:
+        Samples this variation applies to (``mc``, ``data`` or ``all``).
+    tau_only:
+        Whether the variation should only be considered for tau analyses.
+    year:
+        Optional year tied to the variation.
+    direction:
+        Direction label (typically ``Up`` or ``Down``).
+    component:
+        Optional component label (e.g. JES regrouping component).
+    metadata:
+        Additional metadata associated with the variation (sum-of-weights keys,
+        etc.).
+    group:
+        Mapping describing the group of variations this one belongs to.  The
+        mapping is keyed by variation name and stores a dictionary with at least
+        the same metadata keys present for the corresponding variation.  This is
+        mainly used for theory uncertainties that require the up/down sum of
+        weights simultaneously.
+    """
+
+    name: str
+    base: str
+    type: str
+    applies_to: Set[str]
+    tau_only: bool = False
+    year: Optional[str] = None
+    direction: Optional[str] = None
+    component: Optional[str] = None
+    metadata: Dict[str, object] = field(default_factory=dict)
+    group: Dict[str, Dict[str, object]] = field(default_factory=dict)
+
+    def matches_sample(self, is_data: bool, sample_year: Optional[str], tau_analysis: bool) -> bool:
+        """Return ``True`` if this variation should be run for the sample."""
+
+        if self.tau_only and not tau_analysis:
+            return False
+
+        if is_data:
+            if "all" not in self.applies_to and "data" not in self.applies_to:
+                return False
+        else:
+            if "all" not in self.applies_to and "mc" not in self.applies_to:
+                return False
+
+        if self.year is not None and sample_year is not None and self.year != sample_year:
+            return False
+
+        return True
+
+
+class SystematicsHelper:
+    """Helper responsible for expanding and filtering systematic variations."""
+
+    def __init__(
+        self,
+        metadata: Dict[str, object],
+        sample_years: Optional[Iterable[str]] = None,
+        tau_analysis: bool = False,
+    ) -> None:
+        self._metadata = metadata or {}
+        self._tau_analysis = tau_analysis
+        self._sample_years = {str(y) for y in sample_years or []}
+        self._jerc_info = self._load_jerc_info()
+        self._variations = self._build_variations()
+        self._variations_by_name = {var.name: var for var in self._variations}
+
+    @staticmethod
+    def _load_jerc_info() -> Dict[str, Dict[str, object]]:
+        path = topeft_path("modules/jerc_dict.json")
+        with open(path, "r", encoding="utf-8") as handle:
+            return json.load(handle)
+
+    @property
+    def variations(self) -> Sequence[SystematicVariation]:
+        """Return the list of expanded systematic variations."""
+
+        return self._variations
+
+    @property
+    def variation_names(self) -> List[str]:
+        return [var.name for var in self._variations]
+
+    def get(self, name: str) -> Optional[SystematicVariation]:
+        return self._variations_by_name.get(name)
+
+    def _get_sample_years(self) -> List[str]:
+        if self._sample_years:
+            return sorted(self._sample_years)
+        # Fall back to all years known to the JERC configuration so that we do
+        # not silently drop variations when the helper is instantiated before
+        # the samples are read.
+        return sorted(self._jerc_info.keys())
+
+    def _build_variations(self) -> List[SystematicVariation]:
+        syst_config = self._metadata.get("systematics", {})
+        if not isinstance(syst_config, dict):
+            raise TypeError("metadata['systematics'] must be a mapping of definitions")
+
+        sample_years = self._get_sample_years()
+
+        variations: List[SystematicVariation] = []
+
+        for base_name, entry in syst_config.items():
+            if not isinstance(entry, dict):
+                raise TypeError(f"Systematic '{base_name}' definition must be a mapping")
+
+            syst_type = entry.get("type", "weight")
+            applies_to = set(entry.get("applies_to", ["all"]))
+            tau_only = bool(entry.get("tau_only", False))
+            base_metadata = dict(entry.get("metadata", {}))
+
+            if "variations" in entry:
+                raw_variations = entry["variations"]
+                if not isinstance(raw_variations, list):
+                    raise TypeError(f"Systematic '{base_name}' variations must be a list")
+                for raw in raw_variations:
+                    if isinstance(raw, str):
+                        value = raw
+                        var_meta: Dict[str, object] = {}
+                    elif isinstance(raw, dict):
+                        if "value" in raw:
+                            value = str(raw["value"])
+                        elif "name" in raw:
+                            value = str(raw["name"])
+                        else:
+                            raise ValueError(
+                                f"Systematic '{base_name}' variation entry must have a 'value' or 'name'"
+                            )
+                        var_meta = {k: v for k, v in raw.items() if k not in {"value", "name"}}
+                    else:
+                        raise TypeError(
+                            f"Systematic '{base_name}' variations must contain strings or mappings"
+                        )
+
+                    variation = SystematicVariation(
+                        name=value,
+                        base=base_name,
+                        type=syst_type,
+                        applies_to=applies_to,
+                        tau_only=tau_only,
+                        year=str(var_meta.pop("year")) if "year" in var_meta else None,
+                        direction=var_meta.pop("direction", None),
+                        component=var_meta.pop("component", None),
+                        metadata={**base_metadata, **var_meta},
+                    )
+                    variations.append(variation)
+                continue
+
+            template = entry.get("template")
+            if not template:
+                raise ValueError(f"Systematic '{base_name}' requires either 'variations' or 'template'")
+
+            directions = entry.get("directions", [None])
+            if not isinstance(directions, list):
+                raise TypeError(f"Systematic '{base_name}' directions must be a list when provided")
+
+            include_years: List[Optional[str]]
+            if entry.get("year_dependent") or "{year}" in template:
+                requested_years = entry.get("years")
+                if requested_years is None:
+                    include_years = sample_years
+                else:
+                    include_years = [str(y) for y in requested_years if str(y) in sample_years]
+            else:
+                include_years = [None]
+
+            components: List[Optional[str]]
+            if entry.get("components_from") == "jerc":
+                components_set: Set[str] = set()
+                strip_prefix = entry.get("component_strip", "")
+                for year in sample_years:
+                    year_info = self._jerc_info.get(year, {})
+                    for comp in year_info.get("junc", []) or []:
+                        if strip_prefix and isinstance(comp, str) and comp.startswith(strip_prefix):
+                            comp_name = comp[len(strip_prefix) :]
+                        else:
+                            comp_name = comp
+                        components_set.add(str(comp_name))
+                components = sorted(components_set)
+            else:
+                raw_components = entry.get("components")
+                if raw_components is None:
+                    components = [None]
+                elif isinstance(raw_components, list):
+                    components = [str(comp) for comp in raw_components]
+                else:
+                    raise TypeError(
+                        f"Systematic '{base_name}' components must be a list when provided"
+                    )
+
+            for year in include_years:
+                for component in components:
+                    for direction in directions:
+                        fmt_args: Dict[str, object] = {}
+                        if year is not None:
+                            fmt_args["year"] = year
+                        if component is not None:
+                            fmt_args["component"] = component
+                        if direction is not None:
+                            fmt_args["direction"] = direction
+                        try:
+                            value = template.format(**fmt_args)
+                        except KeyError as exc:
+                            missing_key = exc.args[0]
+                            raise KeyError(
+                                f"Missing template argument '{missing_key}' while expanding systematic '{base_name}'"
+                            ) from exc
+                        variations.append(
+                            SystematicVariation(
+                                name=value,
+                                base=base_name,
+                                type=syst_type,
+                                applies_to=applies_to,
+                                tau_only=tau_only,
+                                year=year,
+                                direction=direction,
+                                component=component,
+                                metadata=dict(base_metadata),
+                            )
+                        )
+
+        # Populate group metadata for variations that provide sum-of-weights
+        # information so that processors can request the relevant pairs without
+        # hard coding their names.
+        variations_by_base: Dict[str, List[SystematicVariation]] = {}
+        for variation in variations:
+            variations_by_base.setdefault(variation.base, []).append(variation)
+
+        for base_variations in variations_by_base.values():
+            group_map = {
+                var.name: {**var.metadata}
+                for var in base_variations
+                if var.metadata.get("sum_of_weights")
+            }
+            if not group_map:
+                continue
+            for var in base_variations:
+                var.group = group_map
+
+        # Ensure nominal is always first for convenience and stable ordering of
+        # the rest.
+        variations.sort(key=lambda item: (item.name != "nominal", item.name))
+        return variations
+
+    def variations_for_sample(self, sample: Dict[str, object], include_systematics: bool) -> List[SystematicVariation]:
+        """Return the list of variations to run for the given sample."""
+
+        sample_year = str(sample.get("year")) if sample.get("year") is not None else None
+        is_data = bool(sample.get("isData"))
+
+        applicable = [
+            variation
+            for variation in self._variations
+            if variation.matches_sample(is_data, sample_year, self._tau_analysis)
+        ]
+
+        if not include_systematics:
+            # ``nominal`` is guaranteed to be present thanks to the metadata
+            # definition.
+            return [variation for variation in applicable if variation.name == "nominal"]
+
+        return applicable
+
+
+__all__ = ["SystematicVariation", "SystematicsHelper"]

--- a/topeft/params/metadata.yml
+++ b/topeft/params/metadata.yml
@@ -82,27 +82,238 @@ channel_applications:
   4l:
   - isSR_4l
 systematics:
-- nominal
-- lepSF_muonUp
-- lepSF_muonDown
-- lepSF_elecUp
-- lepSF_elecDown
-- btagSFbc_corrUp
-- btagSFbc_corrDown
-- btagSFlight_corrUp
-- btagSFlight_corrDown
-- PUUp
-- PUDown
-- PreFiringUp
-- PreFiringDown
-- FSRUp
-- FSRDown
-- ISRUp
-- ISRDown
-- renormUp
-- renormDown
-- factUp
-- factDown
+  nominal:
+    type: nominal
+    applies_to:
+      - all
+    variations:
+      - value: nominal
+  jer:
+    type: object
+    applies_to:
+      - mc
+    year_dependent: true
+    template: "JER_{year}{direction}"
+    directions:
+      - Up
+      - Down
+  jes:
+    type: object
+    applies_to:
+      - mc
+    template: "JES_{component}{direction}"
+    directions:
+      - Up
+      - Down
+    components_from: jerc
+    component_strip: "Regrouped_"
+  tes:
+    type: object
+    applies_to:
+      - mc
+    tau_only: true
+    variations:
+      - value: TESUp
+        direction: Up
+      - value: TESDown
+        direction: Down
+  fes:
+    type: object
+    applies_to:
+      - mc
+    tau_only: true
+    variations:
+      - value: FESUp
+        direction: Up
+      - value: FESDown
+        direction: Down
+  lepton_sf_muon:
+    type: weight
+    applies_to:
+      - mc
+    variations:
+      - value: lepSF_muonUp
+        direction: Up
+      - value: lepSF_muonDown
+        direction: Down
+  lepton_sf_elec:
+    type: weight
+    applies_to:
+      - mc
+    variations:
+      - value: lepSF_elecUp
+        direction: Up
+      - value: lepSF_elecDown
+        direction: Down
+  lepton_sf_tau_real:
+    type: weight
+    applies_to:
+      - mc
+    tau_only: true
+    variations:
+      - value: lepSF_taus_realUp
+        direction: Up
+      - value: lepSF_taus_realDown
+        direction: Down
+  lepton_sf_tau_fake:
+    type: weight
+    applies_to:
+      - mc
+    tau_only: true
+    variations:
+      - value: lepSF_taus_fakeUp
+        direction: Up
+      - value: lepSF_taus_fakeDown
+        direction: Down
+  btag_bc_year:
+    type: weight
+    applies_to:
+      - mc
+    year_dependent: true
+    template: "btagSFbc_{year}{direction}"
+    directions:
+      - Up
+      - Down
+  btag_bc_corr:
+    type: weight
+    applies_to:
+      - mc
+    template: "btagSFbc_corr{direction}"
+    directions:
+      - Up
+      - Down
+  btag_light_year:
+    type: weight
+    applies_to:
+      - mc
+    year_dependent: true
+    template: "btagSFlight_{year}{direction}"
+    directions:
+      - Up
+      - Down
+  btag_light_corr:
+    type: weight
+    applies_to:
+      - mc
+    template: "btagSFlight_corr{direction}"
+    directions:
+      - Up
+      - Down
+  pileup:
+    type: weight
+    applies_to:
+      - mc
+    template: "PU{direction}"
+    directions:
+      - Up
+      - Down
+  prefiring:
+    type: weight
+    applies_to:
+      - mc
+    template: "PreFiring{direction}"
+    directions:
+      - Up
+      - Down
+  trigger_sf:
+    type: weight
+    applies_to:
+      - mc
+    year_dependent: true
+    template: "triggerSF_{year}{direction}"
+    directions:
+      - Up
+      - Down
+  isr:
+    type: theory
+    applies_to:
+      - mc
+    variations:
+      - value: ISRUp
+        direction: Up
+        sum_of_weights: nSumOfWeights_ISRUp
+      - value: ISRDown
+        direction: Down
+        sum_of_weights: nSumOfWeights_ISRDown
+  fsr:
+    type: theory
+    applies_to:
+      - mc
+    variations:
+      - value: FSRUp
+        direction: Up
+        sum_of_weights: nSumOfWeights_FSRUp
+      - value: FSRDown
+        direction: Down
+        sum_of_weights: nSumOfWeights_FSRDown
+  renorm:
+    type: theory
+    applies_to:
+      - mc
+    variations:
+      - value: renormUp
+        direction: Up
+        sum_of_weights: nSumOfWeights_renormUp
+      - value: renormDown
+        direction: Down
+        sum_of_weights: nSumOfWeights_renormDown
+  fact:
+    type: theory
+    applies_to:
+      - mc
+    variations:
+      - value: factUp
+        direction: Up
+        sum_of_weights: nSumOfWeights_factUp
+      - value: factDown
+        direction: Down
+        sum_of_weights: nSumOfWeights_factDown
+  renormfact:
+    type: theory
+    applies_to:
+      - mc
+    variations:
+      - value: renormfactUp
+        direction: Up
+        sum_of_weights: nSumOfWeights_renormfactUp
+      - value: renormfactDown
+        direction: Down
+        sum_of_weights: nSumOfWeights_renormfactDown
+  fake_factors:
+    type: data_weight
+    applies_to:
+      - all
+    variations:
+      - value: FFUp
+        direction: Up
+      - value: FFDown
+        direction: Down
+      - value: FFptUp
+        direction: Up
+      - value: FFptDown
+        direction: Down
+      - value: FFetaUp
+        direction: Up
+      - value: FFetaDown
+        direction: Down
+  fake_factors_close_e:
+    type: data_weight
+    applies_to:
+      - all
+    year_dependent: true
+    template: "FFcloseEl_{year}{direction}"
+    directions:
+      - Up
+      - Down
+  fake_factors_close_mu:
+    type: data_weight
+    applies_to:
+      - all
+    year_dependent: true
+    template: "FFcloseMu_{year}{direction}"
+    directions:
+      - Up
+      - Down
 variables:
   invmass:
     regular:


### PR DESCRIPTION
## Summary
- restructure `params/metadata.yml` so each systematic variation is typed and annotated with applicability information
- add `SystematicsHelper` to expand year-dependent JEC/JER and expose variation metadata to the analysis
- refactor `run_analysis.py` and `analysis_processor.py` to consume the helper output and propagate systematic metadata to the processor