### PR TITLE
Fix trigger SF variation guard

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -578,6 +578,8 @@ class AnalysisProcessor(processor.ProcessorABC):
         met_raw = met
         weights_obj_base_for_kinematic_syst = copy.deepcopy(weights_obj_base)
 
+        trigger_weight_label = f"triggerSF_{year}"
+
         #################### Jets ####################
 
         # Jet cleaning, before any jet selection
@@ -771,8 +773,24 @@ class AnalysisProcessor(processor.ProcessorABC):
                     )
 
         # Trigger SFs
-        GetTriggerSF(year,events,l0,l1)
-        weights_obj_base_for_kinematic_syst.add(f"triggerSF_{year}", events.trigger_sf, copy.deepcopy(events.trigger_sfUp), copy.deepcopy(events.trigger_sfDown))            # In principle does not have to be in the lep cat loop
+        GetTriggerSF(year, events, l0, l1)
+        include_trigger_vars = (
+            self._do_systematics
+            and not isData
+            and variation_base == "trigger_sf"
+        )
+        if include_trigger_vars:
+            weights_obj_base_for_kinematic_syst.add(
+                trigger_weight_label,
+                events.trigger_sf,
+                copy.deepcopy(events.trigger_sfUp),
+                copy.deepcopy(events.trigger_sfDown),
+            )
+        else:
+            weights_obj_base_for_kinematic_syst.add(
+                trigger_weight_label,
+                events.trigger_sf,
+            )
 
         ######### Event weights that do depend on the lep cat ###########
         # Determine the lepton multiplicity category from the requested


### PR DESCRIPTION
## Summary
- align the trigger scale-factor systematic guard with the `trigger_sf` variation key so the dedicated up/down weights attach when requested
- keep the nominal trigger scale factor applied for all variations while restricting the directional branches to the trigger systematic

## Testing
- python - <<'PY'  # verifies trigger_sf variation adds up/down weights
- python - <<'PY'  # verifies non-trigger variations only add the nominal weight

------
https://chatgpt.com/codex/tasks/task_e_68dfd5a7d998832390e2a7c57a40a146