### PR TITLE
Handle SparseHist 2D plots in CR workflow

### DIFF
--- a/analysis/topeft_run2/README.md
+++ b/analysis/topeft_run2/README.md
@@ -66,9 +66,10 @@ This directory contains scripts for the Full Run 2 EFT analysis. This README doc
 ### Scripts for finding, comparing and plotting yields from histograms (from the processor)
 
 * `make_cr_and_sr_plots.py`:
-    - This script makes plots for all CRs categories, also has the ability to make SR plots. 
+    - This script makes plots for all CRs categories, also has the ability to make SR plots.
     - The script takes as input a pkl file that should have both data and background MC included.
     - Example usage: `python make_cr_plots.py -f histos/your.pkl.gz -o ~/www/some/dir -n some_dir_name -y 2018 -t -u`
+    - Histograms with multiple dense axes (e.g. the `SparseHist`-based `lepton_pt_vs_eta`) are automatically rendered as CMS-style 2D heatmaps, while the 1D rebinning and systematic envelopes quietly skip them.
 
 * `get_yield_json.py`:
     - This script takes a pkl file produced by the processor, finds the yields in the analysis categories, and saves the yields to a json file. It can also print the info to the screen. The default pkl file to process is `hists/plotsTopEFT.pkl.gz`.


### PR DESCRIPTION
## Summary
- add SparseHist awareness to the CR plotting workflow, including a dedicated 2D heatmap helper and guards around 1D-only systematic handling
- skip multi-dense-axis histograms in auxiliary SR plotting helpers and document the new behaviour for downstream users
- allow yield_tools utilities to accept SparseHist inputs when retrieving axis labels

## Testing
- python -m compileall analysis/topeft_run2/make_cr_and_sr_plots.py topeft/modules/yield_tools.py

------
https://chatgpt.com/codex/tasks/task_e_68db8048f9308323aae6886d0d6fce1a