### PR TITLE
Refine diboson njets scale factor calculation

### DIFF
--- a/analysis/diboson_njets/diboson_sf_run3.py
+++ b/analysis/diboson_njets/diboson_sf_run3.py
@@ -11,6 +11,9 @@ import argparse
 import pickle
 import gzip
 import numpy as np
+import matplotlib.pyplot as plt
+import mplhep as hep
+from scipy.optimize import curve_fit
 import hist
 import boost_histogram as bh
 import awkward as ak
@@ -23,6 +26,7 @@ def load_pkl_file(pkl_file):
 def get_yields_in_bins(hin_dict, proc_list, bins, hist_name, channel_name):
     h = hin_dict[hist_name]
     yields = {}
+    edges = None
 
     for proc in proc_list:
         yields[proc] = []
@@ -36,10 +40,16 @@ def get_yields_in_bins(hin_dict, proc_list, bins, hist_name, channel_name):
             #     if ax.name != "njets":
             #         h_sel = h_sel.integrate(ax.name)
             axis = h_sel.axes[hist_name]
-            view = h_sel.view(flow=False)
             edges = axis.edges
-            view_array = list(view.values())[0]  # Extracts the array
-            view_flatten = view_array.flatten().tolist()
+            values = np.asarray(h_sel.values(flow=False), dtype=float)
+            variances = h_sel.variances(flow=False)
+            if variances is None:
+                variances = np.zeros_like(values, dtype=float)
+            else:
+                variances = np.asarray(variances, dtype=float)
+
+            view_flatten = values.reshape(-1)
+            var_flatten = variances.reshape(-1)
 
         except Exception as e:
             print(f"\n\n  Error slicing/integrating for proc {proc}: {e}")
@@ -48,17 +58,14 @@ def get_yields_in_bins(hin_dict, proc_list, bins, hist_name, channel_name):
 
         for i in range(len(bins) - 1):
             low, high = bins[i], bins[i + 1]
-            val = 0.0
-            err = 0.0
+            axis_edges = np.asarray(axis.edges)
+            start = np.searchsorted(axis_edges, low, side="left")
+            stop = np.searchsorted(axis_edges, high, side="left")
+            val = float(np.sum(view_flatten[start:stop]))
+            err = float(np.sqrt(np.sum(var_flatten[start:stop])))
+            yields[proc].append((val, err))
 
-            bin_indices = [
-                j for j, (lo, hi) in enumerate(zip(axis.edges[:-1], axis.edges[1:]))
-                if hi > low and lo < high
-            ]
-            val = sum(view_flatten[j] for j in bin_indices)
-            yields[proc].append((val, 0.0))
-            
-    return yields
+    return list(edges) if edges is not None else bins, yields
 
 def make_diboson_sf_json(bins, scale_factors, year):
     if len(bins) != len(scale_factors) + 1:
@@ -83,53 +90,133 @@ def main():
     parser.add_argument("-y", "--year", default="2022", help = "The year of the sample")
     args = parser.parse_args()
 
-    bins = list(range(0, 7))
     hin_dict = load_pkl_file(args.pkl)
 
     h = hin_dict[args.hist_name]
+    axis = h.axes[args.hist_name]
+    bins = axis.edges.tolist()
     proc_list = list(h.axes["process"])
 
-    yields = get_yields_in_bins(hin_dict, proc_list, bins, hist_name=args.hist_name, channel_name=args.channel)
+    _, yields = get_yields_in_bins(hin_dict, proc_list, bins, hist_name=args.hist_name, channel_name=args.channel)
 
-    diboson = []
-    data = []
-    other = []
-    
+    diboson_vals = diboson_errs = None
+    data_vals = data_errs = None
+    other_vals = other_errs = None
+
     for proc, vals in yields.items():
         if proc.startswith("flip"):
             continue  # Skip flip samples
         #print("\n\nProcessing proc:", proc) #, vals)
         if proc.startswith("WZTo") or proc.startswith("ZZTo") or proc.startswith("WWTo"):
             #print("  Adding to diboson")
-            if not diboson:
-                diboson = [val for val, _ in vals]
+            val_arr = np.array([val for val, _ in vals], dtype=float)
+            err_arr = np.array([err for _, err in vals], dtype=float)
+            if diboson_vals is None:
+                diboson_vals = val_arr.copy()
+                diboson_errs = err_arr.copy()
             else:
-                diboson = [x + val for x, (val, _) in zip(diboson, vals)]
+                diboson_vals += val_arr
+                diboson_errs = np.sqrt(diboson_errs**2 + err_arr**2)
         elif "data" in proc:
             #print("  Adding to data")
-            data = [val for val, _ in vals]
+            data_vals = np.array([val for val, _ in vals], dtype=float)
+            data_errs = np.array([err for _, err in vals], dtype=float)
         else:
             #print("  Adding to other")
-            if not other:
-                other = [val for val, _ in vals]
+            val_arr = np.array([val for val, _ in vals], dtype=float)
+            err_arr = np.array([err for _, err in vals], dtype=float)
+            if other_vals is None:
+                other_vals = val_arr.copy()
+                other_errs = err_arr.copy()
             else:
-                other = [x + val for x, (val, _) in zip(other, vals)]
+                other_vals += val_arr
+                other_errs = np.sqrt(other_errs**2 + err_arr**2)
+
+    num_bins = len(bins) - 1
+    if diboson_vals is None:
+        diboson_vals = np.zeros(num_bins)
+        diboson_errs = np.zeros(num_bins)
+    if data_vals is None:
+        data_vals = np.zeros(num_bins)
+        data_errs = np.zeros(num_bins)
+    if other_vals is None:
+        other_vals = np.zeros(num_bins)
+        other_errs = np.zeros(num_bins)
 
     # Compute (data - other) / diboson
     scale_factors = []
-    for d, o, f in zip(data, other, diboson):
+    scale_factor_errs = []
+    for d, de, o, oe, f, fe in zip(
+        data_vals, data_errs, other_vals, other_errs, diboson_vals, diboson_errs
+    ):
         if f != 0:
-            sf = (d - o) / f
+            numerator = d - o
+            sf = numerator / f
+            variance = (de**2 + oe**2) / (f**2)
+            variance += ((numerator) ** 2 / (f**4)) * (fe**2)
+            sf_err = float(np.sqrt(max(variance, 0.0)))
         else:
-            sf = float(0)  # or 0, or raise an error
-        scale_factors.append(sf)
+            sf = float(0)
+            sf_err = float(0)
+        scale_factors.append(float(sf))
+        scale_factor_errs.append(sf_err)
     make_diboson_sf_json(bins, scale_factors, year=args.year)
 
     # Output
-    print("diboson =", diboson)
-    print("data  =", data)
-    print("other =", other)
+    print("diboson =", diboson_vals.tolist())
+    print("data  =", data_vals.tolist())
+    print("other =", other_vals.tolist())
     print("SFs   =", scale_factors)
+    print("SF errs =", scale_factor_errs)
+
+    edges = np.array(bins, dtype=float)
+    centers = 0.5 * (edges[:-1] + edges[1:])
+    ratio = np.array(scale_factors, dtype=float)
+    yerr = np.array(scale_factor_errs, dtype=float)
+
+    if len(ratio) <= 7:
+        print("Not enough bins to apply slice(3, -4); skipping plotting.")
+        return
+
+    sel = slice(3, -4)
+    sel_centers = centers[sel]
+    sel_ratio = ratio[sel]
+    sel_err = yerr[sel]
+
+    sel_err_safe = np.where(sel_err > 0, sel_err, 1e-6)
+
+    hep.style.use("CMS")
+    fig, ax = plt.subplots()
+    ax.errorbar(sel_centers, sel_ratio, yerr=sel_err, fmt="o", label="Scale factor")
+
+    coeffs = np.polyfit(sel_centers, sel_ratio, deg=1, w=1.0 / sel_err_safe)
+    ax.plot(sel_centers, np.polyval(coeffs, sel_centers), label="Polyfit")
+
+    def linear(x, m, b):
+        return m * x + b
+
+    try:
+        popt, pcov = curve_fit(
+            linear, sel_centers, sel_ratio, sigma=sel_err_safe, absolute_sigma=True
+        )
+        ax.plot(sel_centers, linear(sel_centers, *popt), label="Curve fit", linestyle="--")
+        print(f"curve_fit parameters: {popt}")
+        print(f"curve_fit covariance matrix:\n{pcov}")
+    except Exception as exc:
+        popt = None
+        pcov = None
+        print(f"curve_fit failed: {exc}")
+
+    print(f"Polyfit coefficients: {coeffs}")
+
+    ax.set_xlabel("Njets bin center")
+    ax.set_ylabel("Scale factor")
+    ax.legend()
+    fig.tight_layout()
+
+    fig.savefig("output.pdf")
+    fig.savefig("output.png")
+    plt.close(fig)
 
 
 


### PR DESCRIPTION
## Summary
- load histogram bin contents and variances to compute per-process yields with uncertainties
- derive scale factors and propagated errors from the histogram axis definition
- add plotting routine with CMS styling, polynomial overlays, and curve-fit diagnostics

## Testing
- `python -m compileall analysis/diboson_njets/diboson_sf_run3.py`


------
https://chatgpt.com/codex/tasks/task_e_68e6665bc0648323bd9f89bb1feb2cf4