### PR TITLE
Refactor channel prefix handling in analysis processor

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -93,13 +93,12 @@ def _build_fake_factor_specs(channel_prefix, year):
 def _add_fake_factor_weights(
     weights_object,
     events,
-    nlep_cat,
+    channel_prefix,
     year,
     requested_data_weight_label=None,
 ):
     """Register fake-factor weights for the requested lepton category."""
 
-    channel_prefix = nlep_cat[:2]
     fake_factor_specs = _build_fake_factor_specs(channel_prefix, year)
 
     requested_variations = None
@@ -683,6 +682,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         # which set of weights to apply when attaching lepton scale factors
         # below.
         nlep_cat = re.match(r"\d+l", self.channel).group(0)
+        channel_prefix = nlep_cat[:2]
 
         if not isData:
             # Begin consolidated MC-only weight registration.
@@ -946,7 +946,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                 )
 
             # Lepton (and optional tau) scale factors depend on the lepton category.
-            if nlep_cat.startswith("1l"):
+            if channel_prefix == "1l":
                 weights_object.add(
                     "lepSF_muon",
                     events.sf_1l_muon,
@@ -972,7 +972,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                         copy.deepcopy(events.sf_2l_taus_fake_hi),
                         copy.deepcopy(events.sf_2l_taus_fake_lo),
                     )
-            elif nlep_cat.startswith("2l"):
+            elif channel_prefix == "2l":
                 weights_object.add(
                     "lepSF_muon",
                     events.sf_2l_muon,
@@ -998,7 +998,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                         copy.deepcopy(events.sf_2l_taus_fake_hi),
                         copy.deepcopy(events.sf_2l_taus_fake_lo),
                     )
-            elif nlep_cat.startswith("3l"):
+            elif channel_prefix == "3l":
                 weights_object.add(
                     "lepSF_muon",
                     events.sf_3l_muon,
@@ -1024,7 +1024,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                         copy.deepcopy(events.sf_2l_taus_fake_hi),
                         copy.deepcopy(events.sf_2l_taus_fake_lo),
                     )
-            elif nlep_cat.startswith("4l"):
+            elif channel_prefix == "4l":
                 weights_object.add(
                     "lepSF_muon",
                     events.sf_4l_muon,
@@ -1045,12 +1045,11 @@ class AnalysisProcessor(processor.ProcessorABC):
         # Attach the lepton-category specific pieces on top of the
         # previously registered central and kinematic weights.
 
-        channel_prefix = nlep_cat[:2]
         if channel_prefix in {"1l", "2l", "3l"}:
             _add_fake_factor_weights(
                 weights_object,
                 events,
-                nlep_cat,
+                channel_prefix,
                 year,
                 requested_data_weight_label,
             )
@@ -1064,7 +1063,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             )
 
         # Additional data-only weights
-        if isData and nlep_cat.startswith("2l") and ("os" not in self.channel):
+        if isData and channel_prefix == "2l" and ("os" not in self.channel):
             weights_object.add("fliprate", events.flipfactor_2l)
 
             central_modifiers = getattr(weights_object, "weight_modifiers", None)

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -99,6 +99,10 @@ def _add_fake_factor_weights(
 ):
     """Register fake-factor weights for the requested lepton category."""
 
+    # Preserve compatibility with callers that still pass the full channel name (e.g. "2lss")
+    # by only using the leading lepton-multiplicity prefix when building attribute names.
+    channel_prefix = channel_prefix[:2]
+
     fake_factor_specs = _build_fake_factor_specs(channel_prefix, year)
 
     requested_variations = None


### PR DESCRIPTION
## Summary
- compute the lepton channel prefix once and reuse it for scale-factor and fake-factor logic
- adjust fake-factor registration to accept the precomputed prefix and simplify channel checks

## Testing
- pytest tests/test_data_weight_variations.py *(fails: ModuleNotFoundError: No module named 'numpy')*