### PR TITLE
Support tuple-keyed histograms in MC validation plotters

### DIFF
--- a/analysis/mc_validation/mc_validation_gen_plotter.py
+++ b/analysis/mc_validation/mc_validation_gen_plotter.py
@@ -3,6 +3,7 @@
 #   - Was used during the June 2022 MC validation studies (for TOP-22-006 pre approval checks)
 
 import os
+import sys
 import datetime
 import argparse
 import gzip
@@ -11,8 +12,20 @@ import cloudpickle
 import hist
 from hist import axis, storage
 
+from pathlib import Path
+
 from topcoffea.modules.YieldTools import YieldTools
 from topcoffea.scripts.make_html import make_html
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+
+from analysis.mc_validation.plot_utils import (  # noqa: E402
+    build_dataset_histograms,
+    component_values,
+    tuple_histogram_items,
+)
 
 
 # Probably I should move the utility functions out of this script and put them in modules
@@ -35,8 +48,19 @@ def save_pkl_for_arr(sf_arr,tag):
 
 # Main wrapper script for making the private vs central comparison plots
 def make_mc_validation_plots(dict_of_hists,year,skip_syst_errs,save_dir_path):
-    sample_lst = yt.get_cat_lables(dict_of_hists,"sample")
-    vars_lst = yt.get_hist_list(dict_of_hists)
+    tuple_entries = tuple_histogram_items(dict_of_hists)
+    using_tuple_entries = bool(tuple_entries)
+    rebuilt_hists = build_dataset_histograms(dict_of_hists) if using_tuple_entries else {}
+
+    if using_tuple_entries:
+        vars_lst = sorted(rebuilt_hists.keys())
+        sample_lst = component_values(tuple_entries, "sample")
+        dataset_axis_name = "dataset"
+    else:
+        vars_lst = yt.get_hist_list(dict_of_hists)
+        sample_lst = yt.get_cat_lables(dict_of_hists, "sample")
+        dataset_axis_name = "sample"
+
     print("\nSamples:",sample_lst)
     print("\nVariables:",vars_lst)
 
@@ -69,14 +93,19 @@ def make_mc_validation_plots(dict_of_hists,year,skip_syst_errs,save_dir_path):
         print("\nVar name:",var_name)
 
         # Sum over channels, and just grab the nominal from the syst axis
-        histo_base = dict_of_hists[var_name]
+        histo_base = rebuilt_hists.get(var_name, dict_of_hists[var_name])
 
         # Now loop over processes and make plots
         for proc in comp_proc_dict.keys():
             print(f"\nProcess: {proc}")
 
             # Group bins
-            proc_histo = mcp.group_bins(histo_base,comp_proc_dict[proc],drop_unspecified=True)
+            proc_histo = mcp.group_bins(
+                histo_base,
+                comp_proc_dict[proc],
+                axis_name=dataset_axis_name,
+                drop_unspecified=True,
+            )
             print(comp_proc_dict[proc])
 
             # Dump SF dictionary (for the HT reweighting tests)
@@ -87,7 +116,7 @@ def make_mc_validation_plots(dict_of_hists,year,skip_syst_errs,save_dir_path):
             #continue
 
             # Make the plots
-            fig = mcp.make_single_fig_with_ratio(proc_histo,"sample","private")
+            fig = mcp.make_single_fig_with_ratio(proc_histo,dataset_axis_name,"private")
             #fig = mcp.make_single_fig(proc_histo,unit_norm_bool=True)
             fig.savefig(os.path.join(save_dir_path,proc+"_"+var_name))
             if "www" in save_dir_path: make_html(save_dir_path)

--- a/analysis/mc_validation/mc_validation_gen_plotter.py
+++ b/analysis/mc_validation/mc_validation_gen_plotter.py
@@ -93,7 +93,11 @@ def make_mc_validation_plots(dict_of_hists,year,skip_syst_errs,save_dir_path):
         print("\nVar name:",var_name)
 
         # Sum over channels, and just grab the nominal from the syst axis
-        histo_base = rebuilt_hists.get(var_name, dict_of_hists[var_name])
+        histo_base = rebuilt_hists.get(var_name)
+        if histo_base is None:
+            histo_base = dict_of_hists.get(var_name)
+        if histo_base is None:
+            raise KeyError(f"Histogram '{var_name}' not found in rebuilt or original mapping")
 
         # Now loop over processes and make plots
         for proc in comp_proc_dict.keys():

--- a/analysis/mc_validation/mc_validation_plotter.py
+++ b/analysis/mc_validation/mc_validation_plotter.py
@@ -179,7 +179,14 @@ def make_mc_validation_plots(dict_of_hists,year,skip_syst_errs,save_dir_path):
 
 
         # Sum over channels, and just grab the nominal from the syst axis
-        histo_base = rebuilt_hists.get(var_name, dict_of_hists[var_name])
+        if var_name in rebuilt_hists:
+            histo_base = rebuilt_hists[var_name]
+        elif var_name in dict_of_hists:
+            histo_base = dict_of_hists[var_name]
+        else:
+            raise KeyError(
+                f"Histogram '{var_name}' not found in rebuilt or original mapping."
+            )
 
         # Normalize by lumi (important to do this before grouping by year)
         sample_lumi_dict = {}

--- a/analysis/mc_validation/plot_utils.py
+++ b/analysis/mc_validation/plot_utils.py
@@ -1,0 +1,182 @@
+"""Utilities for working with tuple-keyed histogram payloads.
+
+The MC validation plotting scripts historically consumed histogram
+collections keyed by the variable name with categorical axes describing the
+dataset, analysis channel, and systematic variation.  The processing
+pipeline now serialises per-histogram tuples instead, so the plotting
+utilities need to rebuild a convenient structure from those tuples.  This
+module centralises that logic so the plotting scripts can remain focussed on
+presentation concerns.
+"""
+
+from __future__ import annotations
+
+import copy
+from collections import defaultdict
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional, Sequence, Tuple
+
+import hist
+
+try:  # pragma: no cover - HistEFT is optional in some environments
+    from topcoffea.modules.histEFT import HistEFT
+except Exception:  # pragma: no cover - fallback when HistEFT is unavailable
+    HistEFT = None  # type: ignore[assignment]
+
+
+TupleKey = Tuple[str, Optional[str], Optional[str], Optional[str], Optional[str]]
+
+_COMPONENT_INDEX = {
+    "variable": 0,
+    "channel": 1,
+    "application": 2,
+    "sample": 3,
+    "systematic": 4,
+}
+
+
+def tuple_histogram_items(hist_store: Mapping[Any, Any]) -> Dict[TupleKey, Any]:
+    """Return a mapping of tuple-keyed histogram entries within *hist_store*."""
+
+    entries: Dict[TupleKey, Any] = {}
+    for key, value in hist_store.items():
+        if isinstance(key, tuple) and len(key) == 5:
+            entries[key] = value
+    return entries
+
+
+def component_values(tuple_entries: Mapping[TupleKey, Any], component: str) -> Sequence[str]:
+    """Return sorted unique values for *component* within *tuple_entries*."""
+
+    index = _COMPONENT_INDEX[component]
+    values = sorted(
+        {
+            str(value)
+            for value in (key[index] for key in tuple_entries.keys())
+            if value is not None
+        }
+    )
+    return values
+
+
+def filter_tuple_histograms(
+    tuple_entries: Mapping[TupleKey, Any],
+    *,
+    variable: Optional[str] = None,
+    channel: Optional[str] = None,
+    application: Optional[str] = None,
+    sample: Optional[str] = None,
+    systematic: Optional[str] = None,
+) -> Dict[TupleKey, Any]:
+    """Return the subset of *tuple_entries* matching the requested filters."""
+
+    filters = {
+        "variable": variable,
+        "channel": channel,
+        "application": application,
+        "sample": sample,
+        "systematic": systematic,
+    }
+    result: Dict[TupleKey, Any] = {}
+    for key, value in tuple_entries.items():
+        include = True
+        for name, criterion in filters.items():
+            if criterion is None:
+                continue
+            index = _COMPONENT_INDEX[name]
+            if key[index] != criterion:
+                include = False
+                break
+        if include:
+            result[key] = value
+    return result
+
+
+def _copy_histogram(histogram: Any) -> Any:
+    """Return a shallow copy of *histogram* preserving its concrete type."""
+
+    copier = getattr(histogram, "copy", None)
+    if callable(copier):
+        return copier()
+    return copy.deepcopy(histogram)
+
+
+def _aggregate_variable_entries(tuple_entries: Mapping[TupleKey, Any]) -> Dict[str, MutableMapping[Tuple[str, str, str], Any]]:
+    """Group histogram entries by variable and dataset/channel/systematic tags."""
+
+    grouped: Dict[str, MutableMapping[Tuple[str, str, str], Any]] = defaultdict(dict)
+    for key, histogram in tuple_entries.items():
+        variable, channel, _, sample, systematic = key
+        dataset = sample or ""
+        channel_label = channel or "inclusive"
+        systematic_label = systematic or "nominal"
+        aggregate_key = (dataset, channel_label, systematic_label)
+
+        variable_entries = grouped[variable]
+        if aggregate_key in variable_entries:
+            variable_entries[aggregate_key] = variable_entries[aggregate_key] + histogram
+        else:
+            variable_entries[aggregate_key] = _copy_histogram(histogram)
+    return grouped
+
+
+def _build_hist_like(template: Any, dataset_labels: Sequence[str], channel_labels: Sequence[str], systematic_labels: Sequence[str]):
+    """Create an empty histogram matching *template* with categorical axes."""
+
+    dataset_axis = hist.axis.StrCategory(dataset_labels, name="dataset")
+    channel_axis = hist.axis.StrCategory(channel_labels, name="channel")
+    systematic_axis = hist.axis.StrCategory(systematic_labels, name="systematic")
+
+    if HistEFT is not None and isinstance(template, HistEFT):
+        dense_axis = template.dense_axis
+        return HistEFT(
+            dataset_axis,
+            channel_axis,
+            systematic_axis,
+            dense_axis,
+            wc_names=getattr(template, "wc_names", []),
+            label=getattr(template, "label", None),
+        )
+
+    axes = list(getattr(template, "axes", ()))
+    storage = template.storage_type() if hasattr(template, "storage_type") else "Double"
+    return hist.Hist(dataset_axis, channel_axis, systematic_axis, *axes, storage=storage)
+
+
+def build_dataset_histograms(hist_store: Mapping[Any, Any]) -> Dict[str, Any]:
+    """Reconstruct histograms with categorical axes from tuple-keyed inputs."""
+
+    tuple_entries = tuple_histogram_items(hist_store)
+    if not tuple_entries:
+        return {}
+
+    grouped = _aggregate_variable_entries(tuple_entries)
+    rebuilt: Dict[str, Any] = {}
+
+    for variable, aggregates in grouped.items():
+        first_hist = next(iter(aggregates.values()))
+        dataset_labels = sorted({key[0] for key in aggregates})
+        channel_labels = sorted({key[1] for key in aggregates})
+        systematic_labels = sorted({key[2] for key in aggregates})
+
+        summary_hist = _build_hist_like(first_hist, dataset_labels, channel_labels, systematic_labels)
+
+        for (dataset, channel, systematic), histogram in aggregates.items():
+            index = {"dataset": dataset, "channel": channel, "systematic": systematic}
+            try:
+                summary_hist[index] = histogram
+            except Exception:
+                summary_hist[index] = histogram.view()
+
+        rebuilt[variable] = summary_hist
+
+    return rebuilt
+
+
+__all__ = [
+    "TupleKey",
+    "build_dataset_histograms",
+    "component_values",
+    "filter_tuple_histograms",
+    "tuple_histogram_items",
+]
+

--- a/tests/test_mc_validation_plot_utils.py
+++ b/tests/test_mc_validation_plot_utils.py
@@ -3,18 +3,26 @@ from pathlib import Path
 
 import cloudpickle
 import numpy as np
-from hist import axis
+from hist import Hist, axis, storage
 
 from analysis.mc_validation.plot_utils import (
     build_dataset_histograms,
     component_values,
     tuple_histogram_items,
 )
-from topcoffea.modules.histEFT import HistEFT
+
+try:  # pragma: no cover - optional dependency in CI
+    from topcoffea.modules.histEFT import HistEFT as _HistEFT
+except ModuleNotFoundError:  # pragma: no cover - fallback used when topcoffea is absent
+    _HistEFT = None
 
 
 def _build_histogram(values):
-    histogram = HistEFT(axis.Regular(4, 0.0, 4.0, name="observable"), wc_names=[], label="Events")
+    dense_axis = axis.Regular(4, 0.0, 4.0, name="observable")
+    if _HistEFT is not None:
+        histogram = _HistEFT(dense_axis, wc_names=[], label="Events")
+    else:
+        histogram = Hist(dense_axis, storage=storage.Double(), label="Events")
     histogram.fill(observable=np.asarray(values), weight=np.ones(len(values)))
     return histogram
 

--- a/tests/test_mc_validation_plot_utils.py
+++ b/tests/test_mc_validation_plot_utils.py
@@ -1,0 +1,59 @@
+import gzip
+from pathlib import Path
+
+import cloudpickle
+import numpy as np
+from hist import axis
+
+from analysis.mc_validation.plot_utils import (
+    build_dataset_histograms,
+    component_values,
+    tuple_histogram_items,
+)
+from topcoffea.modules.histEFT import HistEFT
+
+
+def _build_histogram(values):
+    histogram = HistEFT(axis.Regular(4, 0.0, 4.0, name="observable"), wc_names=[], label="Events")
+    histogram.fill(observable=np.asarray(values), weight=np.ones(len(values)))
+    return histogram
+
+
+def test_tuple_histograms_roundtrip(tmp_path):
+    central_hist = _build_histogram([0.5, 1.5])
+    private_hist = _build_histogram([0.5, 2.5])
+
+    payload = {
+        ("observable", "inclusive", "inclusive", "ttH_centralUL18", "nominal"): central_hist,
+        ("observable", "3l_onZ_1b", "inclusive", "ttHJet_privateUL18", "nominal"): private_hist,
+    }
+
+    destination = Path(tmp_path) / "tuple_payload.pkl.gz"
+    with gzip.open(destination, "wb") as fout:
+        cloudpickle.dump(payload, fout)
+
+    with gzip.open(destination, "rb") as fin:
+        restored = cloudpickle.load(fin)
+
+    tuple_entries = tuple_histogram_items(restored)
+    assert component_values(tuple_entries, "sample") == [
+        "ttHJet_privateUL18",
+        "ttH_centralUL18",
+    ]
+
+    rebuilt = build_dataset_histograms(restored)
+    assert "observable" in rebuilt
+
+    histogram = rebuilt["observable"]
+    assert list(histogram.axes["dataset"]) == [
+        "ttHJet_privateUL18",
+        "ttH_centralUL18",
+    ]
+    assert list(histogram.axes["channel"]) == [
+        "3l_onZ_1b",
+        "inclusive",
+    ]
+
+    private_entry = histogram[{"dataset": "ttHJet_privateUL18", "channel": "3l_onZ_1b", "systematic": "nominal"}]
+    np.testing.assert_allclose(private_entry.values(), private_hist.values())
+


### PR DESCRIPTION
## Summary
- add utilities to rebuild categorical axes from tuple-keyed histogram payloads
- update the generator and reco MC validation plotters to work with the rebuilt dataset axis
- add a regression test that exercises tuple-keyed pickle loading and label mapping

## Testing
- pytest tests/test_mc_validation_plot_utils.py