### PR TITLE
Handle quadratic term axis when detecting sparse CR histograms

### DIFF
--- a/analysis/topeft_run2/make_cr_and_sr_plots.py
+++ b/analysis/topeft_run2/make_cr_and_sr_plots.py
@@ -379,7 +379,11 @@ def get_diboson_njets_syst_arr(njets_histo_vals_arr,bin0_njets):
 
 
 def _is_sparse_2d_hist(histo):
-    return isinstance(histo, SparseHist) and len(histo.dense_axes) > 1
+    if not isinstance(histo, SparseHist):
+        return False
+
+    dense_axes = [ax for ax in histo.dense_axes if getattr(ax, "name", None) != "quadratic_term"]
+    return len(dense_axes) > 1
 
 
 ######### Plotting functions #########
@@ -1372,6 +1376,9 @@ def make_all_cr_plots(dict_of_hists,year,skip_syst_errs,unit_norm_bool,save_dir_
         hist_mc = dict_of_hists[var_name].remove("process", samples_to_rm_from_mc_hist)
         hist_data = dict_of_hists[var_name].remove("process", samples_to_rm_from_data_hist)
         is_sparse2d = _is_sparse_2d_hist(hist_mc)
+        if is_sparse2d and (var_name not in axes_info_2d) and ("_vs_" not in var_name):
+            print(f"Warning: Histogram '{var_name}' identified as sparse 2D but lacks metadata; falling back to 1D plotting.")
+            is_sparse2d = False
 
         # Loop over the CR categories
         for hist_cat in cr_cat_dict.keys():


### PR DESCRIPTION
## Summary
- ignore the quadratic_term dense axis when determining whether a SparseHist should be rendered with the 2D canvas
- add a metadata guard so histograms without 2D configuration fall back to the 1D plotting path instead of calling make_sparse2d_fig

## Testing
- python - <<'PY' ... (custom harness exercising lepton_pt and lepton_pt_vs_eta histograms)


------
https://chatgpt.com/codex/tasks/task_e_68dcd60f91a8832399e79a610b96b81f