### PR TITLE
Refactor flip measurement workflows for tuple-key histograms

### DIFF
--- a/analysis/flip_measurement/flip_ar_plotter.py
+++ b/analysis/flip_measurement/flip_ar_plotter.py
@@ -1,109 +1,112 @@
-# Notes on this script:
-#   - This script runs on the output of flip_ar_processor.py
-#   - It opens the pkl file and plots the SS data and the prediction
-#   - The prediction was calculated in the processor by applying flip probabilities to the OS data
+"""Plotter for tuple-keyed flip application region histograms."""
 
-import os
-import copy
-import matplotlib.pyplot as plt
-import coffea.hist as hist
+from __future__ import annotations
 
-from topcoffea.modules.YieldTools import YieldTools
-yt = YieldTools()
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, Mapping, Tuple
 
 import argparse
-parser = argparse.ArgumentParser(description='You can customize your run')
-parser.add_argument("filepath",default='histos/flipTopEFT.pkl.gz', help = 'path of file with histograms')
-parser.add_argument("--outpath" ,'-o'   , default='.', help = 'Path to the output directory')
-args = parser.parse_args()
-outpath = args.outpath
+import gzip
 
-# Plots one or two histos (optionally along with an "up" and "down" variation) and returns the fig
-def make_fig(histo1,histo2=None,hup=None,hdo=None):
-    #print("\nPlotting values:",histo1.values())
-    #print("\nPlotting values:",histo2.values())
-    fig, ax = plt.subplots(1, 1, figsize=(7,7))
+import matplotlib.pyplot as plt
+import hist
+import cloudpickle
 
-    # Plot the "up" and "down" histos
+from topeft.modules.runner_output import SUMMARY_KEY
+
+
+def load_histograms(path: str) -> Mapping[Tuple[str, str, str, str, str], hist.Hist]:
+    with gzip.open(path, "rb") as fin:
+        payload = cloudpickle.load(fin)
+    if not isinstance(payload, Mapping):
+        raise TypeError("Histogram payload must be a mapping")
+    result: Dict[Tuple[str, str, str, str, str], hist.Hist] = {}
+    for key, value in payload.items():
+        if key == SUMMARY_KEY:
+            continue
+        if not isinstance(key, tuple) or len(key) != 5:
+            continue
+        if not isinstance(value, hist.Hist):
+            continue
+        result[key] = value
+    if not result:
+        raise ValueError("No tuple-keyed histograms found in payload")
+    return result
+
+
+def group_by_variable(
+    histograms: Mapping[Tuple[str, str, str, str, str], hist.Hist]
+) -> Mapping[str, Dict[str, Dict[str, hist.Hist]]]:
+    grouped: Dict[str, Dict[str, Dict[str, hist.Hist]]] = defaultdict(lambda: defaultdict(dict))
+    for key, histogram in histograms.items():
+        variable, channel, application, sample, _systematic = key
+        if application != "flip_application":
+            continue
+        grouped[variable][sample][channel] = histogram.copy()
+    return grouped
+
+
+def make_fig(
+    histo1: hist.Hist,
+    histo2: hist.Hist | None = None,
+    hup: hist.Hist | None = None,
+    hdo: hist.Hist | None = None,
+) -> plt.Figure:
+    fig, ax = plt.subplots(1, 1, figsize=(7, 7))
+
     if hup is not None and hdo is not None:
-        hist.plot1d(
-            hup,
-            stack=False,
-            line_opts={'color': 'lightgrey'},
-            clear=False,
-        )
-        hist.plot1d(
-            hdo,
-            stack=False,
-            line_opts={'color': 'lightgrey'},
-            clear=False,
-        )
+        hist.plot1d(hup, ax=ax, stack=False, line_opts={"color": "lightgrey"})
+        hist.plot1d(hdo, ax=ax, stack=False, line_opts={"color": "lightgrey"})
 
-    # Plot the main histos
-    hist.plot1d(
-        histo1,
-        stack=False,
-        clear=False,
-    )
+    hist.plot1d(histo1, ax=ax, stack=False)
     if histo2 is not None:
-        hist.plot1d(
-            histo2,
-            stack=False,
-            clear=False,
-        )
+        hist.plot1d(histo2, ax=ax, stack=False)
 
-    ax.autoscale(axis='y')
+    ax.autoscale(axis="y")
     return fig
 
 
-# Print summed values from a histo
-def print_summed_hist_vals(in_hist,ret="ssz",quiet=False):
-    val_dict = {}
-    for k,v in in_hist.values().items():
-        val_dict[k[0]] = sum(v)
-    for k,v in val_dict.items():
-        if not quiet: print(f"\t{k}: {v}")
-    fliprate = val_dict["sszTruthFlip"]/(val_dict["sszTruthFlip"] + val_dict["oszTruthNoFlip"])
-    #print("\tFlip rate:", val_dict["sszTruthFlip"]/(val_dict["osz"] + val_dict["ssz"]))
-    #print("\tFlip rate:", val_dict["ssTruthFlip2"]/(val_dict["os"] + val_dict["ss"]))
-    if not quiet: print("\tFlip rate:", fliprate)
-    return val_dict[ret]
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Plot flip application histograms")
+    parser.add_argument(
+        "filepath",
+        default="histos/flipTopEFT.pkl.gz",
+        help="path of file with histograms",
+    )
+    parser.add_argument("--outpath", "-o", default=".", help="Path to the output directory")
+    args = parser.parse_args()
+
+    tuple_histograms = load_histograms(args.filepath)
+    grouped = group_by_variable(tuple_histograms)
+
+    outpath = Path(args.outpath)
+    outpath.mkdir(parents=True, exist_ok=True)
+
+    for variable, sample_map in grouped.items():
+        print(f"\nVariable: {variable}")
+        for sample, channel_map in sample_map.items():
+            ssz_hist = channel_map.get("ssz")
+            osz_hist = channel_map.get("osz")
+            if ssz_hist is None or osz_hist is None:
+                print(f"  Missing channel histograms for sample {sample}, skipping")
+                continue
+
+            print(f"  sample_name {sample}")
+
+            ssz_plot = ssz_hist.copy()
+            osz_plot = osz_hist.copy()
+
+            h_up = osz_plot.copy()
+            h_up *= 1.3
+            h_do = osz_plot.copy()
+            h_do *= 0.7
+
+            fig = make_fig(ssz_plot, histo2=osz_plot, hup=h_up, hdo=h_do)
+            savename = outpath / f"{sample}_{variable}.png"
+            fig.savefig(savename)
+            plt.close(fig)
 
 
-# Main wrapper function
-def make_plot():
-
-    hin_dict = yt.get_hist_from_pkl(args.filepath)
-    sample_names_lst = yt.get_cat_lables(hin_dict,"sample")
-    chan_names_lst = yt.get_cat_lables(hin_dict,"channel")
-
-    print("Samples:",sample_names_lst)
-    print("Channels:",chan_names_lst)
-
-    for histo_name,histo_orig in hin_dict.items():
-        print(f"\nName: {histo_name}")
-
-        # Loop over samples
-        for sample_name in sample_names_lst:
-            print("sample_name",sample_name)
-
-            # Copy (and rebin the ss)
-            histo = copy.deepcopy(histo_orig)
-            if histo_name == "invmass": histo = histo.rebin("invmass",2)
-
-            # Integrate and make plot (overlay the categories)
-            savename = "_".join([sample_name,histo_name])
-            histo = histo.integrate("sample",sample_name)
-            h_up = copy.deepcopy(histo)
-            h_do = copy.deepcopy(histo)
-            h_up.scale(1.3)
-            h_do.scale(0.7)
-            fig = make_fig(histo["ssz"],histo2=histo["osz"],hup=h_up["osz"],hdo=h_do["osz"])
-            fig.savefig(os.path.join(outpath,savename))
-
-
-# Main function
-def main():
-    make_plot()
-
-main()
+if __name__ == "__main__":
+    main()

--- a/analysis/flip_measurement/flip_mr_plotter.py
+++ b/analysis/flip_measurement/flip_mr_plotter.py
@@ -1,122 +1,155 @@
-# Notes on this script:
-#   - This script runs on the output of flip_mr_processor.py
-#   - It opens the pkl file, extracts the flip and no flip histos, calculates the flip prob, and saves that to a histo (also saves the 2d hists to png for reference)
-#   - The output histo is then placed in topcoffea/data so that corrections.py can read in the values using dense lookup
+"""Plotter for the flip measurement tuple-keyed histogram output."""
 
-import copy
-import matplotlib.pyplot as plt
-import cloudpickle
-import gzip
-import coffea.hist as hist
+from __future__ import annotations
 
-from topcoffea.modules.YieldTools import YieldTools
-yt = YieldTools()
+from collections import defaultdict
+from typing import Dict, Mapping, Tuple
 
 import argparse
-parser = argparse.ArgumentParser()
-parser.add_argument("filepath",default='histos/flipMR_TopEFT.pkl.gz', help = 'path of file with histograms')
-args = parser.parse_args()
+import gzip
 
-hin_dict = yt.get_hist_from_pkl(args.filepath)
+import matplotlib.pyplot as plt
+import numpy as np
+import cloudpickle
+import hist
 
-# This binning should match what is defined in the flip measurement processor
-PT_BINS = [0, 30.0, 45.0, 60.0, 100.0, 200.0]
-ABSETA_BINS = [0, 0.4, 0.8, 1.1, 1.4, 1.6, 1.9, 2.2, 2.5]
+from topeft.modules.runner_output import SUMMARY_KEY
 
-# These scale factors are determined by comparing prediction to data in the the flip CR
-# Though now we apply this in corrections.py, so don't scale here
+
+PT_BINS = (0.0, 30.0, 45.0, 60.0, 100.0, 200.0)
+ABSETA_BINS = (0.0, 0.4, 0.8, 1.1, 1.4, 1.6, 1.9, 2.2, 2.5)
+
 SCALE_DICT = {
-    "UL16APV" : 1.0,
-    "UL16"    : 1.0,
-    "UL17"    : 1.0,
-    "UL18"    : 1.0,
+    "UL16APV": 1.0,
+    "UL16": 1.0,
+    "UL17": 1.0,
+    "UL18": 1.0,
 }
 
-# Given an array of values and a pt and eta bin list, make a histo
-def make_ratio_hist(ratio_arr,pt_bin_lst,eta_bin_lst):
-    hist_ratio = hist.Hist(
-        "Ratio",
-        hist.Bin("pt", "pt", pt_bin_lst),
-        hist.Bin("eta", "eta", eta_bin_lst),
-    )
-    hist_ratio._sumw = {(): ratio_arr}
-    return hist_ratio
 
-# Plot and save a png for a given 2d histo
-def make_2d_fig(histo,xaxis_var,save_name,title=None):
-    if title is not None: title_str = title
-    else: title_str = save_name
-    ax = hist.plot2d(histo,xaxis=xaxis_var)
+def load_histograms(path: str) -> Mapping[Tuple[str, str, str, str, str], hist.Hist]:
+    with gzip.open(path, "rb") as fin:
+        payload = cloudpickle.load(fin)
+    if not isinstance(payload, Mapping):
+        raise TypeError("Histogram payload must be a mapping")
+    result: Dict[Tuple[str, str, str, str, str], hist.Hist] = {}
+    for key, value in payload.items():
+        if key == SUMMARY_KEY:
+            continue
+        if not isinstance(key, tuple) or len(key) != 5:
+            continue
+        if not isinstance(value, hist.Hist):
+            continue
+        result[key] = value
+    if not result:
+        raise ValueError("No tuple-keyed histograms found in payload")
+    return result
+
+
+def determine_year(sample: str) -> str | None:
+    if "UL16APV" in sample:
+        return "UL16APV"
+    for year in ("UL16", "UL17", "UL18"):
+        if year in sample and "APV" not in sample:
+            return year
+    return None
+
+
+def group_by_year(
+    histograms: Mapping[Tuple[str, str, str, str, str], hist.Hist]
+) -> Mapping[str, Dict[str, hist.Hist]]:
+    grouped: Dict[str, Dict[str, hist.Hist]] = defaultdict(dict)
+    for key, histogram in histograms.items():
+        variable, flipstatus, _application, sample, _systematic = key
+        if variable != "ptabseta":
+            continue
+        year = determine_year(sample)
+        if year is None:
+            continue
+        if flipstatus not in ("truthFlip", "truthNoFlip"):
+            continue
+        hist_copy = histogram.copy()
+        if flipstatus in grouped[year]:
+            grouped[year][flipstatus] = grouped[year][flipstatus] + hist_copy
+        else:
+            grouped[year][flipstatus] = hist_copy
+    return grouped
+
+
+def make_ratio_hist(ratio_arr: np.ndarray) -> hist.Hist:
+    ratio_hist = hist.Hist(
+        hist.axis.Variable(PT_BINS, name="pt", label="pt"),
+        hist.axis.Variable(ABSETA_BINS, name="abseta", label="abseta"),
+        storage=hist.storage.Double(),
+    )
+    ratio_hist[...] = ratio_arr
+    return ratio_hist
+
+
+def make_2d_fig(histo: hist.Hist, xaxis_var: str, save_name: str, title: str | None = None) -> None:
+    title_str = title if title is not None else save_name
+    hist.plot2d(histo, xaxis=xaxis_var)
     plt.title(title_str)
     plt.savefig(save_name)
 
 
-# Get ratio, flip, and noflip histos from a given input histo
-def get_flip_histos(in_hist_orig):
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "filepath",
+        default="histos/flipMR_TopEFT.pkl.gz",
+        help="path of file with histograms",
+    )
+    args = parser.parse_args()
 
-    # Copy and rebin the histo
-    in_hist = copy.deepcopy(in_hist_orig)
-    in_hist = in_hist.rebin("abseta", hist.Bin("abseta","abseta",ABSETA_BINS))
-    in_hist = in_hist.rebin("pt", hist.Bin("pt","pt",PT_BINS))
+    tuple_histograms = load_histograms(args.filepath)
+    grouped = group_by_year(tuple_histograms)
 
-    # Grab the histo of flipped e and histo of not flipped e
-    hist_flip = in_hist.integrate("flipstatus","truthFlip")
-    hist_noflip = in_hist.integrate("flipstatus","truthNoFlip")
+    for year in ("UL16APV", "UL16", "UL17", "UL18"):
+        flip_map = grouped.get(year, {})
+        if not flip_map:
+            print(f"No histograms found for year {year}, skipping.")
+            continue
+        if "truthFlip" not in flip_map or "truthNoFlip" not in flip_map:
+            print(f"Incomplete histogram set for year {year}, skipping.")
+            continue
 
-    # Calculate ratio and make ratio histo
-    flip_sumw_arr = hist_flip._sumw[()]
-    noflip_sumw_arr = hist_noflip._sumw[()]
-    ratio_sumw_arr = flip_sumw_arr/(flip_sumw_arr+noflip_sumw_arr)
-    hist_ratio = make_ratio_hist(ratio_sumw_arr,PT_BINS,ABSETA_BINS)
+        hist_flip = flip_map["truthFlip"]
+        hist_noflip = flip_map["truthNoFlip"]
 
-    # Print info
-    #print("\nflip:",flip_sumw_arr)
-    #print("\nnoflip:",noflip_sumw_arr)
-    #print("\nflipratio:",ratio_sumw_arr)
+        flip_values = hist_flip.values()
+        noflip_values = hist_noflip.values()
+        denom = flip_values + noflip_values
+        ratio_values = np.divide(
+            flip_values,
+            denom,
+            out=np.zeros_like(flip_values, dtype=float),
+            where=denom != 0,
+        )
 
-    return [hist_flip,hist_noflip,hist_ratio]
+        hist_ratio = make_ratio_hist(ratio_values)
 
+        make_2d_fig(hist_flip, "pt", f"{year}_truth_flip")
+        make_2d_fig(hist_noflip, "pt", f"{year}_truth_noflip")
+        make_2d_fig(
+            hist_ratio,
+            "pt",
+            f"{year}_truth_ratio",
+            "Flip ratio = flip/(flip+noflip)",
+        )
 
-# Main function
-def main():
+        scaled_ratio = hist_ratio.copy()
+        scaled_ratio[...] = ratio_values * SCALE_DICT[year]
+        make_2d_fig(
+            scaled_ratio,
+            "pt",
+            f"{year}_truth_ratio_scaled",
+            "Flip ratio = flip/(flip+noflip)",
+        )
 
-    # Print info about the in dict
-    sample_names_lst = yt.get_cat_lables(hin_dict,"sample")
-    flip_names_lst = yt.get_cat_lables(hin_dict,"flipstatus")
-    print("Samples:",sample_names_lst)
-    print("Flipstatus:",flip_names_lst)
-
-    # Get the histos from the input dict
-    histo_ptabseta = hin_dict["ptabseta"]
-
-    # Loop over the years
-    # NOTE: Will need to hanld UL16APV too
-    for year in ["UL16APV","UL16","UL17","UL18"]:
-
-        # Integrate just the samples for the given year
-        blacklist = []
-        if year != "UL16APV": blacklist = "APV"
-        samples_to_include = yt.filter_lst_of_strs(sample_names_lst,substr_whitelist=year,substr_blacklist=blacklist)
-        print(f"For year {year}, including samples: {samples_to_include}")
-        histo_ptabseta_year = copy.deepcopy(histo_ptabseta)
-        histo_ptabseta_year = histo_ptabseta_year.integrate("sample",samples_to_include)
-
-        # Get the flip histos
-        hist_flip, hist_noflip, hist_ratio = get_flip_histos(histo_ptabseta_year)
-
-        # Save figs
-        make_2d_fig(hist_flip,"pt",year+"_truth_flip")
-        make_2d_fig(hist_noflip,"pt",year+"_truth_noflip")
-        make_2d_fig(hist_ratio,"pt",year+"_truth_ratio","Flip ratio = flip/(flip+noflip)")
-
-        # Scale ratio histo and save a fig for that one too
-        hist_ratio.scale(SCALE_DICT[year])
-        make_2d_fig(hist_ratio,"pt",year+"_truth_ratio_scaled","Flip ratio = flip/(flip+noflip)")
-
-        # Save output histo
-        save_pkl_str = "flip_probs_topcoffea_" + year + ".pkl.gz"
+        save_pkl_str = f"flip_probs_topcoffea_{year}.pkl.gz"
         with gzip.open(save_pkl_str, "wb") as fout:
-            cloudpickle.dump(hist_ratio, fout)
+            cloudpickle.dump(scaled_ratio, fout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace legacy coffea.hist usage in flip measurement processors with `hist` and emit tuple-keyed histogram maps compatible with shared runner utilities
- update flip application processor to fill per-channel histograms keyed by tuples instead of sparse axes and return ordered dictionaries with summaries
- refresh flip plotter scripts to consume tuple-keyed outputs, load histograms via common helper logic, and generate plots using the new histograms

## Testing
- python -m compileall analysis/flip_measurement