### PR TITLE
Add year filtering to tau fitter and refresh sumw2 controls

### DIFF
--- a/README_FITTING.md
+++ b/README_FITTING.md
@@ -36,12 +36,16 @@ does not write output files—so the printed tables are the main products.
 
 ### Running the script
 
-Run the fitter from the repository root so relative paths resolve correctly:
+Run the fitter from the repository root so relative paths resolve correctly. Use
+`-y/--year` to restrict the MC/data samples to specific campaigns when your
+pickle contains multiple eras (e.g. `2022EE`, `2023BPix`). Omit the option to
+keep every year present in the histogram file.
 
 ```bash
 python analysis/topeft_run2/tauFitter.py \
   -f /path/to/plotsTopEFT.pkl.gz \
-  --channels-json /path/to/ch_lst.json
+  --channels-json /path/to/ch_lst.json \
+  -y 2022EE 2023BPix
 ```
 
 The regrouped tau-pT binning defaults to

--- a/analysis/diboson_njets/README.md
+++ b/analysis/diboson_njets/README.md
@@ -3,6 +3,12 @@
 `diboson_sf_run3.py` derives diboson scale factors from the `njets` distribution.
 The default binning is `[0, 1, 2, 3, 4, 5, 6]`.
 
+When preparing the input pickle with `run_analysis.py`, keep the default
+sum-of-weights-squared histograms so the script can propagate statistical
+uncertainties without approximation. If you intentionally disable them via
+`--no-sumw2`, the diboson fitter will still run but the ratio uncertainties
+reflect the raw histogram variances only.
+
 ## Scale factor calculation
 
 For each requested year, the script loads the `njets` histogram, removes any

--- a/analysis/topeft_run2/README.md
+++ b/analysis/topeft_run2/README.md
@@ -66,7 +66,7 @@ This directory contains scripts for the Full Run 2 EFT analysis. This README doc
     - Example usage: `python run_topeft.py ../../topcoffea/cfg/your_cfg.cfg`
 
 * `run_analysis.py`:
-    - Thin wrapper around `analysis_processor.py` used for the standard CR/analysis histogram production. The canned histogram lists now include the 2D `lepton_pt_vs_eta` observable (and `lepton_pt_vs_eta_sumw2` when `--do-errors` is set) so downstream tools can rely on a consistent pt vs $|\eta|$ binning description.
+    - Thin wrapper around `analysis_processor.py` used for the standard CR/analysis histogram production. The canned histogram lists now include the 2D `lepton_pt_vs_eta` observable, and by default the processor also fills the matching `_sumw2` companions. Pass `--no-sumw2` when you explicitly want to skip those variance histograms (which also disables the associated EFT $w^2$ bookkeeping) and produce a lighter-weight pickle.
 
 * `run_sow.py` for `sow_processor.py`:
     - This script runs over the provided json files and calculates the properer sum of weights
@@ -103,7 +103,7 @@ Common invocation patterns (`-y/--year` now accepts multiple tokens for combined
 * Summing luminosities across multiple years: `python make_cr_and_sr_plots.py -f histos/plotsCR_Run2.pkl.gz -y 2016APV 2016 2017 2018`
 * Signal-region pass where the filename already encodes `SR`: `python make_cr_and_sr_plots.py -f histos/SR2018.pkl.gz -o ~/www/sr --variables lj0pt ptz`
 * Overriding the heuristic and forcing a blinded SR workflow: `python make_cr_and_sr_plots.py -f histos/plotsTopEFT.pkl.gz --sr --blind`
-* Producing unblinded CR plots with explicit tagging and timestamped directories: `python make_cr_and_sr_plots.py -f histos/CR2018.pkl.gz --cr -t -n cr_2018_scan`
+* Producing unblinded CR plots with explicit tagging, timestamped directories, and logarithmic stacked axes: `python make_cr_and_sr_plots.py -f histos/CR2018.pkl.gz --cr -t -n cr_2018_scan --log-y`
 
 #### run_plotter.sh shell wrapper quickstart
 

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -1420,7 +1420,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
             for dense_axis_name, dense_axis_vals in varnames.items():
                 fill_base_hist = dense_axis_name in self._hist_lst
-                fill_sumw2_hist = (dense_axis_name+"_sumw2") in self._hist_lst
+                fill_sumw2_hist = self._do_errors and (dense_axis_name+"_sumw2") in self._hist_lst
                 if not (fill_base_hist or fill_sumw2_hist):
                     continue
 

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -100,9 +100,9 @@ if __name__ == "__main__":
         help="Name of the tree inside the files",
     )
     parser.add_argument(
-        "--do-errors",
+        "--no-sumw2",
         action="store_true",
-        help="Save the w**2 coefficients",
+        help="Disable filling the sum of weights squared histograms",
     )
     parser.add_argument(
         "--do-systs",
@@ -211,7 +211,7 @@ if __name__ == "__main__":
     outpath = args.outpath
     pretend = args.pretend
     treename = args.treename
-    do_errors = args.do_errors
+    produce_sumw2 = not args.no_sumw2
     do_systs = args.do_systs
     split_lep_flavor = args.split_lep_flavor
     offZ_split = args.offZ_split
@@ -243,7 +243,10 @@ if __name__ == "__main__":
         outpath = ops.pop("outpath",outpath)
         pretend = ops.pop("pretend",pretend)
         treename = ops.pop("treename",treename)
-        do_errors = ops.pop("do_errors",do_errors)
+        if "no_sumw2" in ops:
+            produce_sumw2 = not bool(ops.pop("no_sumw2"))
+        if "do_errors" in ops:
+            produce_sumw2 = bool(ops.pop("do_errors"))
         do_systs = ops.pop("do_systs",do_systs)
         split_lep_flavor = ops.pop("split_lep_flavor",split_lep_flavor)
         offZ_split = ops.pop("offZ_split",offZ_split)
@@ -322,15 +325,15 @@ if __name__ == "__main__":
             hist_lst.append("l1_SeedEtaOrX_vs_SeedPhiOrY")
         if "l1_eta_vs_phi" not in hist_lst:
             hist_lst.append("l1_eta_vs_phi")
-        if do_errors and "lepton_pt_vs_eta_sumw2" not in hist_lst:
+        if produce_sumw2 and "lepton_pt_vs_eta_sumw2" not in hist_lst:
             hist_lst.append("lepton_pt_vs_eta_sumw2")
-        if do_errors and "l0_SeedEtaOrX_vs_SeedPhiOrY_sumw2" not in hist_lst:
+        if produce_sumw2 and "l0_SeedEtaOrX_vs_SeedPhiOrY_sumw2" not in hist_lst:
             hist_lst.append("l0_SeedEtaOrX_vs_SeedPhiOrY_sumw2")
-        if do_errors and "l0_eta_vs_phi_sumw2" not in hist_lst:
+        if produce_sumw2 and "l0_eta_vs_phi_sumw2" not in hist_lst:
             hist_lst.append("l0_eta_vs_phi_sumw2")
-        if do_errors and "l1_SeedEtaOrX_vs_SeedPhiOrY_sumw2" not in hist_lst:
+        if produce_sumw2 and "l1_SeedEtaOrX_vs_SeedPhiOrY_sumw2" not in hist_lst:
             hist_lst.append("l1_SeedEtaOrX_vs_SeedPhiOrY_sumw2")
-        if do_errors and "l1_eta_vs_phi_sumw2" not in hist_lst:
+        if produce_sumw2 and "l1_eta_vs_phi_sumw2" not in hist_lst:
             hist_lst.append("l1_eta_vs_phi_sumw2")
     elif args.hist_list == ["cr"]:
         # Here we hardcode a list of hists used for the CRs
@@ -388,6 +391,9 @@ if __name__ == "__main__":
         # We want to specify a custom list
         # If we don't specify this argument, it will be None, and the processor will fill all hists
         hist_lst = args.hist_list
+
+    if hist_lst is not None and not produce_sumw2:
+        hist_lst = [name for name in hist_lst if not name.endswith("_sumw2")]
 
     ### Load samples from json
     samplesdict = {}
@@ -524,7 +530,7 @@ if __name__ == "__main__":
         wc_lst,
         hist_lst,
         ecut_threshold,
-        do_errors,
+        produce_sumw2,
         do_systs,
         split_lep_flavor,
         skip_sr,


### PR DESCRIPTION
## Summary
- add a --year CLI option to faketau_sf_fitter.py to filter data/MC samples by campaign
- replace run_analysis.py's legacy --do-errors flag with --no-sumw2, propagate the toggle into the processor, and keep docs in sync
- expand the README guidance for the CR/SR plotter, tau fake-rate fitter, and diboson scale-factor scripts

## Testing
- not run (not requested)