### PR TITLE
Use 4-tuple histogram metadata

### DIFF
--- a/analysis/flip_measurement/flip_ar_plotter.py
+++ b/analysis/flip_measurement/flip_ar_plotter.py
@@ -16,16 +16,16 @@ import cloudpickle
 from topeft.modules.runner_output import SUMMARY_KEY
 
 
-def load_histograms(path: str) -> Mapping[Tuple[str, str, str, str, str], hist.Hist]:
+def load_histograms(path: str) -> Mapping[Tuple[str, str, str, str], hist.Hist]:
     with gzip.open(path, "rb") as fin:
         payload = cloudpickle.load(fin)
     if not isinstance(payload, Mapping):
         raise TypeError("Histogram payload must be a mapping")
-    result: Dict[Tuple[str, str, str, str, str], hist.Hist] = {}
+    result: Dict[Tuple[str, str, str, str], hist.Hist] = {}
     for key, value in payload.items():
         if key == SUMMARY_KEY:
             continue
-        if not isinstance(key, tuple) or len(key) != 5:
+        if not isinstance(key, tuple) or len(key) != 4:
             continue
         if not isinstance(value, hist.Hist):
             continue
@@ -36,13 +36,11 @@ def load_histograms(path: str) -> Mapping[Tuple[str, str, str, str, str], hist.H
 
 
 def group_by_variable(
-    histograms: Mapping[Tuple[str, str, str, str, str], hist.Hist]
+    histograms: Mapping[Tuple[str, str, str, str], hist.Hist]
 ) -> Mapping[str, Dict[str, Dict[str, hist.Hist]]]:
     grouped: Dict[str, Dict[str, Dict[str, hist.Hist]]] = defaultdict(lambda: defaultdict(dict))
     for key, histogram in histograms.items():
-        variable, channel, application, sample, _systematic = key
-        if application != "flip_application":
-            continue
+        variable, channel, sample, _systematic = key
         grouped[variable][sample][channel] = histogram.copy()
     return grouped
 

--- a/analysis/flip_measurement/flip_ar_processor.py
+++ b/analysis/flip_measurement/flip_ar_processor.py
@@ -398,13 +398,13 @@ class AnalysisProcessor(processor.ProcessorABC):
         return hout
 
     def postprocess(self, accumulator):
-        tuple_entries: Dict[Tuple[str, str, str, str, str], hist.Hist] = {
+        tuple_entries: Dict[Tuple[str, str, str, str], hist.Hist] = {
             key: value
             for key, value in accumulator.items()
-            if isinstance(key, tuple) and len(key) == 5
+            if isinstance(key, tuple) and len(key) == 4
         }
 
-        ordered_entries: "OrderedDict[Tuple[str, str, str, str, str], hist.Hist]" = OrderedDict(
+        ordered_entries: "OrderedDict[Tuple[str, str, str, str], hist.Hist]" = OrderedDict(
             sorted(tuple_entries.items(), key=lambda item: item[0])
         )
 
@@ -427,11 +427,10 @@ class AnalysisProcessor(processor.ProcessorABC):
         variable: str,
         channel: str,
         sample: str,
-    ) -> Tuple[str, str, str, str, str]:
+    ) -> Tuple[str, str, str, str]:
         return (
             variable,
             channel,
-            self._application_region,
             sample,
             self._systematic,
         )

--- a/analysis/flip_measurement/flip_mr_plotter.py
+++ b/analysis/flip_measurement/flip_mr_plotter.py
@@ -7,6 +7,7 @@ from typing import Dict, Mapping, Tuple
 
 import argparse
 import gzip
+from typing import Dict, Mapping, Tuple
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -27,16 +28,16 @@ SCALE_DICT = {
 }
 
 
-def load_histograms(path: str) -> Mapping[Tuple[str, str, str, str, str], hist.Hist]:
+def load_histograms(path: str) -> Mapping[Tuple[str, str, str, str], hist.Hist]:
     with gzip.open(path, "rb") as fin:
         payload = cloudpickle.load(fin)
     if not isinstance(payload, Mapping):
         raise TypeError("Histogram payload must be a mapping")
-    result: Dict[Tuple[str, str, str, str, str], hist.Hist] = {}
+    result: Dict[Tuple[str, str, str, str], hist.Hist] = {}
     for key, value in payload.items():
         if key == SUMMARY_KEY:
             continue
-        if not isinstance(key, tuple) or len(key) != 5:
+        if not isinstance(key, tuple) or len(key) != 4:
             continue
         if not isinstance(value, hist.Hist):
             continue
@@ -56,11 +57,11 @@ def determine_year(sample: str) -> str | None:
 
 
 def group_by_year(
-    histograms: Mapping[Tuple[str, str, str, str, str], hist.Hist]
+    histograms: Mapping[Tuple[str, str, str, str], hist.Hist]
 ) -> Mapping[str, Dict[str, hist.Hist]]:
     grouped: Dict[str, Dict[str, hist.Hist]] = defaultdict(dict)
     for key, histogram in histograms.items():
-        variable, flipstatus, _application, sample, _systematic = key
+        variable, flipstatus, sample, _systematic = key
         if variable != "ptabseta":
             continue
         year = determine_year(sample)

--- a/analysis/flip_measurement/flip_mr_processor.py
+++ b/analysis/flip_measurement/flip_mr_processor.py
@@ -145,13 +145,13 @@ class AnalysisProcessor(processor.ProcessorABC):
         return hout
 
     def postprocess(self, accumulator):
-        tuple_entries: Dict[Tuple[str, str, str, str, str], hist.Hist] = {
+        tuple_entries: Dict[Tuple[str, str, str, str], hist.Hist] = {
             key: value
             for key, value in accumulator.items()
-            if isinstance(key, tuple) and len(key) == 5
+            if isinstance(key, tuple) and len(key) == 4
         }
 
-        ordered_entries: "OrderedDict[Tuple[str, str, str, str, str], hist.Hist]" = OrderedDict(
+        ordered_entries: "OrderedDict[Tuple[str, str, str, str], hist.Hist]" = OrderedDict(
             sorted(tuple_entries.items(), key=lambda item: item[0])
         )
 
@@ -172,11 +172,10 @@ class AnalysisProcessor(processor.ProcessorABC):
         *,
         flipstatus: str,
         sample: str,
-    ) -> Tuple[str, str, str, str, str]:
+    ) -> Tuple[str, str, str, str]:
         return (
             self._variable,
             flipstatus,
-            self._application_region,
             sample,
             self._systematic,
         )

--- a/analysis/mc_validation/mc_validation_gen_processor.py
+++ b/analysis/mc_validation/mc_validation_gen_processor.py
@@ -118,7 +118,6 @@ class AnalysisProcessor(processor.ProcessorABC):
             self._hist_lst = hist_lst  # Which hists to fill
 
         self._default_channel = "inclusive"
-        self._default_application = "inclusive"
         self._default_systematic = "nominal"
 
         self._accumulator = processor.dict_accumulator({})
@@ -308,10 +307,10 @@ class AnalysisProcessor(processor.ProcessorABC):
         tuple_entries = {
             key: value
             for key, value in accumulator.items()
-            if isinstance(key, tuple) and len(key) == 5
+            if isinstance(key, tuple) and len(key) == 4
         }
 
-        ordered_tuple_entries: "OrderedDict[Tuple[str, str, str, str, str], HistEFT]" = OrderedDict(
+        ordered_tuple_entries: "OrderedDict[Tuple[str, str, str, str], HistEFT]" = OrderedDict(
             sorted(tuple_entries.items(), key=lambda item: item[0])
         )
 
@@ -319,12 +318,10 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         aggregated: Dict[str, Dict[str, HistEFT]] = defaultdict(dict)
         for key, hist_obj in ordered_tuple_entries.items():
-            variable, channel, application, sample, systematic = key
+            variable, channel, sample, systematic = key
             label_parts = [sample]
             if channel and channel != self._default_channel:
                 label_parts.append(channel)
-            if application and application != self._default_application:
-                label_parts.append(application)
             if systematic and systematic != self._default_systematic:
                 label_parts.append(systematic)
             sample_label = "__".join(filter(None, label_parts))
@@ -371,11 +368,11 @@ class AnalysisProcessor(processor.ProcessorABC):
         channel: Union[str, None] = None,
         application: Union[str, None] = None,
         systematic: Union[str, None] = None,
-    ) -> Tuple[str, str, str, str, str]:
+    ) -> Tuple[str, str, str, str]:
+        _ = application
         return (
             variable,
             channel or self._default_channel,
-            application or self._default_application,
             sample,
             systematic or self._default_systematic,
         )

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -380,13 +380,20 @@ class AnalysisProcessor(processor.ProcessorABC):
                         *info["regular"], name=self._var, label=info["label"]
                     )
 
-                histogram[hist_key_entry] = HistEFT(
+                hist_key = self._build_histogram_key(
+                    key_var,
+                    key_ch,
+                    key_sample,
+                    syst_label,
+                )
+
+                histogram[hist_key] = HistEFT(
                     dense_axis,
                     wc_names=wc_names_lst,
                     label=r"Events",
                 )
 
-                self._hist_keys_to_fill.append(hist_key_entry)
+                self._hist_keys_to_fill.append(hist_key)
 
                 if idx == 0:
                     if not rebin and "variable" in info:
@@ -402,10 +409,9 @@ class AnalysisProcessor(processor.ProcessorABC):
                             label=info["label"] + " sum of w^2",
                         )
 
-                    sumw2_key = (
+                    sumw2_key = self._build_histogram_key(
                         f"{self._var}_sumw2",
                         self._channel,
-                        key_appl,
                         key_sample,
                         syst_label,
                     )
@@ -518,6 +524,11 @@ class AnalysisProcessor(processor.ProcessorABC):
             lep_chan, njet_str=njet_ch, flav_str=None
         )
         return ch_name, base_ch_name
+
+    def _build_histogram_key(
+        self, variable: str, channel: str, sample: str, systematic: str
+    ) -> Tuple[str, str, str, str]:
+        return (variable, channel, sample, systematic)
 
     def _build_dataset_context(self, events) -> DatasetContext:
         events_metadata = self._metadata_to_mapping(getattr(events, "metadata", None))
@@ -1913,19 +1924,17 @@ class AnalysisProcessor(processor.ProcessorABC):
                     "eft_coeff": eft_coeffs_cut,
                 }
 
-                histkey = (
+                histkey = self._build_histogram_key(
                     dense_axis_name,
                     ch_name,
-                    self.appregion,
                     dataset.dataset,
                     hist_variation_label,
                 )
 
                 if histkey not in hout:
-                    fallback_histkey = (
+                    fallback_histkey = self._build_histogram_key(
                         dense_axis_name,
                         base_ch_name,
-                        self.appregion,
                         dataset.dataset,
                         hist_variation_label,
                     )
@@ -1948,10 +1957,9 @@ class AnalysisProcessor(processor.ProcessorABC):
                     "weight": np.square(weights_flat),
                     "eft_coeff": eft_coeffs_cut,
                 }
-                histkey = (
+                histkey = self._build_histogram_key(
                     dense_axis_name + "_sumw2",
                     base_ch_name,
-                    self.appregion,
                     dataset.dataset,
                     hist_variation_label,
                 )

--- a/analysis/training/simple_processor.py
+++ b/analysis/training/simple_processor.py
@@ -131,7 +131,6 @@ class AnalysisProcessor(processor.ProcessorABC):
         }
 
         self._default_channel = "2l"
-        self._default_application = "2l"
         self._default_systematic = "nominal"
 
         self._accumulator = processor.dict_accumulator({})
@@ -328,10 +327,10 @@ class AnalysisProcessor(processor.ProcessorABC):
         application: Optional[str] = None,
         systematic: Optional[str] = None,
     ):
+        _ = application  # application metadata is tracked in the tuple channel name
         return (
             variable,
             channel or self._default_channel,
-            application or self._default_application,
             sample,
             systematic or self._default_systematic,
         )

--- a/tests/test_flavor_split_histograms.py
+++ b/tests/test_flavor_split_histograms.py
@@ -472,21 +472,18 @@ def test_flavor_split_registers_flavored_histograms(processor):
     base_hist_key = (
         "dummy",
         "3l_p_offZ_1b_2j",
-        "isSR_3l",
         _DATASET_NAME,
         "nominal",
     )
     flavored_hist_key = (
         "dummy",
         "3l_eee_p_offZ_1b_2j",
-        "isSR_3l",
         _DATASET_NAME,
         "nominal",
     )
     base_sumw2_key = (
         "dummy_sumw2",
         "3l_p_offZ_1b_2j",
-        "isSR_3l",
         _DATASET_NAME,
         "nominal",
     )
@@ -497,7 +494,6 @@ def test_flavor_split_registers_flavored_histograms(processor):
     assert (
         "dummy_sumw2",
         "3l_eee_p_offZ_1b_2j",
-        "isSR_3l",
         _DATASET_NAME,
         "nominal",
     ) not in processor.accumulator
@@ -532,14 +528,12 @@ def test_histogram_fallback_finds_base_channel(processor):
     histkey = (
         dense_axis_name,
         missing_flavor_channel,
-        processor.appregion,
         dataset_hist,
         hist_variation_label,
     )
     fallback_histkey = (
         dense_axis_name,
         base_ch_name,
-        processor.appregion,
         dataset_hist,
         hist_variation_label,
     )
@@ -548,3 +542,16 @@ def test_histogram_fallback_finds_base_channel(processor):
 
     assert histkey not in hout
     assert fallback_histkey in hout
+
+
+def test_histogram_tuple_structure_includes_channel_metadata(processor):
+    dataset_hist, _ = processor._resolve_dataset_names(_DATASET_NAME)
+    dense_axis_name = processor.var
+    expected_key = (
+        dense_axis_name,
+        processor.channel,
+        dataset_hist,
+        processor.syst,
+    )
+
+    assert expected_key in processor.accumulator

--- a/tests/test_training_tuple_output.py
+++ b/tests/test_training_tuple_output.py
@@ -143,13 +143,12 @@ def training_result(training_processor, synthetic_events):
     return accumulator, module, processor
 
 
-def _assert_tuple_key(key: Tuple[str, str, str, str, str]) -> None:
+def _assert_tuple_key(key: Tuple[str, str, str, str]) -> None:
     assert isinstance(key, tuple)
-    assert len(key) == 5
-    variable, channel, application, sample, systematic = key
+    assert len(key) == 4
+    variable, channel, sample, systematic = key
     assert variable in {"counts", "njets", "j0pt", "j0eta", "l0pt"}
     assert isinstance(channel, str) and channel
-    assert isinstance(application, str) and application
     assert sample == "SampleMC"
     assert systematic == "nominal"
 

--- a/topeft/modules/runner_output.py
+++ b/topeft/modules/runner_output.py
@@ -100,10 +100,10 @@ def materialise_tuple_dict(hist_store: Mapping[TupleKey, Any]) -> "OrderedDict[T
 
     ordered_items = []
     for key, histogram in sorted(hist_store.items(), key=lambda item: item[0]):
-        if not isinstance(key, tuple) or len(key) != 5:
+        if not isinstance(key, tuple) or len(key) != 4:
             raise ValueError(
-                "Histogram accumulator keys must be 5-tuples of (variable, channel, "
-                "application, sample, systematic)."
+                "Histogram accumulator keys must be 4-tuples of (variable, channel, "
+                "sample, systematic)."
             )
         summary = _summarise_histogram(histogram)
         ordered_items.append((key, summary))
@@ -116,7 +116,7 @@ def _tuple_entries(payload: Mapping[Any, Any]) -> Dict[TupleKey, Any]:
 
     result: Dict[TupleKey, Any] = {}
     for key, value in payload.items():
-        if isinstance(key, tuple) and len(key) == 5 and _hist_like(value):
+        if isinstance(key, tuple) and len(key) == 4 and _hist_like(value):
             result[key] = value
     return result
 

--- a/topeft/modules/yield_tools.py
+++ b/topeft/modules/yield_tools.py
@@ -279,7 +279,7 @@ class YieldTools():
                 if isinstance(key, str):
                     if key != "SumOfEFTweights":
                         string_keys.append(key)
-                elif isinstance(key, tuple) and len(key) == 5:
+                elif isinstance(key, tuple) and len(key) == 4:
                     tuple_variables.append(key[0])
             if string_keys:
                 return string_keys
@@ -324,7 +324,7 @@ class YieldTools():
             tuple_entries = {
                 key: value
                 for key, value in hin_dict.items()
-                if isinstance(key, tuple) and len(key) == 5
+                if isinstance(key, tuple) and len(key) == 4
             }
 
             selected_hist = None
@@ -360,9 +360,8 @@ class YieldTools():
             metadata_index = {
                 "variable": 0,
                 "channel": 1,
-                "application": 2,
-                "sample": 3,
-                "systematic": 4,
+                "sample": 2,
+                "systematic": 3,
             }
 
             query_axis = "sample" if axis == "process" else axis

--- a/topeft/tests/test_processor_logging.py
+++ b/topeft/tests/test_processor_logging.py
@@ -1545,7 +1545,7 @@ def test_process_nominal_run_is_quiet(processor, capsys, caplog, monkeypatch):
         )
         self._debug(
             "Filled histkey %s with %d selected events",
-            (self.var, self.channel, self.appregion, dataset, self.syst),
+            (self.var, self.channel, dataset, self.syst),
             0,
         )
         return {dataset: 0}


### PR DESCRIPTION
## Summary
- store per-channel histograms in accumulator entries keyed by (variable, channel, sample, systematic) tuples and update the Run 2 processor plus the mc-validation/flip tooling to consume the new metadata
- keep downstream helpers and plotters in sync with the new tuple structure, ensuring summaries and tuple reconstruction no longer expect an application component
- extend the flavour-splitting test suite with coverage of the new tuple structure and refresh the training tuple-output checks accordingly

## Testing
- pytest tests/test_flavor_split_histograms.py tests/test_training_tuple_output.py