### PR TITLE
Drop redundant systematics flags from run2 processor

### DIFF
--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -690,7 +690,7 @@ if __name__ == "__main__":
     for sample in samples_lst:
         sample_info = samplesdict[sample]
         ch_map = channel_app_map_data if sample_info["isData"] else channel_app_map_mc
-        variations = syst_helper.variations_for_sample(
+        grouped_variations = syst_helper.grouped_variations_for_sample(
             sample_info, include_systematics=do_systs
         )
         sample_type_key = "data" if sample_info["isData"] else "mc"
@@ -700,14 +700,30 @@ if __name__ == "__main__":
             var_info = var_defs[var].copy()
             for clean_ch, appl_list in ch_map.items():
                 for appl in appl_list:
-                    for variation in variations:
+                    for group_descriptor, variations in grouped_variations.items():
+                        hist_keys = {}
+                        multiple_variations = len(variations) > 1
+                        for variation in variations:
+                            if multiple_variations:
+                                syst_label = (group_descriptor.name, variation.name)
+                            else:
+                                syst_label = variation.name
+                            hist_keys[variation.name] = (
+                                var,
+                                clean_ch,
+                                appl,
+                                sample,
+                                syst_label,
+                            )
                         key_lst.append(
                             (
                                 sample,
                                 var,
                                 clean_ch,
                                 appl,
-                                variation,
+                                group_descriptor,
+                                tuple(variations),
+                                hist_keys,
                                 var_info,
                                 available_systematics,
                             )
@@ -821,11 +837,20 @@ if __name__ == "__main__":
     # raise RuntimeError("Stopping here for debugging")
     
     for key in key_lst:
-        sample, var, clean_ch, appl, syst_info, var_info, available_systematics = key
+        (
+            sample,
+            var,
+            clean_ch,
+            appl,
+            group_descriptor,
+            systematic_variations,
+            hist_keys,
+            var_info,
+            available_systematics,
+        ) = key
         sample_dict = samplesdict[sample]
         sample_flist = flist[sample][:1]
 
-        hist_key = (var, clean_ch, appl, sample, syst_info.name)
         channel_dict = build_channel_dict(
             clean_ch,
             appl,
@@ -859,25 +884,22 @@ if __name__ == "__main__":
         processor_instance = analysis_processor.AnalysisProcessor(
             sample_dict,
             wc_lst,
-            hist_key,
+            hist_keys=hist_keys,
             var_info,
             ecut_threshold,
             do_errors,
-            do_systs,
             split_lep_flavor,
-            skip_sr,
-            skip_cr,
             offZ_split=offZ_split,
             tau_h_analysis=tau_h_analysis,
             fwd_analysis=fwd_analysis,
             channel_dict=channel_dict,
             golden_json_path=golden_json_path,
-            systematic_info=syst_info,
+            systematic_variations=systematic_variations,
             available_systematics=available_systematics,
         )
 
         # # print("\nsample_dict:", sample_dict)
-        # print("\nhist_key:", hist_key)
+        # print("\nhist_keys:", hist_keys)
         # # print("\nselect_cat_dict:", select_cat_dict)
         # print("\nchannel_dict:", channel_dict)
 

--- a/tests/test_systematics_grouping.py
+++ b/tests/test_systematics_grouping.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from topeft.modules.systematics import SystematicsHelper
+
+
+def _build_metadata():
+    return {
+        "systematics": {
+            "nominal": {
+                "type": "nominal",
+                "applies_to": ["all"],
+                "variations": [{"value": "nominal"}],
+            },
+            "isr": {
+                "type": "theory",
+                "applies_to": ["mc"],
+                "variations": [
+                    {"value": "ISRUp", "direction": "Up", "sum_of_weights": "nSumOfWeights_ISRUp"},
+                    {"value": "ISRDown", "direction": "Down", "sum_of_weights": "nSumOfWeights_ISRDown"},
+                ],
+            },
+            "pileup": {
+                "type": "weight",
+                "applies_to": ["mc"],
+                "variations": [
+                    {"value": "PUUp", "direction": "Up"},
+                    {"value": "PUDown", "direction": "Down"},
+                ],
+            },
+            "fake_factors": {
+                "type": "data_weight",
+                "applies_to": ["all"],
+                "variations": [
+                    {"value": "FFUp", "direction": "Up"},
+                    {"value": "FFDown", "direction": "Down"},
+                ],
+            },
+        },
+    }
+
+
+def test_grouped_variations_for_sample_mc():
+    metadata = _build_metadata()
+    helper = SystematicsHelper(metadata, sample_years=["2018"])
+    sample = {"year": "2018", "isData": False}
+
+    grouped = helper.grouped_variations_for_sample(sample, include_systematics=True)
+    variations = helper.variations_for_sample(sample, include_systematics=True)
+
+    assert sum(len(members) for members in grouped.values()) == len(variations)
+
+    isr_groups = [item for item in grouped.items() if item[0].name == "isr"]
+    assert len(isr_groups) == 1
+    _, isr_variations = isr_groups[0]
+    assert sorted(variation.name for variation in isr_variations) == ["ISRDown", "ISRUp"]
+
+    first_group = next(iter(grouped.keys()))
+    assert "nominal" in first_group.members
+
+
+def test_grouped_variations_for_data_sample_excludes_mc_theory():
+    metadata = _build_metadata()
+    helper = SystematicsHelper(metadata, sample_years=["2018"])
+    sample = {"year": "2018", "isData": True}
+
+    grouped = helper.grouped_variations_for_sample(sample, include_systematics=True)
+
+    for _, variations in grouped.items():
+        for variation in variations:
+            assert variation.type != "theory"


### PR DESCRIPTION
## Summary
- remove the unused skip_signal_regions/skip_control_regions/do_systematics constructor flags from the run-2 AnalysisProcessor
- derive systematic handling from the provided variation tuple and update the run driver call site accordingly

## Testing
- pytest tests/test_systematics_grouping.py

------
https://chatgpt.com/codex/tasks/task_e_68e53888a02c8323b0f150881171ac8d