### PR TITLE
Adjust stacked panel aspect ratio to 5x4

### DIFF
--- a/analysis/topeft_run2/make_cr_and_sr_plots.py
+++ b/analysis/topeft_run2/make_cr_and_sr_plots.py
@@ -374,7 +374,7 @@ def _draw_stacked_panel(
     fig, (ax, rax) = plt.subplots(
         nrows=2,
         ncols=1,
-        figsize=(9, 8),
+        figsize=(10, 8),
         gridspec_kw={"height_ratios": (4, 1)},
         sharex=True,
     )


### PR DESCRIPTION
## Summary
- update the stacked panel helper to use a 5:4 aspect ratio figure size

## Testing
- not run (not requested)