### PR TITLE
Forward TaskVine stdout by default and stage processor helpers

### DIFF
--- a/analysis/topeft_run2/run_analysis_helpers.py
+++ b/analysis/topeft_run2/run_analysis_helpers.py
@@ -359,6 +359,7 @@ class RunConfig:
     scratch_dir: Optional[str] = None
     resource_monitor: Optional[str] = "measure"
     resources_mode: Optional[str] = "auto"
+    taskvine_print_stdout: bool = True
     ecut: Optional[float] = None
     summary_verbosity: str = "brief"
     log_tasks: bool = False
@@ -432,6 +433,7 @@ class RunConfigBuilder:
             "scratch_path": ("scratch_dir", _coerce_optional_string),
             "resource_monitor": ("resource_monitor", _coerce_optional_string),
             "resources_mode": ("resources_mode", _coerce_optional_string),
+            "taskvine_print_stdout": ("taskvine_print_stdout", coerce_bool),
             "summary_verbosity": ("summary_verbosity", coerce_summary_verbosity),
             "log_tasks": ("log_tasks", coerce_bool),
             "environment_file": ("environment_file", coerce_environment_file),
@@ -569,6 +571,7 @@ class RunConfigBuilder:
                 "scratch_dir": "scratch_dir",
                 "resource_monitor": "resource_monitor",
                 "resources_mode": "resources_mode",
+                "taskvine_print_stdout": "taskvine_print_stdout",
                 "environment_file": "environment_file",
                 "futures_status": "futures_status",
                 "futures_tail_timeout": "futures_tail_timeout",
@@ -591,6 +594,9 @@ class RunConfigBuilder:
                     cli_values[key] = current_value
 
             _apply_source(cli_values)
+
+        if config.taskvine_print_stdout is None:
+            config.taskvine_print_stdout = True
 
         config.scenario_names = unique_preserving_order(config.scenario_names)
         if not config.scenario_names:

--- a/docs/taskvine_workflow.md
+++ b/docs/taskvine_workflow.md
@@ -78,7 +78,11 @@ profiles:
 
 The [`run_analysis.py` CLI and YAML reference](run_analysis_cli_reference.md)
 documents every distributed-execution flag, including helper attributes such as
-`manager_name_template`, `environment_file`, and `resources_mode`.
+`manager_name_template`, `environment_file`, and `resources_mode`. Worker
+standard output is forwarded to the TaskVine manager logs by default—override
+this behaviour with `--no-taskvine-print-stdout` (or the YAML key
+`taskvine_print_stdout: false`) when you only want the structured processor logs
+to reach the terminal.
 
 ## 4. Submit a worker pool with the packaged environment
 
@@ -103,6 +107,11 @@ Local tests can use `vine_worker` instead:
 ```bash
 vine_worker --cores 1 --memory 8000 --disk 8000 -M ${USER}-taskvine-coffea
 ```
+
+The workflow stages `analysis_processor.py` and any sibling helper modules that
+match `analysis_processor*.py` before tasks are submitted. Add new helpers next
+to the processor (or under an `analysis_processor_helpers/` package) and they
+will be shipped automatically without having to update CLI glue code.
 
 ## 5. Explore the quickstart workflows
 

--- a/tests/test_executor_cli.py
+++ b/tests/test_executor_cli.py
@@ -68,6 +68,7 @@ def test_executor_cli_taskvine_configuration(tmp_path):
             "none",
             "--resources-mode",
             "manual",
+            "--no-taskvine-print-stdout",
             "--futures-workers",
             "4",
             "--futures-status",
@@ -102,6 +103,8 @@ def test_executor_cli_taskvine_configuration(tmp_path):
     assert taskvine.resource_monitor is None
     assert taskvine.resources_mode == "manual"
     assert taskvine.environment_file == "/tmp/env.tar"
+    assert config.taskvine_print_stdout is False
+    assert taskvine.print_stdout is False
 
     staging_dir = taskvine.staging_directory()
     assert staging_dir == scratch_dir
@@ -115,6 +118,7 @@ def test_executor_cli_taskvine_configuration(tmp_path):
     assert kwargs["extra_input_files"] == ["proc.py"]
     assert kwargs["filepath"] == str(staging_dir)
     assert kwargs["environment_file"] == "/tmp/env.tar"
+    assert kwargs["print_stdout"] is False
 
     processor_module = SimpleNamespace(TaskVineExecutor=_DummyTaskVineExecutor)
     instance = taskvine.instantiate(processor_module, kwargs, negotiate_port=False)
@@ -163,6 +167,8 @@ def test_executor_cli_defaults(monkeypatch, tmp_path):
     assert taskvine.resource_monitor == "measure"
     assert taskvine.resources_mode == "auto"
     assert taskvine.environment_file == str(tmp_path / "env.tar")
+    assert config.taskvine_print_stdout is True
+    assert taskvine.print_stdout is True
 
     staging_dir = taskvine.staging_directory()
     assert staging_dir == staging_root
@@ -170,6 +176,9 @@ def test_executor_cli_defaults(monkeypatch, tmp_path):
 
     logs_dir = taskvine.logs_directory(staging_dir)
     assert logs_dir.exists()
+
+    kwargs = taskvine.executor_kwargs(extra_input_files=["proc.py"], logs_dir=logs_dir)
+    assert kwargs["print_stdout"] is True
 
     assert remote_env.calls == [({}, [])]
 

--- a/topeft/modules/executor.py
+++ b/topeft/modules/executor.py
@@ -147,6 +147,7 @@ def _base_distributed_args(
     resource_monitor: Optional[str],
     resources_mode: Optional[str],
     environment_file: Optional[str],
+    print_stdout: bool,
 ) -> Dict[str, Any]:
     args: Dict[str, Any] = {
         "filepath": str(staging_dir),
@@ -155,7 +156,7 @@ def _base_distributed_args(
         "compression": 8,
         "fast_terminate_workers": 0,
         "verbose": True,
-        "print_stdout": False,
+        "print_stdout": bool(print_stdout),
     }
     if resource_monitor is not None:
         args["resource_monitor"] = resource_monitor
@@ -176,6 +177,7 @@ def build_taskvine_args(
     resource_monitor: Optional[str],
     resources_mode: Optional[str],
     environment_file: Optional[str],
+    print_stdout: bool,
     custom_init: Optional[Callable[[Any], None]] = None,
 ) -> Dict[str, Any]:
     """Return TaskVine executor keyword arguments with shared defaults."""
@@ -186,6 +188,7 @@ def build_taskvine_args(
         resource_monitor=resource_monitor,
         resources_mode=resources_mode,
         environment_file=environment_file,
+        print_stdout=print_stdout,
     )
     if manager_name:
         args["manager_name"] = manager_name

--- a/topeft/tests/test_processor_logging.py
+++ b/topeft/tests/test_processor_logging.py
@@ -1223,7 +1223,14 @@ def _install_stubs(monkeypatch):
             )
         return normalised
 
-    def _base_executor_args(staging_dir, extra_input_files, resource_monitor, resources_mode, environment_file):
+    def _base_executor_args(
+        staging_dir,
+        extra_input_files,
+        resource_monitor,
+        resources_mode,
+        environment_file,
+        print_stdout,
+    ):
         from pathlib import Path as _Path
 
         staging_path = _Path(staging_dir)
@@ -1234,7 +1241,7 @@ def _install_stubs(monkeypatch):
             "compression": 8,
             "fast_terminate_workers": 0,
             "verbose": True,
-            "print_stdout": False,
+            "print_stdout": bool(print_stdout),
         }
         if resource_monitor is not None:
             args["resource_monitor"] = resource_monitor
@@ -1254,6 +1261,7 @@ def _install_stubs(monkeypatch):
         resource_monitor,
         resources_mode,
         environment_file,
+        print_stdout,
         custom_init=None,
     ):
         args = _base_executor_args(
@@ -1262,6 +1270,7 @@ def _install_stubs(monkeypatch):
             resource_monitor,
             resources_mode,
             environment_file,
+            print_stdout,
         )
         if manager_name:
             args["manager_name"] = manager_name


### PR DESCRIPTION
## Summary
- add a TaskVine stdout toggle to the executor CLI helper and configuration
- forward the stdout setting through the TaskVine argument builders and workflow staging
- document the new CLI flag and staging behaviour while extending smoke-test coverage

## Testing
- `pytest tests/test_executor_cli.py tests/test_executor_factory.py`