### PR TITLE
Simplify hist key construction

### DIFF
--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -706,20 +706,18 @@ if __name__ == "__main__":
                 for appl in appl_list:
                     for group_descriptor, variations in grouped_variations.items():
                         #print("\n", group_descriptor.name, [v.name for v in variations])
-                        hist_keys = {}
-                        multiple_variations = len(variations) > 1
-                        for variation in variations:
-                            if multiple_variations:
-                                syst_label = (group_descriptor.name, variation.name)
-                            else:
-                                syst_label = variation.name
-                            hist_keys[variation.name] = (
+                        hist_keys = {
+                            variation.name: (
                                 var,
                                 clean_ch,
                                 appl,
                                 sample,
-                                syst_label,
+                                (group_descriptor.name, variation.name)
+                                if len(variations) > 1
+                                else variation.name,
                             )
+                            for variation in variations
+                        }
                         key_lst.append(
                             (
                                 sample,


### PR DESCRIPTION
## Summary
- replace the manual loop that builds `hist_keys` with a dictionary comprehension that maps each variation to its tuple
- compute the systematic label inline to preserve existing behavior without a separate flag

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e680fe04cc83238c147a2755f90f2d