### PR TITLE
Remove commented coffea import from fake tau fitter

### DIFF
--- a/analysis/topeft_run2/faketau_sf_fitter.py
+++ b/analysis/topeft_run2/faketau_sf_fitter.py
@@ -23,7 +23,6 @@ import logging
 import math
 from collections import OrderedDict
 import functools
-#from coffea import hist
 import hist
 
 import sys


### PR DESCRIPTION
## Summary
- remove the stale commented coffea import from the fake tau scale factor fitter

## Testing
- python -m compileall topeft/analysis/topeft_run2/faketau_sf_fitter.py