### PR TITLE
Handle systematic variation metadata centrally

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -549,9 +549,12 @@ class AnalysisProcessor(processor.ProcessorABC):
         object_variation = "nominal"
         weight_variations_to_run = ["nominal"]
 
-        if variation_type == "object" and current_variation_name in object_systematics:
+        if variation_type == "object":
+            if current_variation_name not in object_systematics:
+                raise ValueError(
+                    f"Requested object systematic '{current_variation_name}' is not available in the mapping"
+                )
             object_variation = current_variation_name
-            weight_variations_to_run = [object_variation]
         elif variation_type in {"weight", "theory", "data_weight"} and current_variation_name != "nominal":
             variation_pool = {
                 "weight": weight_systematics,
@@ -1015,6 +1018,8 @@ class AnalysisProcessor(processor.ProcessorABC):
         else:
             wgt_var_lst = ["nominal"]
 
+        hist_variation_label = current_variation_name or "nominal"
+
         lep_chan = self._channel_dict["chan_def_lst"][0]
         jet_req = self._channel_dict["jet_selection"]
         lep_flav_iter = self._channel_dict["lep_flav_lst"] if self._split_by_lepton_flavor else [None]
@@ -1086,7 +1091,13 @@ class AnalysisProcessor(processor.ProcessorABC):
                 if ((dense_axis_name in ["o0pt","b0pt","bl0pt"]) & ("CR" in ch_name)):
                     continue
 
-                histkey = (dense_axis_name, ch_name, self.appregion, dataset, wgt_fluct)
+                histkey = (
+                    dense_axis_name,
+                    ch_name,
+                    self.appregion,
+                    dataset,
+                    hist_variation_label,
+                )
                 if histkey not in hout.keys():
                     continue
                 hout[histkey].fill(**axes_fill_info_dict)
@@ -1096,7 +1107,13 @@ class AnalysisProcessor(processor.ProcessorABC):
                     "weight": np.square(weights_flat),
                     "eft_coeff": eft_coeffs_cut,
                 }
-                histkey = (dense_axis_name + "_sumw2", ch_name, self.appregion, dataset, wgt_fluct)
+                histkey = (
+                    dense_axis_name + "_sumw2",
+                    ch_name,
+                    self.appregion,
+                    dataset,
+                    hist_variation_label,
+                )
                 if histkey not in hout.keys():
                     continue
                 hout[histkey].fill(**axes_fill_info_dict)

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -680,17 +680,21 @@ if __name__ == "__main__":
 
     # raise RuntimeError("\n\nStopping here for debugging")
 
+    available_systematics_by_sample_type = {
+        "mc": syst_helper.names_by_type("mc", include_systematics=do_systs),
+        "data": syst_helper.names_by_type("data", include_systematics=do_systs),
+    }
+
     key_lst = []
 
     for sample in samples_lst:
-        ch_map = channel_app_map_data if samplesdict[sample]["isData"] else channel_app_map_mc
         sample_info = samplesdict[sample]
+        ch_map = channel_app_map_data if sample_info["isData"] else channel_app_map_mc
         variations = syst_helper.variations_for_sample(
             sample_info, include_systematics=do_systs
         )
-        available_systematics = syst_helper.names_by_type(
-            sample_info, include_systematics=do_systs
-        )
+        sample_type_key = "data" if sample_info["isData"] else "mc"
+        available_systematics = available_systematics_by_sample_type[sample_type_key]
         for var in var_lst:
             var_info = var_defs[var].copy()
             for clean_ch, appl_list in ch_map.items():


### PR DESCRIPTION
## Summary
- add a helper on SystematicsHelper to return systematic names grouped by type and sample category
- reuse the grouped systematic lists in run_analysis and pass them to AnalysisProcessor
- refactor AnalysisProcessor to consume the supplied metadata for object and weight variations and tighten validation

## Testing
- python -m compileall topeft/modules/systematics.py analysis/topeft_run2/run_analysis.py analysis/topeft_run2/analysis_processor.py

------
https://chatgpt.com/codex/tasks/task_e_68dadd0951848323b037c1df27428874