### PR TITLE
Refactor systematic configuration handling

### DIFF
--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -684,15 +684,29 @@ if __name__ == "__main__":
 
     for sample in samples_lst:
         ch_map = channel_app_map_data if samplesdict[sample]["isData"] else channel_app_map_mc
+        sample_info = samplesdict[sample]
         variations = syst_helper.variations_for_sample(
-            samplesdict[sample], include_systematics=do_systs
+            sample_info, include_systematics=do_systs
+        )
+        available_systematics = syst_helper.names_by_type(
+            sample_info, include_systematics=do_systs
         )
         for var in var_lst:
             var_info = var_defs[var].copy()
             for clean_ch, appl_list in ch_map.items():
                 for appl in appl_list:
                     for variation in variations:
-                        key_lst.append((sample, var, clean_ch, appl, variation, var_info))
+                        key_lst.append(
+                            (
+                                sample,
+                                var,
+                                clean_ch,
+                                appl,
+                                variation,
+                                var_info,
+                                available_systematics,
+                            )
+                        )
 
     if executor in ["work_queue", "taskvine"]:
         executor_args = {
@@ -800,7 +814,7 @@ if __name__ == "__main__":
     # raise RuntimeError("Stopping here for debugging")
 
     for key in key_lst:
-        sample, var, clean_ch, appl, syst_info, var_info = key
+        sample, var, clean_ch, appl, syst_info, var_info, available_systematics = key
         sample_dict = samplesdict[sample]
         sample_flist = flist[sample][:1]
 
@@ -852,6 +866,7 @@ if __name__ == "__main__":
             channel_dict=channel_dict,
             golden_json_path=golden_json_path,
             systematic_info=syst_info,
+            available_systematics=available_systematics,
         )
 
         #print("\nsample_dict:", sample_dict)

--- a/topeft/modules/systematics.py
+++ b/topeft/modules/systematics.py
@@ -266,7 +266,9 @@ class SystematicsHelper:
         variations.sort(key=lambda item: (item.name != "nominal", item.name))
         return variations
 
-    def variations_for_sample(self, sample: Dict[str, object], include_systematics: bool) -> List[SystematicVariation]:
+    def variations_for_sample(
+        self, sample: Dict[str, object], include_systematics: bool
+    ) -> List[SystematicVariation]:
         """Return the list of variations to run for the given sample."""
 
         sample_year = str(sample.get("year")) if sample.get("year") is not None else None
@@ -284,6 +286,21 @@ class SystematicsHelper:
             return [variation for variation in applicable if variation.name == "nominal"]
 
         return applicable
+
+    def names_by_type(
+        self, sample: Dict[str, object], include_systematics: bool
+    ) -> Dict[str, Sequence[str]]:
+        """Return variation names grouped by type for the given sample."""
+
+        variations = self.variations_for_sample(sample, include_systematics)
+
+        grouped: Dict[str, List[str]] = {}
+        for variation in variations:
+            grouped.setdefault(variation.type, []).append(variation.name)
+
+        # Return immutable sequences to prevent callers from mutating the
+        # cached information by mistake.
+        return {key: tuple(names) for key, names in grouped.items()}
 
 
 __all__ = ["SystematicVariation", "SystematicsHelper"]


### PR DESCRIPTION
## Summary
- add a SystematicsHelper accessor to expose variation names grouped by type for each sample
- propagate the grouped systematics through run_analysis into AnalysisProcessor and remove hard-coded lists and file reloads

## Testing
- python -m compileall topeft/modules/systematics.py analysis/topeft_run2/analysis_processor.py analysis/topeft_run2/run_analysis.py

------
https://chatgpt.com/codex/tasks/task_e_68daa1ec50248323a40d7fd8d807ec9e