### PR TITLE
docs: document tuple-keyed histogram metadata

### DIFF
--- a/docs/analysis_processing.md
+++ b/docs/analysis_processing.md
@@ -22,8 +22,9 @@ The high-level flow is:
 4. :class:`analysis.topeft_run2.workflow.HistogramPlanner` enumerates histogram
    combinations by crossing samples, channel metadata, Coffea applications, and
    systematic toggles.  The result is a :class:`HistogramPlan` which records the
-   ``(sample, channel, variable, application, systematic)`` tuples that will be
-   processed.
+   ``(variable, channel, application, sample, systematic)`` tuples described in
+   the shared [tuple-key reference](../topcoffea/docs/analysis_processing.md)
+   before the tasks are processed.
 5. An :class:`analysis.topeft_run2.workflow.ExecutorFactory` creates the
    requested backend runner (``futures``, ``iterative`` or ``taskvine``).  Each
    histogram task is turned into an :class:`AnalysisProcessor` instance with the


### PR DESCRIPTION
## Summary
- add analysis processing notes documenting the tuple-keyed histogram dictionary layout
- describe how HistogramPlan and related dataclasses map onto tuple keys while referencing PEP 557 features
- update quickstart and configuration guides so auxiliary scripts adopt the tuple-based convention

## Testing
- not run (documentation only)