### PR TITLE
Validate fliprate data weight registration

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -911,6 +911,15 @@ class AnalysisProcessor(processor.ProcessorABC):
         if isData and nlep_cat.startswith("2l") and ("os" not in self.channel):
             weights_object.add("fliprate", events.flipfactor_2l)
 
+            central_modifiers = getattr(weights_object, "weight_modifiers", None)
+            if central_modifiers is None:
+                central_modifiers = getattr(weights_object, "_names", None)
+
+            if central_modifiers is None or "fliprate" not in set(central_modifiers):
+                raise AssertionError(
+                    "The 2l same-sign data branch must register the central 'fliprate' weight."
+                )
+
         # MC-only scale factors
         if not isData:
             if nlep_cat.startswith("1l"):
@@ -938,11 +947,11 @@ class AnalysisProcessor(processor.ProcessorABC):
                 raise Exception(f"Unknown channel name: {nlep_cat}")
 
         # Ensure that for data we only have the expected systematic
-        # variations in the Weights object
+        # variations in the Weights object.  This whitelist is limited to
+        # genuine data-weight systematics; the 2l same-sign flip-rate
+        # normalisation is validated independently above.
         if self._do_systematics and isData:
             expected_vars = set(data_weight_systematics_set)
-            if nlep_cat.startswith("2l") and ("os" not in self.channel):
-                expected_vars.add("fliprate")
 
             variation_set = set(weights_object.variations)
             unexpected_variations = variation_set - expected_vars

--- a/tests/test_data_weight_variations.py
+++ b/tests/test_data_weight_variations.py
@@ -1,0 +1,91 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+from coffea.analysis_tools import Weights
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _load_analysis_processor_with_correction_stubs():
+    analysis_path = REPO_ROOT / "analysis" / "topeft_run2" / "analysis_processor.py"
+
+    def _make_stub(module_name):
+        module = types.ModuleType(module_name)
+
+        def _placeholder(*_args, **_kwargs):
+            return None
+
+        module.__getattr__ = lambda _name: _placeholder  # type: ignore[attr-defined]
+        return module
+
+    stubbed_modules = {
+        "topeft.modules.corrections": _make_stub("topeft.modules.corrections"),
+        "topcoffea.modules.corrections": _make_stub("topcoffea.modules.corrections"),
+    }
+
+    saved_modules = {}
+    module_name = "analysis_processor_for_test"
+
+    try:
+        for name, stub in stubbed_modules.items():
+            if name in sys.modules:
+                saved_modules[name] = sys.modules[name]
+            sys.modules[name] = stub
+
+        spec = importlib.util.spec_from_file_location(module_name, analysis_path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.modules.pop(module_name, None)
+        for name in stubbed_modules:
+            if name in saved_modules:
+                sys.modules[name] = saved_modules[name]
+            else:
+                sys.modules.pop(name, None)
+
+
+def test_same_sign_data_weights_include_fliprate_and_requested_variations():
+    analysis_module = _load_analysis_processor_with_correction_stubs()
+
+    weights = Weights(3)
+    events = types.SimpleNamespace(
+        fakefactor_2l=np.array([0.9, 1.1, 1.0]),
+        fakefactor_2l_up=np.array([1.0, 1.2, 1.1]),
+        fakefactor_2l_down=np.array([0.8, 1.0, 0.9]),
+        nom=np.ones(3),
+        fakefactor_2l_pt1=np.full(3, 1.05),
+        fakefactor_2l_pt2=np.full(3, 0.95),
+        fakefactor_2l_be1=np.full(3, 1.02),
+        fakefactor_2l_be2=np.full(3, 0.98),
+        fakefactor_2l_elclosureup=np.full(3, 1.01),
+        fakefactor_2l_elclosuredown=np.full(3, 0.99),
+        fakefactor_2l_muclosureup=np.full(3, 1.03),
+        fakefactor_2l_muclosuredown=np.full(3, 0.97),
+        flipfactor_2l=np.array([1.2, 0.8, 1.0]),
+    )
+
+    analysis_module._add_fake_factor_weights(
+        weights,
+        events,
+        "2lss",
+        "UL18",
+        requested_data_weight_label="FF",
+    )
+
+    weights.add("fliprate", events.flipfactor_2l)
+
+    central_modifiers = getattr(weights, "weight_modifiers", None)
+    if central_modifiers is None:
+        central_modifiers = getattr(weights, "_names", None)
+
+    assert central_modifiers is not None
+    assert "fliprate" in set(central_modifiers)
+
+    assert set(weights.variations) == {"FFUp", "FFDown"}


### PR DESCRIPTION
## Summary
- ensure the 2l same-sign data branch explicitly confirms the central fliprate weight is registered instead of whitelisting it as a variation
- clarify that the data-weight variation whitelist only covers genuine systematic shifts because fliprate is checked separately
- add a focused regression test that stubs heavy corrections modules and verifies fliprate plus fake-factor variations for 2l same-sign data

## Testing
- pytest tests/test_data_weight_variations.py

------
https://chatgpt.com/codex/tasks/task_e_68e3fca1e2c4832387af8e822623ccb9