### PR TITLE
Wrap plotting helper scripts in main functions

### DIFF
--- a/analysis/topeft_run2/README.md
+++ b/analysis/topeft_run2/README.md
@@ -79,6 +79,8 @@ This directory contains scripts for the Full Run 2 EFT analysis. This README doc
     - Whenever the Run 2 bundle is activated (any of `2016`, `2016APV`, `2017`, `2018`, `UL16`, `UL16APV`, `UL17`, or `UL18` appear in `-y/--year`), the wrapper forwards the matching Run 2 payload to `run_analysis.py` via `--years`. Aliases are resolved so that `UL16` behaves like `2016`, `UL16APV` like `2016APV`, and similarly for `UL17`/`2017` and `UL18`/`2018`.
 * `fullR2_run.sh`: Historical wrapper for the original TOP-22-006 pickle production. Keep it around for archival reproducibility; new workflows should prefer `fullR3_run.sh`.
 
+> **Sourcing helpers:** `run_plotter.sh`, `submit_plotter_condor.sh`, `fullR3_run.sh`, `fullR3_run_diboson.sh`, and `condor_plotter_entry.sh` now funnel their work through a `main()` function. They return non-zero statuses instead of exiting outright when validation fails, so sourcing them in an interactive shell will surface the error without tearing down your session. Executing the scripts directly still exits with the same return codes as before.
+
 
 ### Scripts for finding, comparing and plotting yields from histograms (from the processor)
 
@@ -188,7 +190,7 @@ Prefix the command with `--dry-run` when you want to review the generated job wr
 
 **Entry-script environment steps**
 
-Jobs land in `analysis/topeft_run2/condor_plotter_entry.sh`, which unsets `PYTHONPATH`, honours `TOPEFT_REPO_ROOT`/`TOPEFT_ENTRY_DIR` to pick the checkout and working directory, and activates `clib-env` via either the discovered Conda installation or an explicit `TOPEFT_CONDA_PREFIX`. Override those environment variables in the submit script when you need to point at a different checkout, wrapper directory, or Conda stack, or if you prefer to activate a bespoke environment before calling `run_plotter.sh`.
+Jobs land in `analysis/topeft_run2/condor_plotter_entry.sh`, which unsets `PYTHONPATH`, honours `TOPEFT_REPO_ROOT`/`TOPEFT_ENTRY_DIR` to pick the checkout and working directory, and activates `clib-env` via either the discovered Conda installation or an explicit `TOPEFT_CONDA_PREFIX`. Override those environment variables in the submit script when you need to point at a different checkout, wrapper directory, or Conda stack, or if you prefer to activate a bespoke environment before calling `run_plotter.sh`. The entry script shares the same `main()`-style return handling as the other helpers, so sourcing it during local smoke tests or unit checks surfaces failures without exiting your shell.
 
 **Inspecting jobs and logs**
 

--- a/analysis/topeft_run2/condor_plotter_entry.sh
+++ b/analysis/topeft_run2/condor_plotter_entry.sh
@@ -1,57 +1,73 @@
 #!/usr/bin/env bash
-set -euo pipefail
-
-unset PYTHONPATH
-
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-REPO_ROOT="${TOPEFT_REPO_ROOT:-$(cd "${SCRIPT_DIR}/../.." && pwd)}"
-ENTRY_DIR="${TOPEFT_ENTRY_DIR:-${SCRIPT_DIR}}"
-
-cd "${REPO_ROOT}"
-
-activate_with_conda() {
-    if command -v conda >/dev/null 2>&1; then
-        # shellcheck disable=SC1091
-        eval "$(conda shell.bash hook)"
-        conda activate clib-env
-        return 0
-    fi
-    return 1
-}
-
-activate_with_prefix() {
-    local prefix="$1"
-    local activate_script="${prefix}/bin/activate"
-
-    if [[ -f "${activate_script}" ]]; then
-        # shellcheck disable=SC1091
-        source "${activate_script}"
-        return 0
-    fi
-
-    if [[ -f "${prefix}/etc/profile.d/conda.sh" ]]; then
-        # shellcheck disable=SC1091
-        source "${prefix}/etc/profile.d/conda.sh"
-        conda activate clib-env
-        return 0
-    fi
-
-    return 1
-}
-
-if [[ -n "${TOPEFT_CONDA_PREFIX:-}" ]]; then
-    if ! activate_with_prefix "${TOPEFT_CONDA_PREFIX}"; then
-        echo "[condor_plotter_entry] ERROR: Unable to activate clib-env from TOPEFT_CONDA_PREFIX='${TOPEFT_CONDA_PREFIX}'." >&2
-        exit 1
-    fi
-elif ! activate_with_conda; then
-    DEFAULT_PREFIX="${REPO_ROOT}/clib-env"
-    if ! activate_with_prefix "${DEFAULT_PREFIX}"; then
-        echo "[condor_plotter_entry] ERROR: Unable to activate clib-env; conda not found and neither TOPEFT_CONDA_PREFIX nor '${DEFAULT_PREFIX}' is usable." >&2
-        exit 1
-    fi
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    set -euo pipefail
 fi
 
-cd "${ENTRY_DIR}"
+main() {
+    unset PYTHONPATH
 
-exec ./run_plotter.sh "$@"
+    local SCRIPT_DIR
+    SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+    local REPO_ROOT="${TOPEFT_REPO_ROOT:-$(cd "${SCRIPT_DIR}/../.." && pwd)}"
+    local ENTRY_DIR="${TOPEFT_ENTRY_DIR:-${SCRIPT_DIR}}"
+
+    cd "${REPO_ROOT}"
+
+    activate_with_conda() {
+        if command -v conda >/dev/null 2>&1; then
+            # shellcheck disable=SC1091
+            eval "$(conda shell.bash hook)"
+            conda activate clib-env
+            return 0
+        fi
+        return 1
+    }
+
+    activate_with_prefix() {
+        local prefix="$1"
+        local activate_script="${prefix}/bin/activate"
+
+        if [[ -f "${activate_script}" ]]; then
+            # shellcheck disable=SC1091
+            source "${activate_script}"
+            return 0
+        fi
+
+        if [[ -f "${prefix}/etc/profile.d/conda.sh" ]]; then
+            # shellcheck disable=SC1091
+            source "${prefix}/etc/profile.d/conda.sh"
+            conda activate clib-env
+            return 0
+        fi
+
+        return 1
+    }
+
+    if [[ -n "${TOPEFT_CONDA_PREFIX:-}" ]]; then
+        if ! activate_with_prefix "${TOPEFT_CONDA_PREFIX}"; then
+            echo "[condor_plotter_entry] ERROR: Unable to activate clib-env from TOPEFT_CONDA_PREFIX='${TOPEFT_CONDA_PREFIX}'." >&2
+            return 1
+        fi
+    elif ! activate_with_conda; then
+        local DEFAULT_PREFIX="${REPO_ROOT}/clib-env"
+        if ! activate_with_prefix "${DEFAULT_PREFIX}"; then
+            echo "[condor_plotter_entry] ERROR: Unable to activate clib-env; conda not found and neither TOPEFT_CONDA_PREFIX nor '${DEFAULT_PREFIX}' is usable." >&2
+            return 1
+        fi
+    fi
+
+    cd "${ENTRY_DIR}"
+
+    "${ENTRY_DIR}/run_plotter.sh" "$@"
+}
+
+if main "$@"; then
+    exit_code=0
+else
+    exit_code=$?
+fi
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    exit "${exit_code}"
+else
+    return "${exit_code}"
+fi

--- a/analysis/topeft_run2/fullR3_run.sh
+++ b/analysis/topeft_run2/fullR3_run.sh
@@ -17,243 +17,261 @@ PrintUsage() {
   echo "to run_analysis.py, allowing access to its full set of arguments."
 }
 
-# Early exit when no arguments are provided
-if [[ $# -eq 0 ]]; then
-  PrintUsage
-  exit 0
-fi
+main() {
+  # Early exit when no arguments are provided
+  if [[ $# -eq 0 ]]; then
+    PrintUsage
+    return 0
+  fi
 
-# Default values
-DEFAULT_YEAR="2022"
-DEFAULT_TAG="fec79a60_PNet"
-FLAG_CR=false
-FLAG_SR=false
-EXTRA_ARGS=()
-YEARS=()
-EXPANDED_YEARS=()
-RESOLVED_YEARS=()
-USER_CHUNK_OVERRIDE=false
+  # Default values
+  local DEFAULT_YEAR="2022"
+  local DEFAULT_TAG="fec79a60_PNet"
+  local FLAG_CR=false
+  local FLAG_SR=false
+  local -a EXTRA_ARGS=()
+  local -a YEARS=()
+  local -a EXPANDED_YEARS=()
+  local -a RESOLVED_YEARS=()
+  local USER_CHUNK_OVERRIDE=false
+  local TAG=""
 
-# Parse command-line arguments
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    -y|--year)
-      shift
-      if [[ $# -eq 0 || "$1" == -* ]]; then
-        echo "Error: -y|--year requires at least one argument"
-        exit 1
+  # Parse command-line arguments
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -y|--year)
+        shift
+        if [[ $# -eq 0 || "$1" == -* ]]; then
+          echo "Error: -y|--year requires at least one argument"
+          return 1
+        fi
+        while [[ $# -gt 0 ]]; do
+          case "$1" in
+            -*)
+              break
+              ;;
+            *)
+              YEARS+=("$1")
+              shift
+              ;;
+          esac
+        done
+        ;;
+      -t|--tag)
+        TAG="$2"
+        shift 2
+        ;;
+      --cr)
+        FLAG_CR=true
+        shift
+        ;;
+      --sr)
+        FLAG_SR=true
+        shift
+        ;;
+      -h|--help)
+        PrintUsage
+        return 0
+        ;;
+      *)
+        EXTRA_ARGS+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  # Detect if a user-specified chunk size was provided
+  local ARG
+  for ARG in "${EXTRA_ARGS[@]}"; do
+    case "$ARG" in
+      -s|--chunksize|--chunksize=*)
+        USER_CHUNK_OVERRIDE=true
+        break
+        ;;
+    esac
+  done
+
+  # Ensure exactly one mode is chosen
+  if [[ "$FLAG_CR" == "false" && "$FLAG_SR" == "false" ]] || [[ "$FLAG_CR" == "true" && "$FLAG_SR" == "true" ]]; then
+    echo "Error: You must specify exactly one of --cr or --sr."
+    echo
+    PrintUsage
+    return 1
+  fi
+
+  # Apply defaults with warnings if not provided
+  if [[ ${#YEARS[@]} -eq 0 ]]; then
+    echo "Warning: YEAR not provided, using default YEAR=$DEFAULT_YEAR"
+    YEARS=("$DEFAULT_YEAR")
+  fi
+
+  local YEAR
+  for YEAR in "${YEARS[@]}"; do
+    case "${YEAR,,}" in
+      run2)
+        EXPANDED_YEARS+=(UL16 UL16APV UL17 UL18)
+        ;;
+      run3)
+        EXPANDED_YEARS+=(2022 2022EE 2023 2023BPix)
+        ;;
+      *)
+        EXPANDED_YEARS+=("$YEAR")
+        ;;
+    esac
+  done
+
+  declare -A YEAR_SEEN=()
+  for YEAR in "${EXPANDED_YEARS[@]}"; do
+    if [[ -z "${YEAR_SEEN[$YEAR]}" ]]; then
+      RESOLVED_YEARS+=("$YEAR")
+      YEAR_SEEN[$YEAR]=1
+    fi
+  done
+
+  if [[ ${#RESOLVED_YEARS[@]} -eq 0 ]]; then
+    echo "Error: No years resolved from the provided arguments." >&2
+    return 1
+  fi
+
+  if [[ -z "$TAG" ]]; then
+    echo "Warning: TAG not provided, using default TAG=$DEFAULT_TAG"
+    TAG="$DEFAULT_TAG"
+  fi
+
+  # Define output name based on mode
+  local YEAR_LABEL
+  YEAR_LABEL=$(IFS=-; echo "${RESOLVED_YEARS[*]}")
+
+  local OUT_NAME
+  if [[ "$FLAG_CR" == "true" ]]; then
+    OUT_NAME="${YEAR_LABEL}CRs_${TAG}"
+  else
+    OUT_NAME="${YEAR_LABEL}SRs_${TAG}"
+  fi
+
+  echo "OUT_NAME: $OUT_NAME"
+
+  # Build the configuration file list
+  local CFGS_PATH="../../input_samples/cfgs"
+  local -a CFGS_LIST=()
+
+  declare -A RUN2_YEAR_MAP=(
+    [2016]=2016
+    [UL16]=2016
+    [2016APV]=2016APV
+    [UL16APV]=2016APV
+    [2017]=2017
+    [UL17]=2017
+    [2018]=2018
+    [UL18]=2018
+  )
+
+  local RUN2_CFGS_SR=(
+    "${CFGS_PATH}/mc_signal_samples_NDSkim.cfg"
+    "${CFGS_PATH}/mc_background_samples_NDSkim.cfg"
+    "${CFGS_PATH}/data_samples_NDSkim.cfg"
+  )
+
+  local RUN2_CFGS_CR=(
+    "${CFGS_PATH}/mc_signal_samples_NDSkim.cfg"
+    "${CFGS_PATH}/mc_background_samples_NDSkim.cfg"
+    "${CFGS_PATH}/mc_background_samples_cr_NDSkim.cfg"
+    "${CFGS_PATH}/data_samples_NDSkim.cfg"
+  )
+
+  declare -A SEEN_CFGS=()
+  local RUN2_BUNDLE_ADDED=false
+
+  add_cfg() {
+    local cfg_file="$1"
+    if [[ ! -f "$cfg_file" ]]; then
+      echo "Error: Required cfg file not found: $cfg_file" >&2
+      return 1
+    fi
+    if [[ -n "${SEEN_CFGS[$cfg_file]}" ]]; then
+      return 0
+    fi
+    CFGS_LIST+=("$cfg_file")
+    SEEN_CFGS[$cfg_file]=1
+    return 0
+  }
+
+  local CFG YEAR_CFGS
+  for YEAR in "${RESOLVED_YEARS[@]}"; do
+    if [[ -n "${RUN2_YEAR_MAP[$YEAR]}" ]]; then
+      if [[ "$RUN2_BUNDLE_ADDED" == "false" ]]; then
+        if [[ "$FLAG_CR" == "true" ]]; then
+          for CFG in "${RUN2_CFGS_CR[@]}"; do
+            add_cfg "$CFG" || return 1
+          done
+        else
+          for CFG in "${RUN2_CFGS_SR[@]}"; do
+            add_cfg "$CFG" || return 1
+          done
+        fi
+        RUN2_BUNDLE_ADDED=true
       fi
-      while [[ $# -gt 0 ]]; do
-        case "$1" in
-          -*)
-            break
-            ;;
-          *)
-            YEARS+=("$1")
-            shift
-            ;;
-        esac
+    else
+      YEAR_CFGS=(
+        "${CFGS_PATH}/NDSkim_${YEAR}_signal_samples.cfg"
+        "${CFGS_PATH}/NDSkim_${YEAR}_background_samples.cfg"
+        "${CFGS_PATH}/NDSkim_${YEAR}_data_samples.cfg"
+      )
+
+      for CFG in "${YEAR_CFGS[@]}"; do
+        add_cfg "$CFG" || return 1
       done
-      ;;
-    -t|--tag)
-      TAG="$2"
-      shift 2
-      ;;
-    --cr)
-      FLAG_CR=true
-      shift
-      ;;
-    --sr)
-      FLAG_SR=true
-      shift
-      ;;
-    -h|--help)
-      PrintUsage
-      exit 0
-      ;;
-    *)
-      EXTRA_ARGS+=("$1")
-      shift
-      ;;
-  esac
-done
+    fi
+  done
+  local CFGS
+  CFGS=$(IFS=,; echo "${CFGS_LIST[*]}")
 
-# Detect if a user-specified chunk size was provided
-for ARG in "${EXTRA_ARGS[@]}"; do
-  case "$ARG" in
-    -s|--chunksize|--chunksize=*)
-      USER_CHUNK_OVERRIDE=true
-      break
-      ;;
-  esac
-done
+  echo "Resolved years: ${RESOLVED_YEARS[*]}"
+  echo "Resolved CFGS: $CFGS"
 
-# Ensure exactly one mode is chosen
-if [[ "$FLAG_CR" == "false" && "$FLAG_SR" == "false" ]] || [[ "$FLAG_CR" == "true" && "$FLAG_SR" == "true" ]]; then
-  echo "Error: You must specify exactly one of --cr or --sr."
-  echo
-  PrintUsage
-  exit 1
-fi
-
-# Apply defaults with warnings if not provided
-if [[ ${#YEARS[@]} -eq 0 ]]; then
-  echo "Warning: YEAR not provided, using default YEAR=$DEFAULT_YEAR"
-  YEARS=("$DEFAULT_YEAR")
-fi
-
-for YEAR in "${YEARS[@]}"; do
-  case "${YEAR,,}" in
-    run2)
-      EXPANDED_YEARS+=(UL16 UL16APV UL17 UL18)
-      ;;
-    run3)
-      EXPANDED_YEARS+=(2022 2022EE 2023 2023BPix)
-      ;;
-    *)
-      EXPANDED_YEARS+=("$YEAR")
-      ;;
-  esac
-done
-
-declare -A YEAR_SEEN=()
-for YEAR in "${EXPANDED_YEARS[@]}"; do
-  if [[ -z "${YEAR_SEEN[$YEAR]}" ]]; then
-    RESOLVED_YEARS+=("$YEAR")
-    YEAR_SEEN[$YEAR]=1
+  # Define options based on mode
+  local -a OPTIONS
+  if [[ "$FLAG_CR" == "true" ]]; then
+    OPTIONS=(
+      --hist-list cr
+      --skip-sr
+    )
+    if [[ "$USER_CHUNK_OVERRIDE" == "false" ]]; then
+      OPTIONS+=(-s 50000)
+    fi
+    OPTIONS+=(
+      #--split-lep-flavor
+      -p "/scratch365/$USER/"
+      -o "$OUT_NAME"
+      -x work_queue
+    )
+  else
+    OPTIONS=(
+      --hist-list ana
+      --skip-cr
+      --do-systs
+    )
+    if [[ "$USER_CHUNK_OVERRIDE" == "false" ]]; then
+      OPTIONS+=(-s 50000)
+    fi
+    OPTIONS+=(-o "$OUT_NAME")
   fi
-done
 
-if [[ ${#RESOLVED_YEARS[@]} -eq 0 ]]; then
-  echo "Error: No years resolved from the provided arguments." >&2
-  exit 1
-fi
+  # Build and run the command
+  local -a RUN_CMD=(python run_analysis.py "$CFGS")
+  RUN_CMD+=(--years "${RESOLVED_YEARS[@]}")
+  RUN_CMD+=("${OPTIONS[@]}")
+  RUN_CMD+=("${EXTRA_ARGS[@]}")
 
-if [[ -z "$TAG" ]]; then
-  echo "Warning: TAG not provided, using default TAG=$DEFAULT_TAG"
-  TAG="$DEFAULT_TAG"
-fi
+  printf "\nRunning the following command:\n%s\n\n" "${RUN_CMD[*]}"
 
-# Define output name based on mode
-YEAR_LABEL=$(IFS=-; echo "${RESOLVED_YEARS[*]}")
-
-if [[ "$FLAG_CR" == "true" ]]; then
-  OUT_NAME="${YEAR_LABEL}CRs_${TAG}"
-else
-  OUT_NAME="${YEAR_LABEL}SRs_${TAG}"
-fi
-
-echo "OUT_NAME: $OUT_NAME"
-
-# Build the configuration file list
-CFGS_PATH="../../input_samples/cfgs"
-CFGS_LIST=()
-
-declare -A RUN2_YEAR_MAP=(
-  [2016]=2016
-  [UL16]=2016
-  [2016APV]=2016APV
-  [UL16APV]=2016APV
-  [2017]=2017
-  [UL17]=2017
-  [2018]=2018
-  [UL18]=2018
-)
-
-RUN2_CFGS_SR=(
-  "${CFGS_PATH}/mc_signal_samples_NDSkim.cfg"
-  "${CFGS_PATH}/mc_background_samples_NDSkim.cfg"
-  "${CFGS_PATH}/data_samples_NDSkim.cfg"
-)
-
-RUN2_CFGS_CR=(
-  "${CFGS_PATH}/mc_signal_samples_NDSkim.cfg"
-  "${CFGS_PATH}/mc_background_samples_NDSkim.cfg"
-  "${CFGS_PATH}/mc_background_samples_cr_NDSkim.cfg"
-  "${CFGS_PATH}/data_samples_NDSkim.cfg"
-)
-
-declare -A SEEN_CFGS=()
-RUN2_BUNDLE_ADDED=false
-
-add_cfg() {
-  local cfg_file="$1"
-  if [[ ! -f "$cfg_file" ]]; then
-    echo "Error: Required cfg file not found: $cfg_file" >&2
-    exit 1
-  fi
-  if [[ -n "${SEEN_CFGS[$cfg_file]}" ]]; then
-    return
-  fi
-  CFGS_LIST+=("$cfg_file")
-  SEEN_CFGS[$cfg_file]=1
+  time "${RUN_CMD[@]}"
 }
 
-for YEAR in "${RESOLVED_YEARS[@]}"; do
-  if [[ -n "${RUN2_YEAR_MAP[$YEAR]}" ]]; then
-    if [[ "$RUN2_BUNDLE_ADDED" == "false" ]]; then
-      if [[ "$FLAG_CR" == "true" ]]; then
-        for CFG in "${RUN2_CFGS_CR[@]}"; do
-          add_cfg "$CFG"
-        done
-      else
-        for CFG in "${RUN2_CFGS_SR[@]}"; do
-          add_cfg "$CFG"
-        done
-      fi
-      RUN2_BUNDLE_ADDED=true
-    fi
-  else
-    YEAR_CFGS=(
-      "${CFGS_PATH}/NDSkim_${YEAR}_signal_samples.cfg"
-      "${CFGS_PATH}/NDSkim_${YEAR}_background_samples.cfg"
-      "${CFGS_PATH}/NDSkim_${YEAR}_data_samples.cfg"
-    )
-
-    for CFG in "${YEAR_CFGS[@]}"; do
-      add_cfg "$CFG"
-    done
-  fi
-
-done
-CFGS=$(IFS=,; echo "${CFGS_LIST[*]}")
-
-echo "Resolved years: ${RESOLVED_YEARS[*]}"
-echo "Resolved CFGS: $CFGS"
-
-# Define options based on mode
-if [[ "$FLAG_CR" == "true" ]]; then
-  OPTIONS=(
-    --hist-list cr
-    --skip-sr
-  )
-  if [[ "$USER_CHUNK_OVERRIDE" == "false" ]]; then
-    OPTIONS+=(-s 50000)
-  fi
-  OPTIONS+=(
-    #--split-lep-flavor
-    -p "/scratch365/$USER/"
-    -o "$OUT_NAME"
-    -x work_queue
-  )
+main "$@"
+exit_code=$?
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  exit "${exit_code}"
 else
-  OPTIONS=(
-    --hist-list ana
-    --skip-cr
-    --do-systs
-  )
-  if [[ "$USER_CHUNK_OVERRIDE" == "false" ]]; then
-    OPTIONS+=(-s 50000)
-  fi
-  OPTIONS+=(-o "$OUT_NAME")
+  return "${exit_code}"
 fi
-
-# Build and run the command
-RUN_CMD=(python run_analysis.py "$CFGS")
-RUN_CMD+=(--years "${RESOLVED_YEARS[@]}")
-RUN_CMD+=("${OPTIONS[@]}")
-RUN_CMD+=("${EXTRA_ARGS[@]}")
-
-printf "\nRunning the following command:\n%s\n\n" "${RUN_CMD[*]}"
-
-time "${RUN_CMD[@]}"

--- a/analysis/topeft_run2/fullR3_run_diboson.sh
+++ b/analysis/topeft_run2/fullR3_run_diboson.sh
@@ -17,101 +17,115 @@ PrintUsage() {
   echo "to run_analysis.py, allowing access to its full set of arguments."
 }
 
-# Default values
-DEFAULT_YEAR="2022"
-DEFAULT_TAG="fec79a60_PNet"
-DEFAULT_CHUNKSIZE=100000
-DEFAULT_NCHUNKS=""
-FLAG_CR=false
-FLAG_SR=false
-CHUNKSIZE="$DEFAULT_CHUNKSIZE"
-NCHUNKS="$DEFAULT_NCHUNKS"
-EXTRA_ARGS=()
+main() {
+  # Default values
+  local DEFAULT_YEAR="2022"
+  local DEFAULT_TAG="fec79a60_PNet"
+  local DEFAULT_CHUNKSIZE=100000
+  local DEFAULT_NCHUNKS=""
+  local FLAG_CR=false
+  local FLAG_SR=false
+  local CHUNKSIZE="$DEFAULT_CHUNKSIZE"
+  local NCHUNKS="$DEFAULT_NCHUNKS"
+  local YEAR=""
+  local TAG=""
+  local -a EXTRA_ARGS=()
 
-# Parse command-line arguments
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    -y)
-      YEAR="$2"
-      shift 2
-      ;;
-    -t)
-      TAG="$2"
-      shift 2
-      ;;
-    --cr)
-      FLAG_CR=true
-      shift
-      ;;
-    --sr)
-      FLAG_SR=true
-      shift
-      ;;
-    -s)
-      CHUNKSIZE="$2"
-      shift 2
-      ;;
-    -c)
-      NCHUNKS="$2"
-      shift 2
-      ;;
-    -h|--help)
-      PrintUsage
-      exit 0
-      ;;
-    *)
-      EXTRA_ARGS+=("$1")
-      shift
-      ;;
-  esac
-done
+  # Parse command-line arguments
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -y)
+        YEAR="$2"
+        shift 2
+        ;;
+      -t)
+        TAG="$2"
+        shift 2
+        ;;
+      --cr)
+        FLAG_CR=true
+        shift
+        ;;
+      --sr)
+        FLAG_SR=true
+        shift
+        ;;
+      -s)
+        CHUNKSIZE="$2"
+        shift 2
+        ;;
+      -c)
+        NCHUNKS="$2"
+        shift 2
+        ;;
+      -h|--help)
+        PrintUsage
+        return 0
+        ;;
+      *)
+        EXTRA_ARGS+=("$1")
+        shift
+        ;;
+    esac
+  done
 
-# Ensure exactly one mode is chosen
-if [[ "$FLAG_CR" == "false" && "$FLAG_SR" == "false" ]] || [[ "$FLAG_CR" == "true" && "$FLAG_SR" == "true" ]]; then
-  echo "Error: You must specify exactly one of --cr or --sr."
-  echo
-  PrintUsage
-  exit 1
-fi
+  # Ensure exactly one mode is chosen
+  if [[ "$FLAG_CR" == "false" && "$FLAG_SR" == "false" ]] || [[ "$FLAG_CR" == "true" && "$FLAG_SR" == "true" ]]; then
+    echo "Error: You must specify exactly one of --cr or --sr."
+    echo
+    PrintUsage
+    return 1
+  fi
 
-# Apply defaults with warnings if not provided
-if [[ -z "$YEAR" ]]; then
-  echo "Warning: YEAR not provided, using default YEAR=$DEFAULT_YEAR"
-  YEAR="$DEFAULT_YEAR"
-fi
+  # Apply defaults with warnings if not provided
+  if [[ -z "$YEAR" ]]; then
+    echo "Warning: YEAR not provided, using default YEAR=$DEFAULT_YEAR"
+    YEAR="$DEFAULT_YEAR"
+  fi
 
-if [[ -z "$TAG" ]]; then
-  echo "Warning: TAG not provided, using default TAG=$DEFAULT_TAG"
-  TAG="$DEFAULT_TAG"
-fi
+  if [[ -z "$TAG" ]]; then
+    echo "Warning: TAG not provided, using default TAG=$DEFAULT_TAG"
+    TAG="$DEFAULT_TAG"
+  fi
 
-# Define output name based on mode
-if [[ "$FLAG_CR" == "true" ]]; then
-  OUT_NAME="${YEAR}CRs_${TAG}"
+  # Define output name based on mode
+  local OUT_NAME
+  if [[ "$FLAG_CR" == "true" ]]; then
+    OUT_NAME="${YEAR}CRs_${TAG}"
+  else
+    OUT_NAME="${YEAR}SRs_${TAG}"
+  fi
+
+  echo "OUT_NAME: $OUT_NAME"
+
+  # Build the configuration file list
+  local CFGS_PATH="../../input_samples/cfgs"
+  local CFGS="${CFGS_PATH}/NDSkim_${YEAR}_background_samples.cfg,${CFGS_PATH}/NDSkim_${YEAR}_data_samples.cfg,${CFGS_PATH}/NDSkim_${YEAR}_signal_samples.cfg"
+
+  # Define options based on mode
+  local OPTIONS
+  if [[ "$FLAG_CR" == "true" ]]; then
+    OPTIONS="--hist-list cr --skip-sr -p /scratch365/$USER/ -o $OUT_NAME -x work_queue --do-np"
+  else
+    OPTIONS="--hist-list ana --skip-cr --do-systs --do-np -o $OUT_NAME"
+  fi
+
+  # Build and run the command
+  local -a RUN_CMD=(python run_analysis_diboson.py $CFGS $OPTIONS -s "$CHUNKSIZE")
+  if [[ -n "$NCHUNKS" ]]; then
+    RUN_CMD+=(-c "$NCHUNKS")
+  fi
+  RUN_CMD+=("${EXTRA_ARGS[@]}")
+
+  printf "\nRunning the following command:\n%s\n\n" "${RUN_CMD[*]}"
+
+  time "${RUN_CMD[@]}"
+}
+
+main "$@"
+exit_code=$?
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  exit "${exit_code}"
 else
-  OUT_NAME="${YEAR}SRs_${TAG}"
+  return "${exit_code}"
 fi
-
-echo "OUT_NAME: $OUT_NAME"
-
-# Build the configuration file list
-CFGS_PATH="../../input_samples/cfgs"
-CFGS="${CFGS_PATH}/NDSkim_${YEAR}_background_samples.cfg,${CFGS_PATH}/NDSkim_${YEAR}_data_samples.cfg,${CFGS_PATH}/NDSkim_${YEAR}_signal_samples.cfg"
-
-# Define options based on mode
-if [[ "$FLAG_CR" == "true" ]]; then
-  OPTIONS="--hist-list cr --skip-sr -p /scratch365/$USER/ -o $OUT_NAME -x work_queue --do-np"
-else
-  OPTIONS="--hist-list ana --skip-cr --do-systs --do-np -o $OUT_NAME"
-fi
-
-# Build and run the command
-RUN_CMD=(python run_analysis_diboson.py $CFGS $OPTIONS -s "$CHUNKSIZE")
-if [[ -n "$NCHUNKS" ]]; then
-  RUN_CMD+=(-c "$NCHUNKS")
-fi
-RUN_CMD+=("${EXTRA_ARGS[@]}")
-
-printf "\nRunning the following command:\n%s\n\n" "${RUN_CMD[*]}"
-
-time "${RUN_CMD[@]}"

--- a/analysis/topeft_run2/run_plotter.sh
+++ b/analysis/topeft_run2/run_plotter.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-set -euo pipefail
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    set -euo pipefail
+fi
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 PLOTTER_SCRIPT="${SCRIPT_DIR}/make_cr_and_sr_plots.py"
@@ -44,27 +46,6 @@ historical "--" delimiter is no longer necessary; any leftover tokens are passed
 through automatically.
 USAGE
 }
-
-if [[ ! -f "${PLOTTER_SCRIPT}" ]]; then
-    echo "Error: unable to locate make_cr_and_sr_plots.py next to this wrapper." >&2
-    exit 1
-fi
-
-input_path=""
-output_dir=""
-output_name=""
-declare -a years=()
-timestamp_tag=0
-skip_syst=0
-unit_norm=0
-log_y=0
-region_override=""
-blind_override=""
-declare -a variables=()
-workers=1
-dry_run=0
-verbosity=""
-channel_output=""
 
 trim_whitespace() {
     local value="$1"
@@ -125,15 +106,37 @@ normalize_year_tokens() {
     printf '%s\n' "${normalized[@]}"
 }
 
-# Collect passthrough arguments for make_cr_and_sr_plots.py.
-extra_args=()
+main() {
+    if [[ ! -f "${PLOTTER_SCRIPT}" ]]; then
+        echo "Error: unable to locate make_cr_and_sr_plots.py next to this wrapper." >&2
+        return 1
+    fi
 
-while [[ $# -gt 0 ]]; do
-    case "$1" in
+    local input_path=""
+    local output_dir=""
+    local output_name=""
+    local -a years=()
+    local timestamp_tag=0
+    local skip_syst=0
+    local unit_norm=0
+    local log_y=0
+    local region_override=""
+    local blind_override=""
+    local -a variables=()
+    local workers=1
+    local dry_run=0
+    local verbosity=""
+    local channel_output=""
+
+    # Collect passthrough arguments for make_cr_and_sr_plots.py.
+    local -a extra_args=()
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
         -f|--input)
             if [[ $# -lt 2 ]]; then
                 echo "Error: Missing value for $1" >&2
-                exit 1
+                return 1
             fi
             input_path="$2"
             shift 2
@@ -141,7 +144,7 @@ while [[ $# -gt 0 ]]; do
         -o|--output-dir)
             if [[ $# -lt 2 ]]; then
                 echo "Error: Missing value for $1" >&2
-                exit 1
+                return 1
             fi
             output_dir="$2"
             shift 2
@@ -149,7 +152,7 @@ while [[ $# -gt 0 ]]; do
         -n|--name)
             if [[ $# -lt 2 ]]; then
                 echo "Error: Missing value for $1" >&2
-                exit 1
+                return 1
             fi
             output_name="$2"
             shift 2
@@ -158,7 +161,7 @@ while [[ $# -gt 0 ]]; do
             shift
             if [[ $# -eq 0 ]]; then
                 echo "Error: Missing value for -y/--year" >&2
-                exit 1
+                return 1
             fi
             added_year=0
             while [[ $# -gt 0 ]]; do
@@ -181,7 +184,7 @@ while [[ $# -gt 0 ]]; do
             done
             if [[ ${added_year} -eq 0 ]]; then
                 echo "Error: -y/--year requires at least one year token" >&2
-                exit 1
+                return 1
             fi
             ;;
         -t|--timestamp)
@@ -220,7 +223,7 @@ while [[ $# -gt 0 ]]; do
             shift
             if [[ $# -eq 0 ]]; then
                 echo "Error: --variables requires at least one argument" >&2
-                exit 1
+                return 1
             fi
             while [[ $# -gt 0 ]]; do
                 case "$1" in
@@ -240,7 +243,7 @@ while [[ $# -gt 0 ]]; do
         --workers)
             if [[ $# -lt 2 ]]; then
                 echo "Error: Missing value for --workers" >&2
-                exit 1
+                return 1
             fi
             workers="$2"
             shift 2
@@ -248,7 +251,7 @@ while [[ $# -gt 0 ]]; do
         --channel-output)
             if [[ $# -lt 2 ]]; then
                 echo "Error: Missing value for --channel-output" >&2
-                exit 1
+                return 1
             fi
             channel_output="${2,,}"
             case "${channel_output}" in
@@ -256,7 +259,7 @@ while [[ $# -gt 0 ]]; do
                     ;;
                 *)
                     echo "Error: --channel-output expects one of: merged, split, both" >&2
-                    exit 1
+                    return 1
                     ;;
             esac
             shift 2
@@ -275,7 +278,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         -h|--help)
             show_help
-            exit 0
+            return 0
             ;;
         *)
             if [[ "$1" == "--" ]]; then
@@ -288,34 +291,34 @@ while [[ $# -gt 0 ]]; do
             extra_args+=("$1")
             shift
             ;;
-    esac
-done
+        esac
+    done
 
-if (( ${#years[@]} > 0 )); then
-    mapfile -t years < <(normalize_year_tokens "${years[@]}")
-fi
-
-if (( ${#years[@]} == 0 )); then
-    echo "Error: At least one year must be provided with -y/--year." >&2
-    exit 1
-fi
-
-if [[ -z "${input_path}" ]]; then
-    echo "Error: An input pickle must be provided with -f/--input." >&2
-    exit 1
-fi
-
-if [[ -z "${output_dir}" ]]; then
-    echo "Error: An output directory must be provided with -o/--output-dir." >&2
-    exit 1
-fi
-
-detect_region() {
-    local path="$1"
-    if [[ -z "${path}" ]]; then
-        printf '\n0\n'
-        return
+    if (( ${#years[@]} > 0 )); then
+        mapfile -t years < <(normalize_year_tokens "${years[@]}")
     fi
+
+    if (( ${#years[@]} == 0 )); then
+        echo "Error: At least one year must be provided with -y/--year." >&2
+        return 1
+    fi
+
+    if [[ -z "${input_path}" ]]; then
+        echo "Error: An input pickle must be provided with -f/--input." >&2
+        return 1
+    fi
+
+    if [[ -z "${output_dir}" ]]; then
+        echo "Error: An output directory must be provided with -o/--output-dir." >&2
+        return 1
+    fi
+
+    detect_region() {
+        local path="$1"
+        if [[ -z "${path}" ]]; then
+            printf '\n0\n'
+            return
+        fi
     local filename
     filename=$(basename -- "$path")
     local uppercase="${filename^^}"
@@ -342,143 +345,157 @@ detect_region() {
     else
         printf '\n0\n'
     fi
+    }
+
+    IFS=$'\n' read -r detected_region detection_ambiguous < <(detect_region "${input_path}")
+
+    local resolved_region="${region_override}"
+    if [[ -n "${resolved_region}" ]]; then
+        echo "Region override requested: ${resolved_region}"
+    else
+        if [[ -n "${detected_region}" ]]; then
+            echo "Auto-detected region '${detected_region}' from input filename."
+            resolved_region="${detected_region}"
+        else
+            echo "No region token detected in input filename; defaulting to 'CR'."
+            resolved_region="CR"
+        fi
+        if [[ "${detection_ambiguous}" == "1" && -z "${region_override}" ]]; then
+            echo "Warning: Detected both 'CR' and 'SR' tokens in the input filename. Defaulting to 'CR'." >&2
+            resolved_region="CR"
+        fi
+    fi
+
+    declare -r resolved_region
+
+    local resolved_unblind=0
+    local blinding_source=""
+    case "${blind_override}" in
+        blind)
+            resolved_unblind=0
+            blinding_source="command-line --blind override"
+            ;;
+        unblind)
+            resolved_unblind=1
+            blinding_source="command-line --unblind override"
+            ;;
+        "")
+            if [[ "${resolved_region}" == "CR" ]]; then
+                resolved_unblind=1
+                blinding_source="default for CR region"
+            else
+                resolved_unblind=0
+                blinding_source="default for SR region"
+            fi
+            ;;
+    esac
+
+    echo "Resolved plotting region: ${resolved_region}"
+    if [[ ${resolved_unblind} -eq 1 ]]; then
+        echo "Resolved blinding mode: unblinded (${blinding_source})"
+    else
+        echo "Resolved blinding mode: blinded (${blinding_source})"
+    fi
+
+    if (( ${#years[@]} > 0 )); then
+        echo "Selected years: ${years[*]}"
+    fi
+
+    if (( ${#variables[@]} > 0 )); then
+        echo "Selected variables: ${variables[*]}"
+    fi
+    if [[ -n "${channel_output}" ]]; then
+        echo "Channel output selection: ${channel_output}"
+    fi
+
+    if (( log_y )); then
+        echo "Stacked panel will use a logarithmic y-axis."
+    fi
+
+    if [[ -n "${workers}" && "${workers}" != "1" ]]; then
+        echo "Worker processes: ${workers}"
+    fi
+
+    case "${verbosity}" in
+        verbose)
+            echo "Verbose diagnostics enabled."
+            ;;
+        quiet)
+            echo "Quiet mode enforced."
+            ;;
+    esac
+
+    mkdir -p "${output_dir}"
+
+    local -a cmd=("${PYTHON_BIN}" "${PLOTTER_SCRIPT}" "-f" "${input_path}" "-o" "${output_dir}")
+
+    if [[ -n "${output_name}" ]]; then
+        cmd+=("-n" "${output_name}")
+    fi
+    if (( ${#years[@]} > 0 )); then
+        cmd+=("-y")
+        cmd+=("${years[@]}")
+    fi
+    if (( timestamp_tag )); then
+        cmd+=("-t")
+    fi
+    if (( skip_syst )); then
+        cmd+=("-s")
+    fi
+    if (( unit_norm )); then
+        cmd+=("-u")
+    fi
+    if (( log_y )); then
+        cmd+=("--log-y")
+    fi
+    if [[ "${resolved_region}" == "CR" ]]; then
+        cmd+=("--cr")
+    else
+        cmd+=("--sr")
+    fi
+    if (( resolved_unblind )); then
+        cmd+=("--unblind")
+    else
+        cmd+=("--blind")
+    fi
+    if (( ${#variables[@]} > 0 )); then
+        cmd+=("--variables")
+        cmd+=("${variables[@]}")
+    fi
+    cmd+=("--workers" "${workers}")
+    if [[ -n "${channel_output}" ]]; then
+        cmd+=("--channel-output" "${channel_output}")
+    fi
+    case "${verbosity}" in
+        verbose)
+            cmd+=("--verbose")
+            ;;
+        quiet)
+            cmd+=("--quiet")
+            ;;
+    esac
+    cmd+=("${extra_args[@]}")
+
+    echo "Executing make_cr_and_sr_plots.py with command:"
+    printf '  %q' "${cmd[@]}"
+    echo
+
+    if (( dry_run )); then
+        echo "Dry-run requested; skipping execution."
+    else
+        "${cmd[0]}" "${cmd[@]:1}"
+    fi
+
+    return 0
 }
 
-IFS=$'\n' read -r detected_region detection_ambiguous < <(detect_region "${input_path}")
-
-resolved_region="${region_override}"
-if [[ -n "${resolved_region}" ]]; then
-    echo "Region override requested: ${resolved_region}"
+if main "$@"; then
+    exit_code=0
 else
-    if [[ -n "${detected_region}" ]]; then
-        echo "Auto-detected region '${detected_region}' from input filename."
-        resolved_region="${detected_region}"
-    else
-        echo "No region token detected in input filename; defaulting to 'CR'."
-        resolved_region="CR"
-    fi
-    if [[ "${detection_ambiguous}" == "1" && -z "${region_override}" ]]; then
-        echo "Warning: Detected both 'CR' and 'SR' tokens in the input filename. Defaulting to 'CR'." >&2
-        resolved_region="CR"
-    fi
+    exit_code=$?
 fi
-
-declare -r resolved_region
-
-resolved_unblind=0
-blinding_source=""
-case "${blind_override}" in
-    blind)
-        resolved_unblind=0
-        blinding_source="command-line --blind override"
-        ;;
-    unblind)
-        resolved_unblind=1
-        blinding_source="command-line --unblind override"
-        ;;
-    "")
-        if [[ "${resolved_region}" == "CR" ]]; then
-            resolved_unblind=1
-            blinding_source="default for CR region"
-        else
-            resolved_unblind=0
-            blinding_source="default for SR region"
-        fi
-        ;;
-esac
-
-echo "Resolved plotting region: ${resolved_region}"
-if [[ ${resolved_unblind} -eq 1 ]]; then
-    echo "Resolved blinding mode: unblinded (${blinding_source})"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    exit "${exit_code}"
 else
-    echo "Resolved blinding mode: blinded (${blinding_source})"
-fi
-
-if (( ${#years[@]} > 0 )); then
-    echo "Selected years: ${years[*]}"
-fi
-
-if (( ${#variables[@]} > 0 )); then
-    echo "Selected variables: ${variables[*]}"
-fi
-if [[ -n "${channel_output}" ]]; then
-    echo "Channel output selection: ${channel_output}"
-fi
-
-if (( log_y )); then
-    echo "Stacked panel will use a logarithmic y-axis."
-fi
-
-if [[ -n "${workers}" && "${workers}" != "1" ]]; then
-    echo "Worker processes: ${workers}"
-fi
-
-case "${verbosity}" in
-    verbose)
-        echo "Verbose diagnostics enabled."
-        ;;
-    quiet)
-        echo "Quiet mode enforced."
-        ;;
-esac
-
-mkdir -p "${output_dir}"
-
-cmd=("${PYTHON_BIN}" "${PLOTTER_SCRIPT}" "-f" "${input_path}" "-o" "${output_dir}")
-
-if [[ -n "${output_name}" ]]; then
-    cmd+=("-n" "${output_name}")
-fi
-if (( ${#years[@]} > 0 )); then
-    cmd+=("-y")
-    cmd+=("${years[@]}")
-fi
-if (( timestamp_tag )); then
-    cmd+=("-t")
-fi
-if (( skip_syst )); then
-    cmd+=("-s")
-fi
-if (( unit_norm )); then
-    cmd+=("-u")
-fi
-if (( log_y )); then
-    cmd+=("--log-y")
-fi
-if [[ "${resolved_region}" == "CR" ]]; then
-    cmd+=("--cr")
-else
-    cmd+=("--sr")
-fi
-if (( resolved_unblind )); then
-    cmd+=("--unblind")
-else
-    cmd+=("--blind")
-fi
-if (( ${#variables[@]} > 0 )); then
-    cmd+=("--variables")
-    cmd+=("${variables[@]}")
-fi
-cmd+=("--workers" "${workers}")
-if [[ -n "${channel_output}" ]]; then
-    cmd+=("--channel-output" "${channel_output}")
-fi
-case "${verbosity}" in
-    verbose)
-        cmd+=("--verbose")
-        ;;
-    quiet)
-        cmd+=("--quiet")
-        ;;
-esac
-cmd+=("${extra_args[@]}")
-
-echo "Executing make_cr_and_sr_plots.py with command:"
-printf '  %q' "${cmd[@]}"
-echo
-
-if (( dry_run )); then
-    echo "Dry-run requested; skipping execution."
-else
-    "${cmd[0]}" "${cmd[@]:1}"
+    return "${exit_code}"
 fi

--- a/analysis/topeft_run2/submit_plotter_condor.sh
+++ b/analysis/topeft_run2/submit_plotter_condor.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-set -euo pipefail
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    set -euo pipefail
+fi
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 RUN_PLOTTER="${SCRIPT_DIR}/run_plotter.sh"
@@ -36,222 +38,228 @@ delimiter is optional; extra flags are forwarded automatically when present.
 USAGE
 }
 
-if [[ ! -x "${RUN_PLOTTER}" ]]; then
-    echo "Error: run_plotter.sh not found next to this helper." >&2
-    exit 1
-fi
-
-if [[ ! -x "${ENTRY_SCRIPT}" ]]; then
-    echo "Error: condor_plotter_entry.sh not found next to this helper." >&2
-    exit 1
-fi
-
-queue_count=1
-log_dir=""
-ceph_root="${DEFAULT_CEPH_ROOT}"
-conda_prefix=""
-dry_run=0
-request_cpus=""
-request_memory=""
-plotter_args=()
-parsing_condor=1
-
-while [[ $# -gt 0 ]]; do
-    if (( parsing_condor )); then
-        case "$1" in
-            --queue)
-                if [[ $# -lt 2 ]]; then
-                    echo "Error: --queue requires a value." >&2
-                    exit 1
-                fi
-                queue_count="$2"
-                shift 2
-                continue
-                ;;
-            --log-dir)
-                if [[ $# -lt 2 ]]; then
-                    echo "Error: --log-dir requires a value." >&2
-                    exit 1
-                fi
-                log_dir="$2"
-                shift 2
-                continue
-                ;;
-            --ceph-root)
-                if [[ $# -lt 2 ]]; then
-                    echo "Error: --ceph-root requires a value." >&2
-                    exit 1
-                fi
-                ceph_root="$2"
-                shift 2
-                continue
-                ;;
-            --conda-prefix)
-                if [[ $# -lt 2 ]]; then
-                    echo "Error: --conda-prefix requires a value." >&2
-                    exit 1
-                fi
-                conda_prefix="$2"
-                shift 2
-                continue
-                ;;
-            --request-cpus)
-                if [[ $# -lt 2 ]]; then
-                    echo "Error: --request-cpus requires a value." >&2
-                    exit 1
-                fi
-                request_cpus="$2"
-                shift 2
-                continue
-                ;;
-            --request-memory)
-                if [[ $# -lt 2 ]]; then
-                    echo "Error: --request-memory requires a value." >&2
-                    exit 1
-                fi
-                request_memory="$2"
-                shift 2
-                continue
-                ;;
-            --dry-run)
-                dry_run=1
-                shift
-                continue
-                ;;
-            -h|--help)
-                show_help
-                exit 0
-                ;;
-            --)
-                shift
-                parsing_condor=0
-                continue
-                ;;
-            *)
-                parsing_condor=0
-                ;;
-        esac
+main() {
+    if [[ ! -x "${RUN_PLOTTER}" ]]; then
+        echo "Error: run_plotter.sh not found next to this helper." >&2
+        return 1
     fi
 
-    if [[ "$1" == "--" ]]; then
-        # Backward compatibility: ignore the legacy delimiter while forwarding
-        # everything else verbatim.
+    if [[ ! -x "${ENTRY_SCRIPT}" ]]; then
+        echo "Error: condor_plotter_entry.sh not found next to this helper." >&2
+        return 1
+    fi
+
+    local queue_count=1
+    local log_dir=""
+    local ceph_root="${DEFAULT_CEPH_ROOT}"
+    local conda_prefix=""
+    local dry_run=0
+    local request_cpus=""
+    local request_memory=""
+    local -a plotter_args=()
+    local parsing_condor=1
+
+    while [[ $# -gt 0 ]]; do
+        if (( parsing_condor )); then
+            case "$1" in
+                --queue)
+                    if [[ $# -lt 2 ]]; then
+                        echo "Error: --queue requires a value." >&2
+                        return 1
+                    fi
+                    queue_count="$2"
+                    shift 2
+                    continue
+                    ;;
+                --log-dir)
+                    if [[ $# -lt 2 ]]; then
+                        echo "Error: --log-dir requires a value." >&2
+                        return 1
+                    fi
+                    log_dir="$2"
+                    shift 2
+                    continue
+                    ;;
+                --ceph-root)
+                    if [[ $# -lt 2 ]]; then
+                        echo "Error: --ceph-root requires a value." >&2
+                        return 1
+                    fi
+                    ceph_root="$2"
+                    shift 2
+                    continue
+                    ;;
+                --conda-prefix)
+                    if [[ $# -lt 2 ]]; then
+                        echo "Error: --conda-prefix requires a value." >&2
+                        return 1
+                    fi
+                    conda_prefix="$2"
+                    shift 2
+                    continue
+                    ;;
+                --request-cpus)
+                    if [[ $# -lt 2 ]]; then
+                        echo "Error: --request-cpus requires a value." >&2
+                        return 1
+                    fi
+                    request_cpus="$2"
+                    shift 2
+                    continue
+                    ;;
+                --request-memory)
+                    if [[ $# -lt 2 ]]; then
+                        echo "Error: --request-memory requires a value." >&2
+                        return 1
+                    fi
+                    request_memory="$2"
+                    shift 2
+                    continue
+                    ;;
+                --dry-run)
+                    dry_run=1
+                    shift
+                    continue
+                    ;;
+                -h|--help)
+                    show_help
+                    return 0
+                    ;;
+                --)
+                    shift
+                    parsing_condor=0
+                    continue
+                    ;;
+                *)
+                    parsing_condor=0
+                    ;;
+            esac
+        fi
+
+        if [[ "$1" == "--" ]]; then
+            # Backward compatibility: ignore the legacy delimiter while forwarding
+            # everything else verbatim.
+            shift
+            continue
+        fi
+
+        plotter_args+=("$1")
         shift
-        continue
+    done
+
+    if (( ${#plotter_args[@]} == 0 )); then
+        echo "Error: run_plotter.sh arguments are required. Use --help for details." >&2
+        return 1
     fi
 
-    plotter_args+=("$1")
-    shift
-done
-
-if (( ${#plotter_args[@]} == 0 )); then
-    echo "Error: run_plotter.sh arguments are required. Use --help for details." >&2
-    exit 1
-fi
-
-if ! [[ "${queue_count}" =~ ^[0-9]+$ ]] || (( queue_count < 1 )); then
-    echo "Error: --queue expects a positive integer." >&2
-    exit 1
-fi
-
-if [[ -n "${request_cpus}" ]]; then
-    if ! [[ "${request_cpus}" =~ ^[0-9]+$ ]] || (( request_cpus < 1 )); then
-        echo "Error: --request-cpus expects a positive integer." >&2
-        exit 1
+    if ! [[ "${queue_count}" =~ ^[0-9]+$ ]] || (( queue_count < 1 )); then
+        echo "Error: --queue expects a positive integer." >&2
+        return 1
     fi
-fi
 
-if [[ -n "${request_memory}" ]]; then
-    if [[ "${request_memory}" =~ ^[[:space:]]*$ ]]; then
-        echo "Error: --request-memory expects a non-empty string." >&2
-        exit 1
+    if [[ -n "${request_cpus}" ]]; then
+        if ! [[ "${request_cpus}" =~ ^[0-9]+$ ]] || (( request_cpus < 1 )); then
+            echo "Error: --request-cpus expects a positive integer." >&2
+            return 1
+        fi
     fi
-fi
 
-if [[ -z "${log_dir}" ]]; then
-    log_dir="${PWD}/condor_logs"
-fi
+    if [[ -n "${request_memory}" ]]; then
+        if [[ "${request_memory}" =~ ^[[:space:]]*$ ]]; then
+            echo "Error: --request-memory expects a non-empty string." >&2
+            return 1
+        fi
+    fi
 
-log_dir=$(python3 - "${log_dir}" <<'PY'
+    if [[ -z "${log_dir}" ]]; then
+        log_dir="${PWD}/condor_logs"
+    fi
+
+    log_dir=$(python3 - "${log_dir}" <<'PY'
 import os
 import sys
 print(os.path.abspath(os.path.expanduser(sys.argv[1])))
 PY
 )
-mkdir -p "${log_dir}"
+    mkdir -p "${log_dir}"
 
-ceph_root=$(python3 - "${ceph_root}" <<'PY'
+    ceph_root=$(python3 - "${ceph_root}" <<'PY'
 import os
 import sys
 print(os.path.abspath(os.path.expanduser(sys.argv[1])))
 PY
 )
 
-if [[ -n "${conda_prefix}" ]]; then
-    conda_prefix=$(python3 - "${conda_prefix}" <<'PY'
+    if [[ -n "${conda_prefix}" ]]; then
+        conda_prefix=$(python3 - "${conda_prefix}" <<'PY'
 import os
 import sys
 print(os.path.abspath(os.path.expanduser(sys.argv[1])))
 PY
 )
-fi
+    fi
 
-analysis_dir="${ceph_root}/analysis/topeft_run2"
-if [[ ! -d "${analysis_dir}" ]]; then
-    echo "Error: '${analysis_dir}' does not exist; check --ceph-root." >&2
-    exit 1
-fi
+    local analysis_dir="${ceph_root}/analysis/topeft_run2"
+    if [[ ! -d "${analysis_dir}" ]]; then
+        echo "Error: '${analysis_dir}' does not exist; check --ceph-root." >&2
+        return 1
+    fi
 
-entry_on_ceph="${analysis_dir}/condor_plotter_entry.sh"
-if [[ ! -f "${entry_on_ceph}" ]]; then
-    echo "Error: '${entry_on_ceph}' was not found." >&2
-    exit 1
-fi
+    local entry_on_ceph="${analysis_dir}/condor_plotter_entry.sh"
+    if [[ ! -f "${entry_on_ceph}" ]]; then
+        echo "Error: '${entry_on_ceph}' was not found." >&2
+        return 1
+    fi
 
-if ! validation_output=$("${RUN_PLOTTER}" "${plotter_args[@]}" --dry-run 2>&1); then
-    echo "Error: run_plotter.sh validation failed:" >&2
-    printf '%s\n' "${validation_output}" >&2
-    exit 1
-fi
+    local validation_output=""
+    if ! validation_output=$("${RUN_PLOTTER}" "${plotter_args[@]}" --dry-run 2>&1); then
+        echo "Error: run_plotter.sh validation failed:" >&2
+        printf '%s\n' "${validation_output}" >&2
+        return 1
+    fi
 
-tmp_dir=$(mktemp -d)
-trap 'rm -rf "${tmp_dir}"' EXIT
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    trap '[[ -n "${tmp_dir:-}" ]] && rm -rf "${tmp_dir}"' EXIT
 
-submit_file="${tmp_dir}/plotter_job.sub"
-staged_entry="${tmp_dir}/$(basename "${ENTRY_SCRIPT}")"
+    local submit_file="${tmp_dir}/plotter_job.sub"
+    local staged_entry="${tmp_dir}/$(basename "${ENTRY_SCRIPT}")"
 
-cp "${ENTRY_SCRIPT}" "${staged_entry}"
-chmod +x "${staged_entry}"
+    cp "${ENTRY_SCRIPT}" "${staged_entry}"
+    chmod +x "${staged_entry}"
 
-repo_root=$(python3 - "${analysis_dir}" <<'PY'
+    local repo_root
+    repo_root=$(python3 - "${analysis_dir}" <<'PY'
 import os
 import sys
 print(os.path.abspath(os.path.join(sys.argv[1], os.pardir)))
 PY
 )
 
-environment_entries=(
-    "TOPEFT_REPO_ROOT=${repo_root}"
-    "TOPEFT_ENTRY_DIR=${analysis_dir}"
-)
+    local -a environment_entries=(
+        "TOPEFT_REPO_ROOT=${repo_root}"
+        "TOPEFT_ENTRY_DIR=${analysis_dir}"
+    )
 
-if [[ -n "${conda_prefix}" ]]; then
-    environment_entries+=("TOPEFT_CONDA_PREFIX=${conda_prefix}")
-fi
-
-environment_string=""
-for entry in "${environment_entries[@]}"; do
-    if [[ -n "${environment_string}" ]]; then
-        environment_string+=";"
+    if [[ -n "${conda_prefix}" ]]; then
+        environment_entries+=("TOPEFT_CONDA_PREFIX=${conda_prefix}")
     fi
-    environment_string+="${entry}"
-done
 
-printf -v arg_string ' %q' "${plotter_args[@]}"
-arg_string="${arg_string# }"
+    local environment_string=""
+    local entry
+    for entry in "${environment_entries[@]}"; do
+        if [[ -n "${environment_string}" ]]; then
+            environment_string+=";"
+        fi
+        environment_string+="${entry}"
+    done
 
-{
-cat <<EOF
+    local arg_string=""
+    printf -v arg_string ' %q' "${plotter_args[@]}"
+    arg_string="${arg_string# }"
+
+    {
+    cat <<EOF
 universe                = vanilla
 executable              = "${staged_entry}"
 arguments               = ${arg_string}
@@ -264,23 +272,37 @@ should_transfer_files   = YES
 transfer_executable     = True
 environment              = "${environment_string}"
 EOF
-if [[ -n "${request_cpus}" ]]; then
-    printf 'request_cpus            = %s\n' "${request_cpus}"
-fi
-if [[ -n "${request_memory}" ]]; then
-    printf 'request_memory          = %s\n' "${request_memory}"
-fi
-cat <<EOF
+    if [[ -n "${request_cpus}" ]]; then
+        printf 'request_cpus            = %s\n' "${request_cpus}"
+    fi
+    if [[ -n "${request_memory}" ]]; then
+        printf 'request_memory          = %s\n' "${request_memory}"
+    fi
+    cat <<EOF
 queue ${queue_count}
 EOF
-} > "${submit_file}"
+    } > "${submit_file}"
 
-if (( dry_run )); then
-    echo "run_plotter.sh validation output:" >&2
-    printf '%s\n' "${validation_output}" >&2
-    echo "--- ${submit_file} ---"
-    cat "${submit_file}"
-    exit 0
+    if (( dry_run )); then
+        echo "run_plotter.sh validation output:" >&2
+        printf '%s\n' "${validation_output}" >&2
+        echo "--- ${submit_file} ---"
+        cat "${submit_file}"
+        return 0
+    fi
+
+    condor_submit "${submit_file}"
+
+    return 0
+}
+
+if main "$@"; then
+    exit_code=0
+else
+    exit_code=$?
 fi
-
-condor_submit "${submit_file}"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    exit "${exit_code}"
+else
+    return "${exit_code}"
+fi

--- a/analysis/topeft_run2/test/test_submit_plotter_condor.py
+++ b/analysis/topeft_run2/test/test_submit_plotter_condor.py
@@ -84,4 +84,4 @@ def test_submit_plotter_condor_dry_run(tmp_path):
 
     entry_script = (analysis_dir / "condor_plotter_entry.sh").read_text()
     assert "unset PYTHONPATH" in entry_script
-    assert "run_plotter.sh \"$@\"" in entry_script
+    assert '"${ENTRY_DIR}/run_plotter.sh" "$@"' in entry_script


### PR DESCRIPTION
## Summary
- refactor the plotting helper shell scripts to route their logic through a `main` function
- update error handling so sourced shells receive return codes instead of exiting outright
- document the new sourcing behaviour and adjust the Condor entry test for the updated wrapper invocation

## Testing
- pytest analysis/topeft_run2/test/test_submit_plotter_condor.py