### PR TITLE
Ensure systematic grouping tracks component/year metadata

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -616,7 +616,9 @@ class AnalysisProcessor(processor.ProcessorABC):
             sow_variations = {"nominal": sow}
 
             if variation is not None and self._systematic_variations and not isData:
-                group_info = variation.group or {}
+                group_mapping = variation.group or {}
+                group_key = (variation.base, variation.component, variation.year)
+                group_info = group_mapping.get(group_key, {})
                 if not group_info and variation.metadata.get("sum_of_weights"):
                     group_info = {
                         variation.name: {


### PR DESCRIPTION
## Summary
- reorganize systematic variation grouping metadata so each base exposes component/year keyed groups
- propagate the new grouping structure into the analysis processor and ensure group descriptors remain stable
- extend unit coverage to validate grouping for trigger, pileup, and fake factor systematics

## Testing
- pytest tests/test_systematics_grouping.py


------
https://chatgpt.com/codex/tasks/task_e_68e6734e63688323b1e10e1dd8c8d87d