### PR TITLE
Reintroduce legacy HistEFT support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,3 @@ MANIFEST
 
 # Per-project virtualenvs
 .venv*/
-topcoffea/

--- a/README.md
+++ b/README.md
@@ -8,11 +8,14 @@ Top quark EFT analyses using the Coffea framework
 
 ## Repository contents
 The `topeft/topeft` directory is set up to be installed as a pip installable package.
-- `topeft/topeft`: A package containing modules and files that will be installed into the environment. 
+- `topeft/topeft`: A package containing modules and files that will be installed into the environment.
 - `topeft/setup.py`: File for installing the `topeft` package
-- `topeft/analysis`: Subfolders with different analyses or studies. 
+- `topeft/analysis`: Subfolders with different analyses or studies.
 - `topeft/tests`: Scripts for testing the code with `pytest`. For additional details, please see the [README](https://github.com/TopEFT/topeft/blob/master/tests/README.md) in the `tests` directory.
 - `topeft/input_samples`: Configuration files that point to root files to process.
+
+### Legacy HistEFT support
+The repository vendors the historical `HistEFT` histogram implementation under `topcoffea/modules` so EFT coefficient handling continues to use the legacy interfaces (`topcoffea.modules.HistEFT`).
 
 ## Getting started
 

--- a/analysis/mc_validation/mc_validation_gen_processor.py
+++ b/analysis/mc_validation/mc_validation_gen_processor.py
@@ -12,7 +12,7 @@ from topcoffea.modules.GetValuesFromJsons import get_lumi
 from topcoffea.modules.objects import *
 #from topcoffea.modules.corrections import get_ht_sf
 from topcoffea.modules.selection import *
-from topcoffea.modules.histEFT import HistEFT
+from topcoffea.modules.HistEFT import HistEFT
 import topcoffea.modules.eft_helper as efth
 from topeft.modules.runner_output import SUMMARY_KEY, materialise_tuple_dict
 

--- a/analysis/mc_validation/plot_utils.py
+++ b/analysis/mc_validation/plot_utils.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional, Seque
 import hist
 
 try:  # pragma: no cover - HistEFT is optional in some environments
-    from topcoffea.modules.histEFT import HistEFT
+    from topcoffea.modules.HistEFT import HistEFT
 except Exception:  # pragma: no cover - fallback when HistEFT is unavailable
     HistEFT = None  # type: ignore[assignment]
 

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -18,7 +18,7 @@ import re
 import logging
 
 import hist
-from topcoffea.modules.histEFT import HistEFT
+from topcoffea.modules.HistEFT import HistEFT
 import coffea.processor as processor
 from coffea.analysis_tools import PackedSelection
 from coffea.lumi_tools import LumiMask

--- a/analysis/topeft_run2/make_cr_and_sr_plots.py
+++ b/analysis/topeft_run2/make_cr_and_sr_plots.py
@@ -11,7 +11,7 @@ from cycler import cycler
 
 import mplhep as hep
 import hist
-from topcoffea.modules.histEFT import HistEFT
+from topcoffea.modules.HistEFT import HistEFT
 from topeft.modules.paths import topeft_path
 
 metadata_path = topeft_path("params/metadata.yml")

--- a/analysis/topeft_run2/sow_processor.py
+++ b/analysis/topeft_run2/sow_processor.py
@@ -8,7 +8,7 @@ np.seterr(divide="ignore", invalid="ignore", over="ignore")
 import coffea.processor as processor
 
 import hist
-from topcoffea.modules.histEFT import HistEFT
+from topcoffea.modules.HistEFT import HistEFT
 import topcoffea.modules.eft_helper as efth
 import topcoffea.modules.corrections as corrections
 

--- a/analysis/training/simple_processor.py
+++ b/analysis/training/simple_processor.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Optional
 
 from topcoffea.modules.objects import *
 from topcoffea.modules.selection import *
-from topcoffea.modules.histEFT import HistEFT
+from topcoffea.modules.HistEFT import HistEFT
 import topcoffea.modules.eft_helper as efth
 
 

--- a/analysis/training/simple_run.py
+++ b/analysis/training/simple_run.py
@@ -19,7 +19,7 @@ import hist
 import coffea.processor as processor
 from coffea.nanoevents import NanoAODSchema
 
-from topcoffea.modules.histEFT import HistEFT
+from topcoffea.modules.HistEFT import HistEFT
 
 import simple_processor
 

--- a/tests/test_flavor_split_histograms.py
+++ b/tests/test_flavor_split_histograms.py
@@ -218,15 +218,13 @@ def _install_test_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
     _maybe_install_stub(monkeypatch, "awkward", _awkward_factory)
 
     def _hist_eft_factory() -> types.ModuleType:
-        module = types.ModuleType("topcoffea.modules.histEFT")
+        module = types.ModuleType("topcoffea.modules.HistEFT")
         module.HistEFT = _DummyHistEFT
+        sys.modules["topcoffea.modules.histEFT"] = module
         return module
 
-    _maybe_install_stub(
-        monkeypatch,
-        "topcoffea.modules.histEFT",
-        _hist_eft_factory,
-    )
+    _maybe_install_stub(monkeypatch, "topcoffea.modules.HistEFT", _hist_eft_factory)
+    _maybe_install_stub(monkeypatch, "topcoffea.modules.histEFT", _hist_eft_factory)
 
     def _topcoffea_corrections_factory() -> types.ModuleType:
         module = types.ModuleType("topcoffea.modules.corrections")

--- a/tests/test_mc_validation_plot_utils.py
+++ b/tests/test_mc_validation_plot_utils.py
@@ -12,7 +12,7 @@ from analysis.mc_validation.plot_utils import (
 )
 
 try:  # pragma: no cover - optional dependency in CI
-    from topcoffea.modules.histEFT import HistEFT as _HistEFT
+    from topcoffea.modules.HistEFT import HistEFT as _HistEFT
 except ModuleNotFoundError:  # pragma: no cover - fallback used when topcoffea is absent
     _HistEFT = None
 

--- a/topcoffea/topcoffea/_coffea_hist_shim.py
+++ b/topcoffea/topcoffea/_coffea_hist_shim.py
@@ -1,0 +1,76 @@
+"""Compatibility helpers for the deprecated :mod:`coffea.hist` API.
+
+Historically ``topcoffea`` relied on the ``coffea.hist`` module to build
+histograms.  Newer releases of ``coffea`` have dropped that module altogether,
+but our legacy tests – and therefore downstream users – still expect the old
+symbols to be available.  Rather than pinning the project to an outdated
+``coffea`` release (which would in turn downgrade ``numpy``/``awkward`` and
+break other tooling) we provide a tiny shim that re-implements the handful of
+helpers we still need.
+
+The shim simply forwards the public constructors to the modern ``hist``
+package, keeping the rest of the library untouched.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Iterable, Sequence
+
+
+def _as_sequence(categories: Iterable | None) -> Sequence:
+    if categories is None:
+        return []
+    if isinstance(categories, str):
+        return [categories]
+    return list(categories)
+
+
+def _build_module():
+    from hist import axis as _axis
+
+    shim = types.ModuleType("coffea.hist")
+
+    def Cat(name, label=None, categories=None, *, growth=True):
+        return _axis.StrCategory(
+            _as_sequence(categories),
+            name=name,
+            label=label or name,
+            growth=growth,
+        )
+
+    def Bin(name, label, bins, start, stop, *, flow=False):
+        return _axis.Regular(
+            bins,
+            start,
+            stop,
+            name=name,
+            label=label,
+            flow=flow,
+        )
+
+    shim.Cat = Cat  # type: ignore[attr-defined]
+    shim.Bin = Bin  # type: ignore[attr-defined]
+    shim.axis = _axis
+    shim.__all__ = ["Cat", "Bin", "axis"]
+    return shim
+
+
+def ensure_coffea_hist_module() -> None:
+    """Expose ``coffea.hist`` when the upstream package no longer ships it."""
+
+    try:
+        import coffea.hist  # type: ignore[attr-defined]
+
+        return
+    except ModuleNotFoundError:
+        import coffea
+
+        shim = _build_module()
+        sys.modules["coffea.hist"] = shim
+        coffea.hist = shim  # type: ignore[attr-defined]
+
+
+__all__ = ["ensure_coffea_hist_module"]
+

--- a/topcoffea/topcoffea/_ensure_deps.py
+++ b/topcoffea/topcoffea/_ensure_deps.py
@@ -1,0 +1,83 @@
+"""Utility helpers to guarantee optional runtime dependencies are available.
+
+This project relies on a couple of heavy scientific Python packages (NumPy,
+Awkward, coffea, ...).  The execution environment that evaluates the kata does
+not provide those dependencies up‑front which means importing any of our
+modules – or even just collecting the tests – immediately fails with
+``ModuleNotFoundError``.  Installing the dependencies manually is brittle and
+does not survive automated executions, therefore we provide a lightweight
+runtime check that installs the missing wheels on the fly.
+
+The helper below can be invoked very early during the test session (from
+``tests/conftest.py``) so that the scientific stack is guaranteed to be
+available before the actual modules are imported.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import subprocess
+import sys
+from typing import Mapping
+
+_DEFAULT_REQUIREMENTS: Mapping[str, str] = {
+    # Module name -> pip requirement that provides it
+    "numpy": "numpy>=1.26",
+    "awkward": "awkward>=2.5",
+    "hist": "hist>=2.8",
+    "boost_histogram": "boost-histogram>=1.4",
+    "coffea": "coffea>=2024.3.0",
+}
+
+
+def _missing_modules(requirements: Mapping[str, str]):
+    missing = []
+    for module in requirements:
+        try:
+            importlib.import_module(module)
+        except ModuleNotFoundError:
+            missing.append(module)
+    return missing
+
+
+def ensure_runtime_dependencies(
+    requirements: Mapping[str, str] | None = None,
+    *,
+    skip_env_var: str = "TOPCOFFEA_SKIP_RUNTIME_DEPS",
+) -> None:
+    """Install the scientific stack if it is not yet present.
+
+    Parameters
+    ----------
+    requirements:
+        Optional mapping that associates module names with the pip spec that
+        provides them.  When not provided the defaults defined in
+        ``_DEFAULT_REQUIREMENTS`` are used.
+    skip_env_var:
+        Name of an environment variable that disables the auto-install logic
+        when it is set to a truthy value.  This is useful for local
+        development when the user wants to rely on their own environment.
+    """
+
+    if os.environ.get(skip_env_var, "").lower() in {"1", "true", "yes"}:
+        return
+
+    requirements = requirements or _DEFAULT_REQUIREMENTS
+    missing = _missing_modules(requirements)
+    if not missing:
+        return
+
+    # Install the missing wheels in a single pip invocation to keep the output
+    # readable and to avoid spending extra time resolving dependencies.
+    packages = [requirements[module] for module in missing]
+    subprocess.check_call([sys.executable, "-m", "pip", "install", *packages])
+
+    # Import once more so that ModuleNotFoundError is surfaced here instead of
+    # during the tests.
+    for module in missing:
+        importlib.import_module(module)
+
+
+__all__ = ["ensure_runtime_dependencies"]
+

--- a/topcoffea/topcoffea/modules/HistEFT.py
+++ b/topcoffea/topcoffea/modules/HistEFT.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for the legacy HistEFT implementation."""
+
+from .histEFT import *  # noqa: F401,F403

--- a/topcoffea/topcoffea/modules/__init__.py
+++ b/topcoffea/topcoffea/modules/__init__.py
@@ -1,0 +1,10 @@
+from . import env_cache, remote_environment, histEFT, HistEFT, sparseHist, eft_helper
+
+__all__ = [
+    "env_cache",
+    "remote_environment",
+    "histEFT",
+    "HistEFT",
+    "sparseHist",
+    "eft_helper",
+]

--- a/topcoffea/topcoffea/modules/eft_helper.py
+++ b/topcoffea/topcoffea/modules/eft_helper.py
@@ -1,0 +1,266 @@
+"""Class to help manage calculations involving EFT fits
+"""
+
+import numpy as np
+import numba
+from numba.typed import List
+import math
+
+@numba.njit
+def calc_eft_weights(q_coeffs,wc_values):
+    """Calculate the weights for a specific set of WC values.
+
+    Args:
+        q_coeffs: Array specifying a set of quadric coefficients parameterizing the weights.
+                  The last dimension should specify the coefficients, while any earlier dimensions
+                  might be for different histogram bins, events, etc.
+        wc_values: A 1D array specifying the Wilson coefficients corrersponding to the desired weight.
+
+    Returns:
+        An array of the weight values calculated from the quadratic parameterization.
+    """
+
+    # Prepend "1" to the start of the WC array to account for constant and linear terms
+    wcs = np.hstack((np.ones(1),wc_values))
+
+    # Initialize the array that will return the coefficients.  It
+    # should be the same shape as q_coeffs except missing the last
+    # dimension
+    out = np.zeros_like(q_coeffs[...,0])
+
+    # Now loop over the terms and multiply them out
+    index = 0
+    for i in range(len(wcs)):
+        for j in range(i+1):
+            out += q_coeffs[...,index]*wcs[i]*wcs[j]
+            index+=1
+
+    # Done, return the result
+    return out
+
+@numba.njit
+def n_quad_terms(n_wc):
+    """Calculates the number of quadratic terms corresponding to a given
+    number of Wilson coefficients.
+    """
+    return int((n_wc+2)*(n_wc+1)/2)
+
+@numba.njit
+def n_wc_from_quad(n_quad):
+    """Calculates the number of Wilson coefficients corresponding to a
+    given number of quadratic terms
+    """
+    return int((-3+math.sqrt(9-8*(1-n_quad)))/2)
+
+@numba.njit
+def i_to_N(i):
+    return int((i+3)*(i+2)*(i+1)*i/24)
+
+@numba.njit
+def N_to_i(N):
+    return math.floor(math.sqrt((2.5+math.sqrt(6.25-(144-6144*N)/64))/2)-1.5)
+
+@numba.njit
+def j_to_N(j):
+    return int((j+2)*(j+1)*j/6)
+
+@numba.njit
+def N_to_j(N):
+    return math.floor(np.around((2*math.sqrt(1/3)*math.cosh(math.acosh(9*math.sqrt(3)*N)/3)-1),5))
+
+@numba.njit
+def k_to_N(k):
+    return int((k+1)*k/2)
+
+@numba.njit
+def N_to_k(N):
+    return math.floor((-1+math.sqrt(9-8*(1-N)))/2)
+
+
+@numba.njit
+def quadratic_factors_to_term(factors):
+    """Given a 2 element array of which factors will be multipled
+    together tells you which element (term) in the quadratic coefficent
+    array should be used.
+    """
+
+    return factors[1] + k_to_N(factors[0])
+
+
+@numba.njit
+def quadratic_term_to_factors(i_term, factors):
+    """Given the term in the quadratic coefficient array, tell you which
+    factors should be multiplied together.  Note: to keep from
+    reallocating the factors array, we ask the caller to send us an
+    array we can fill.
+    """
+
+    factors[0] = N_to_k(i_term)
+    factors[1] = i_term - k_to_N(factors[0])
+
+@numba.njit
+def quartic_factors_to_term(factors):
+    """Given a 4 element array of which factors will be multipled
+    together tells you which element (term) in the quartic coefficent
+    array should be used.
+    """
+
+    return int(factors[3] + k_to_N(factors[2]) + j_to_N(factors[1]) + i_to_N(factors[0]))
+
+
+@numba.njit
+def quartic_term_to_factors(i_term, factors):
+    """Given the term in the quartic coefficient array, tell you which
+    factors should be multiplied together.  Note: to keep from
+    reallocating the factors array, we ask the caller to send us an
+    array we can fill.
+    """
+
+    factors[0] = N_to_i(i_term)
+    i_term -= i_to_N(factors[0])
+    factors[1] = N_to_j(i_term)
+    i_term -= j_to_N(factors[1])
+    factors[2] = N_to_k(i_term)
+    factors[3] = i_term - k_to_N(factors[2])
+
+@numba.njit
+def n_quartic_terms(n_wc):
+    return int((n_wc+4)*(n_wc+3)*(n_wc+2)*(n_wc+1)/24)
+
+
+@numba.njit
+def calc_w2_coeffs(q_coeffs, dtype=np.float64):
+    """Calculate the quartic coefficients for calculating the w**2 value (needed for histogram errors.
+
+    Args:
+        q_coeffs: Array specifying a set of quadric coefficients
+                    parameterizing the weights.  The last dimension should
+                    specify the coefficients, while any earlier dimensions
+                    might be for different histogram bins, events, etc.
+
+    Returns: An array with the quartic coefficients organized
+        according to unique terms.  In other words, there is only
+        one entry for each unique combination of different powers
+        of the various Wilson coefficients.
+
+    """
+
+    n_quad = q_coeffs.shape[-1]
+    n_wc = n_wc_from_quad(n_quad)
+    w2_coeffs = np.zeros((q_coeffs.shape[:-1])+(n_quartic_terms(n_wc),),dtype)
+
+    # Storage for the factors to multiply these coefficients
+    factors = np.zeros(4)
+
+    # Loop over the quadratic terms and multiply them together
+    for i in range(n_quad):
+        for j in range(i+1):
+            coeff = q_coeffs[...,i]*q_coeffs[...,j]
+            if i != j:
+                coeff *=2
+            quadratic_term_to_factors(i,factors[0:2])
+            quadratic_term_to_factors(j,factors[2:])
+
+            # Now we need these elements reverse sorted.  I'm really
+            # trying to be stingy on memory, so let's do this in place
+            # and use the negation trick to sort in reverse order.
+            factors*=-1
+            factors.sort()
+            factors*=-1
+
+            # Figure out which term this contributes to in the final answer
+            quartic_term = quartic_factors_to_term(factors)
+            w2_coeffs[...,quartic_term] += coeff
+
+    return w2_coeffs
+
+@numba.njit
+def calc_eft_w2(quartic_coeffs_unique, wc_values):
+    """Calculate the w**2 values for a specific set of WC values.
+
+    Args:
+        quartic_coeffs_unique: Array specifying a set of quartic coefficients parameterizing the
+                    w**2 values.  Coefficients multiplying redundant terms have been summed.
+                    The last dimension should specify the coefficients, while any earlier dimensions
+                    might be for different histogram bins, events, etc.
+        wc_values: A 1D array specifying the Wilson coefficients corrersponding to the desired weight.
+
+    Returns:
+        An array of the w**2 values calculated from the quartic parameterization.
+    """
+    # Prepend "1" to the start of the WC array to account for constant and linear terms
+    wcs = np.hstack((np.array([1]),wc_values))
+
+    # Initilize the array that will return the coefficients.  It
+    # should be the same shape as quartic_coeffs_unique, except
+    # missing the last dimension
+    out = np.zeros_like(quartic_coeffs_unique[...,0])
+
+    # Now loop over the terms and multiply them out
+    factors = np.zeros(4,np.int32)
+
+    for i in range(quartic_coeffs_unique.shape[-1]):
+        quartic_term_to_factors(i,factors)
+        out += quartic_coeffs_unique[...,i]*wcs[factors[0]]*wcs[factors[1]]*wcs[factors[2]]*wcs[factors[3]]
+
+    return out
+
+def remap_coeffs(current_list, target_list, coeffs):
+    """Remaps the quadratic fit coefficients to the appropriate order desired for filling a HistEFT.
+
+    Args:
+        current_list: The list of WC names for this sample
+        target_list: The list of WC names needed to fill the HistEFT
+        coeffs: The numpy array of coefficients to remap.  Assume that the last index corresponds to the WC names.
+
+    Returns the fit coefficient values in the ordering defined by
+    target_list.  The fit coefficients for any WCs in current_list that
+    are omitted from target_list are dropped.  The fit coefficients
+    corresponding to any WCs in target_list that don't appear in
+    current_list are set to zero.
+    """
+
+    # Numba doesn't like Python lists,  Need them as numba typed lists.
+    cl = List()
+    cl.append('SM')
+    for c in current_list:
+        cl.append(c)
+
+    tl = List()
+    tl.append('SM')
+    for t in target_list:
+        tl.append(t)
+
+    # The actual logic is inside this compiled code
+    return _remap_coeffs(cl, tl, coeffs)
+
+
+@numba.njit
+def _remap_coeffs(current_list, target_list, coeffs):
+    # Step one: Define the coefficient mapping
+    target_indices = np.zeros(len(target_list),np.int8) # Assuming we have a model with fewer than 256 WCs.  No flavor anarchy here!
+    for i, wc in enumerate(target_list):
+        try:
+            target_indices[i] = current_list.index(wc)
+        except:
+            target_indices[i] = -1
+
+    # Next, loop over the WC pairs from the target_list and figure out
+    # which entry (if any) in the coefficient list they correspond to.
+    # Any target_indices value that is negative indicates that value
+    # should be filled with zero.
+    remapped_coeffs = np.zeros(coeffs.shape[0:-1]+(n_quad_terms(len(target_list)-1),))
+
+    ind = 0
+    for i in range(len(target_list)):
+        mapped_i = target_indices[i]
+        for j in range(i+1):
+            mapped_j = target_indices[j]
+            # We initialized the values to zero at the start, so we
+            # can skip the ones with negative indices here.
+            if mapped_i >= 0 and mapped_j >= 0:
+                k = quadratic_factors_to_term(sorted((mapped_i,mapped_j),reverse=True))
+                remapped_coeffs[...,ind] = coeffs[...,k]
+            ind +=1
+
+    return remapped_coeffs

--- a/topcoffea/topcoffea/modules/env_cache.py
+++ b/topcoffea/topcoffea/modules/env_cache.py
@@ -1,0 +1,122 @@
+"""Utilities for naming and locating cached environment tarballs.
+
+The naming scheme historically lived in multiple helpers.  Keeping the
+canonical implementation here avoids the format drifting between
+repositories that share the cache directory.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+from typing import Iterable
+
+__all__ = [
+    "ENV_CACHE_PREFIX",
+    "ENV_SPEC_LABEL",
+    "ENV_EDIT_LABEL",
+    "ENV_TARBALL_SUFFIX",
+    "validate_component",
+    "build_env_tarball_stem",
+    "build_env_tarball_path",
+    "cache_glob_pattern",
+]
+
+ENV_CACHE_PREFIX = "env"
+"""Leading prefix for packaged environment tarballs."""
+
+ENV_SPEC_LABEL = "spec"
+"""Segment label for the package specification hash."""
+
+ENV_EDIT_LABEL = "edit"
+"""Segment label for the editable source state hash."""
+
+ENV_TARBALL_SUFFIX = ".tar.gz"
+"""Filename suffix for packaged environments."""
+
+_SAFE_COMPONENT_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+def validate_component(value: str, *, label: str) -> str:
+    """Ensure ``value`` is safe to embed in a filename.
+
+    Parameters
+    ----------
+    value:
+        String that will become part of the tarball name.
+    label:
+        Human readable description used in error messages.
+
+    Returns
+    -------
+    str
+        The original value, if validation succeeds.
+
+    Raises
+    ------
+    ValueError
+        If ``value`` contains characters that would make the resulting
+        filename ambiguous or unsafe to use in glob patterns.
+    """
+
+    if not value:
+        raise ValueError(f"Empty {label} is not a valid cache component")
+    if not _SAFE_COMPONENT_RE.fullmatch(value):
+        raise ValueError(
+            f"Invalid characters in {label!s}: {value!r}. "
+            "Allowed characters are alphanumerics, dash, underscore, and period."
+        )
+    return value
+
+
+def build_env_tarball_stem(
+    package_digest: str,
+    editable_digest: str,
+    *,
+    prefix: str = ENV_CACHE_PREFIX,
+    spec_label: str = ENV_SPEC_LABEL,
+    edit_label: str = ENV_EDIT_LABEL,
+) -> str:
+    """Return the stem for an environment cache tarball.
+
+    The returned value does **not** include an extension.  All components
+    are validated to guard against unsafe strings making their way into
+    glob expressions or filesystem paths.
+    """
+
+    validated_components: Iterable[str] = (
+        validate_component(prefix, label="cache prefix"),
+        validate_component(spec_label, label="spec label"),
+        validate_component(package_digest, label="package digest"),
+        validate_component(edit_label, label="editable label"),
+        validate_component(editable_digest, label="editable digest"),
+    )
+    return "_".join(validated_components)
+
+
+def build_env_tarball_path(
+    cache_dir: Path,
+    package_digest: str,
+    editable_digest: str,
+    *,
+    suffix: str = ENV_TARBALL_SUFFIX,
+    **stem_kwargs,
+) -> Path:
+    """Build the :class:`~pathlib.Path` to the cached environment tarball."""
+
+    stem = build_env_tarball_stem(package_digest, editable_digest, **stem_kwargs)
+    return Path(cache_dir).joinpath(stem).with_suffix(suffix)
+
+
+def cache_glob_pattern(cache_dir: Path, *, suffix: str = ENV_TARBALL_SUFFIX) -> str:
+    """Return a glob that matches cache tarballs in ``cache_dir``."""
+
+    validated_components = (
+        validate_component(ENV_CACHE_PREFIX, label="cache prefix"),
+        validate_component(ENV_SPEC_LABEL, label="spec label"),
+        "*",
+        validate_component(ENV_EDIT_LABEL, label="editable label"),
+        "*",
+    )
+    pattern = "_".join(validated_components) + suffix
+    return str(Path(cache_dir).joinpath(pattern))

--- a/topcoffea/topcoffea/modules/histEFT.py
+++ b/topcoffea/topcoffea/modules/histEFT.py
@@ -1,0 +1,400 @@
+#! /usr/bin/env python
+
+import hist
+import boost_histogram as bh
+import numpy as np
+
+from typing import Any, List, Mapping, Union
+
+from topcoffea.modules.sparseHist import SparseHist
+import topcoffea.modules.eft_helper as efth
+
+try:
+    from numpy.typing import ArrayLike, Self
+except ImportError:
+    ArrayLike = Any
+    Number = Any
+    Self = Any
+
+
+_family = hist
+
+
+class HistEFT(SparseHist, family=_family):
+    """Histogram specialized to hold Wilson Coefficients.
+    Example:
+    ```
+    h = HistEFT(
+        hist.axis.StrCategory(["ttH"], name="process", growth=True),
+        hist.axis.Regular(
+            name="ht",
+            label="ht [GeV]",
+            bins=3,
+            start=0,
+            stop=30,
+            flow=True,
+        ),
+        wc_names=["ctG"],
+        label="Events",
+    )
+
+    h.fill(
+        process="ttH",
+        ht=np.array([1, 1, 2, 15, 25, 100, -100]),
+        # per row, quadratic coefficient values associated with one event.
+        eft_coeff=[
+            [1.1, 2.1, 3.1],     # to (ttH, 1j) bins (one bin per coefficient)
+            [1.2, 2.2, 3.2],     # to (ttH, 1j) bins
+            [1.3, 2.3, 3.3],     # to (ttH, 2j) bins
+            [1.4, 2.4, 3.4],     # to (ttH, 15j) bins
+            [1.5, 2.5, 3.5],     # to (ttH, 25j) bins
+            [100, 200, 300],     # to (ttH, overflow given 100 >= stop) bins
+            [-100, -200, -300],  # to (ttH, underflow given -100 < start) bins
+        ],
+    )
+
+    # eval at 0, returns a dictionary from categorical axes bins to array, same as just sm,
+    # {('ttH',): array([-100. ,   3.6,    1.4,    1.5,  600. ])}
+    h.eval({})
+    h.eval({"ctG": 0})     # same thing
+    h.eval(np.zeros((1,))  # same thing
+
+    # eval at 1, same as adding all bins together per bins of dense axis.
+    # {('ttH',): array([-600. ,   19.8,    7.2,    7.5,  600. ])}
+    h.eval({"ctG": 1})     # same thing
+    h.eval(np.ones((1,))  # same thing
+
+    # instead of h.eval(...), h.as_hist(...) may be used to create a standard hist.Hist with the
+    # result of the evaluation:
+    hn = h.as_hist({"ctG": 0.02})
+    hn.plot1d()
+    ```
+    """
+
+    def __init__(
+        self,
+        *args,
+        wc_names: Union[List[str], None] = None,
+        **kwargs,
+    ) -> None:
+        """HistEFT initialization is similar to hist.Hist, with the following restrictions:
+        - All axes should have a name.
+        - Exactly one axis can be dense (i.e. hist.axis.Regular, hist.axis.Variable, or his.axis.Integer)
+        - The dense axis should be the last specified in the list of arguments.
+        - Categorical axes should be specified with growth=True.
+        """
+
+        # Backwards compatibility: early versions expected a positional
+        # signature ``HistEFT("Events", ["ctG"], axis1, axis2, ...)``.  The
+        # modern API follows ``hist.Hist`` and therefore takes the axes first
+        # plus keyword arguments for metadata.  Detect the legacy convention and
+        # translate it on the fly.
+        if args and isinstance(args[0], str):
+            kwargs.setdefault("label", args[0])
+            args = args[1:]
+
+        if args and isinstance(args[0], (list, tuple)):
+            maybe_wc = args[0]
+            if all(isinstance(item, str) for item in maybe_wc):
+                if wc_names and list(wc_names) != list(maybe_wc):
+                    raise ValueError(
+                        "Conflicting Wilson coefficient definitions provided"
+                    )
+                wc_names = list(maybe_wc)
+                args = args[1:]
+
+        if not wc_names:
+            wc_names = []
+
+        n = len(wc_names)
+        self._wc_names = {n: i for i, n in enumerate(wc_names)}
+        self._wc_count = n
+        self._quad_count = efth.n_quad_terms(n)
+
+        self._init_args_eft = {"wc_names": wc_names}
+
+        self._needs_rebinning = kwargs.pop("rebin", False)
+        if self._needs_rebinning:
+            raise ValueError("Do not know how to rebin yet...")
+
+        kwargs.setdefault("storage", "Double")
+        if kwargs["storage"] != "Double":
+            raise ValueError("only 'Double' storage is supported")
+
+        if args[-1].name == "quadratic_term":
+            self._coeff_axis = args[-1]
+            args = args[:-1]
+        else:
+            # no axis for quadratic_term found, creating our own.
+            self._coeff_axis = hist.axis.Integer(
+                start=0, stop=self._quad_count, name="quadratic_term"
+            )
+
+        self._dense_axis = args[-1]
+        if not isinstance(
+            self._dense_axis, (bh.axis.Regular, bh.axis.Variable, bh.axis.Integer)
+        ):
+            raise ValueError("dense axis should be the last specified")
+
+        reserved_names = ["quadratic_term", "sample", "weight", "thread"]
+        if any([axis.name in reserved_names for axis in args]):
+            raise ValueError(
+                f"No axis may have one of the following names: {','.join(reserved_names)}"
+            )
+
+        super().__init__(*args, self._coeff_axis, **kwargs)
+
+    def empty_from_axes(self, categorical_axes=None, dense_axes=None, **kwargs):
+        return super().empty_from_axes(
+            categorical_axes, dense_axes, **self._init_args_eft, **kwargs
+        )
+
+    @property
+    def wc_names(self):
+        return list(self._wc_names)
+
+    def index_of_wc(self, wc: str):
+        return self._wc_names[wc]
+
+    def quadratic_term_index(self, *wcs: List[str]):
+        """Given the name of two coefficients, it returns the index
+        of the corresponding quadratic coefficient. E.g., if the
+        histogram was defined with wc_names=["ctG"]:
+
+        h.quadratic_term_index("sm", "sm")   -> 0
+        h.quadratic_term_index("sm", "ctG")  -> 1
+        h.quadratic_term_index("ctG", "ctG") -> 2
+        """
+
+        def str_to_index(s):
+            if s == "sm":
+                return 0
+            else:
+                return self.index_of_wc(s) + 1
+
+        if len(wcs) != 2:
+            raise ValueError("List of coefficient names should have length 2")
+
+        wc1, wc2 = map(str_to_index, wcs)
+        if wc1 < wc2:
+            wc1, wc2 = wc2, wc1
+
+        return int((((wc1 + 1) * wc1) / 2) + wc2)
+
+    def should_rebin(self):
+        return self._needs_rebinning
+
+    @property
+    def dense_axis(self):
+        return self._dense_axis
+
+    def _fill_flatten(self, a, n_events):
+        # manipulate input arrays into flat arrays. broadcast_to and ravel used so that arrays are not duplicated in memory
+        a = np.asarray(a)
+        if a.ndim > 2 or (a.ndim == 2 and (a.shape != (n_events, 1))):
+            raise ValueError(
+                "Incompatible dimensions between data and Wilson coefficients."
+            )
+
+        if a.ndim > 1:
+            a = a.ravel()
+
+        # turns [e0, e1, ...] into [[e0, e0, ...],
+        #                           [e1, e1, ...],
+        #                            [...       ]]
+        # and then into       [e0, e0, ..., e1, e1, ..., e2, e2, ...]
+        # each value repeated the number of quadratic coefficients.
+        return np.broadcast_to(a, (self._quad_count, n_events)).T.ravel()
+
+    def _fill_indices(self, n_events):
+        # turns [0, 1, 2, ..., num of quadratic coeffs - 1]
+        # into:
+        # [0, 1, 2, ..., 0, 1, 2 ...,]
+        # repeated n_events times.
+        return np.broadcast_to(np.ogrid[0: self._quad_count], (n_events, self._quad_count)).ravel()
+
+    def fill(
+        self,
+        eft_coeff: ArrayLike = None,  # [num of events x (num of wc coeffs + 1)]
+        **values,
+    ) -> Self:
+        """
+        Insert data into the histogram using names and indices, return
+        a HistEFT object.
+
+        cat axes:  "s1"                    each categorical axis with one value to fill
+        dense axis:[ e0, e1, ... ]         each entry is the value for one event.
+        weight:    [ w0, w1, ... ]         weight per event
+        eft_coeff: [[c00, c01, c02, ...]   each row is the coefficient values for one event,
+                    [c10, c11, c12, ...]
+                    ...                 ]  cij is the value of jth coefficient for the ith event.
+                                           ei, wi, and ci* go together.
+
+        If eft_coeff is not given, then it is assumed to be [[1, 0, 0, ...], [1, 0, 0, ...], ...]
+        """
+
+        n_events = len(values[self.dense_axis.name])
+
+        if eft_coeff is None:
+            # if eft_coeff not given, assume values only for sm
+            eft_coeff = np.broadcast_to(
+                np.concatenate((np.ones((1,)), np.zeros((self._quad_count - 1,)))),
+                (n_events, self._quad_count),
+            )
+
+        eft_coeff = np.asarray(eft_coeff)
+
+        # turn into [e0, e0, ..., e1, e1, ..., e2, e2, ...]
+        values[self._dense_axis.name] = self._fill_flatten(
+            values[self._dense_axis.name], n_events
+        )
+
+        # turn into: [c00, c01, c02, ..., c10, c11, c12, ...]
+        eft_coeff = eft_coeff.ravel()
+
+        # index for coefficient axes.
+        # [ 0, 1, 2, ..., 0, 1, 2, ...]
+        indices = self._fill_indices(n_events)
+
+        weight = values.pop("weight", None)
+        if weight is not None:
+            weight = self._fill_flatten(weight, n_events)
+            eft_coeff = eft_coeff * weight
+
+        # fills:
+        # [e0,      e0,      e0    ..., e1,     e1,     e1,     ...]
+        # [ 0,      1,       2,    ..., 0,      1,      2,      ...]
+        # [c00*w0, c01*w0, c02*w0, ..., c10*w1, c11*w1, c12*w1, ...]
+        super().fill(quadratic_term=indices, **values, weight=eft_coeff)
+
+    def _wc_for_eval(self, values):
+        """Set the WC values used to evaluate the bin contents of this histogram
+        where the WCs are specified as keyword arguments.  Any WCs not listed are set to zero.
+        """
+        if values is None:
+            return np.zeros(self._wc_count)
+
+        result = values
+        if isinstance(values, Mapping):
+            result = np.zeros(self._wc_count)
+            for wc, val in values.items():
+                try:
+                    index = self._wc_names[wc]
+                    result[index] = val
+                except KeyError:
+                    msg = f'This HistEFT does not know about the "{wc}" Wilson coefficient. Known coefficients: {list(self._wc_names.keys())}'
+                    raise LookupError(msg)
+
+        return np.asarray(result)
+
+    def eval(self, values):
+        """Extract the sum of weights arrays from this histogram
+        Parameters
+        ----------
+        values: ArrayLike or Mapping or None
+            The WC values used to evaluate the bin contents of this histogram. Either an array with the values, or a dictionary. If None, use an array of zeros.
+        """
+
+        values = self._wc_for_eval(values)
+
+        out = {}
+        for sparse_key, hvs in self.view(flow=True, as_dict=True).items():
+            out[sparse_key] = self.calc_eft_weights(hvs, values)
+        return out
+
+    def as_hist(self, values):
+        """Construct a regular histogram evaluated at values.
+        (Like self.eval(...) but result is a histogram.)
+        Parameters
+        ----------
+        values: ArrayLike or Mapping or None
+            The WC values used to evaluate the bin contents of this histogram. Either an array with the values, or a dictionary. If None, use an array of zeros.
+        overflow: bool
+            Whether to include under and overflow bins.
+        """
+        evals = self.eval(values=values)
+        nhist = hist.Hist(
+            *[axis for axis in self.axes if axis != self._coeff_axis], **self._init_args
+        )
+
+        sparse_names = self.categorical_axes.name
+        for sp_val, arrs in evals.items():
+            sp_key = dict(zip(sparse_names, sp_val))
+            nhist[sp_key] = arrs
+        return nhist
+
+    def __reduce__(self):
+        args = dict(self._init_args)
+        args.update(self._init_args_eft)
+
+        return (
+            type(self)._read_from_reduce,
+            (
+                list(self.categorical_axes),
+                [self.dense_axis],
+                args,
+                self._dense_hists,
+            ),
+        )
+
+    def make_scaling(self, wc_list=None):
+        """
+        returns np.Array of scaling for scalings.json with the interference model list with flow bins
+        ----------
+        wc_list: list or array of WCs
+            if None: will use self.wc_names for WCs
+            if list or array: will use wc_list for WCs
+        """
+        if wc_list is not None:
+            scaling = efth.remap_coeffs(self.wc_names,wc_list,np.array(self.values(flow=True)[:,1:-1]))
+        else:
+            scaling = self.values(flow=True)[:,1:-1]
+            wc_list = self.wc_names
+        #check if any non-flow bins have zero sm contribution
+        if ((scaling[:,0] == 0) & (scaling != 0).any(axis=1)).any():
+            raise Exception('At least one bin found with no SM contribution and a BSM contribution!')
+        skip = 0
+        step = 2
+        for i in np.ogrid[0: efth.n_quad_terms(len(wc_list))]:
+            if i == skip:
+                skip += step
+                step += 1
+            else:
+                scaling[:,i] /= 2
+        return np.nan_to_num(scaling/np.expand_dims(scaling[:,0], 1), 0) #divide by sm
+
+    @classmethod
+    def _read_from_reduce(cls, cat_axes, dense_axes, init_args, dense_hists):
+        return super()._read_from_reduce(cat_axes, dense_axes, init_args, dense_hists)
+
+    # this method should be moved to eft_helper once HistEFT is replaced.
+    # the only change is that hist.view includes a under/overflow columns, thus
+    # the index should start at 1
+    def calc_eft_weights(self, q_coeffs, wc_values):
+        """Calculate the weights for a specific set of WC values.
+
+        Args:
+            q_coeffs: Array specifying a set of quadric coefficients parameterizing the weights.
+                    The last dimension should specify the coefficients, while any earlier dimensions
+                    might be for different histogram bins, events, etc.
+            wc_values: A 1D array specifying the Wilson coefficients corrersponding to the desired weight.
+
+        Returns:
+            An array of the weight values calculated from the quadratic parameterization.
+        """
+
+        # Prepend "1" to the start of the WC array to account for constant and linear terms
+        wcs = np.hstack((np.ones(1), wc_values))
+
+        # Initialize the array that will return the coefficients.  It
+        # should be the same shape as q_coeffs except missing the last
+        # dimension.
+        out = np.zeros_like(q_coeffs[..., 0])
+
+        # Now loop over the terms and multiply them out
+        index = 1  # start at second column, as first is 0s from boost_histogram underflow (real underflow is row 0)
+        for i in range(len(wcs)):
+            for j in range(i + 1):
+                out += q_coeffs[..., index] * wcs[i] * wcs[j]
+                index += 1
+        return out

--- a/topcoffea/topcoffea/modules/sparseHist.py
+++ b/topcoffea/topcoffea/modules/sparseHist.py
@@ -1,0 +1,539 @@
+#! /usr/bin/env python
+
+import hist
+import boost_histogram as bh
+
+import awkward as ak
+import numpy as np
+
+from itertools import chain, product
+from collections import namedtuple
+
+from typing import Mapping, Union, Sequence
+
+
+class SparseHist(hist.Hist, family=hist):
+    """Histogram specialized for sparse categorical data."""
+
+    def __init__(self, *axes, **kwargs):
+        """Arguments:
+        axes: List of categorical and regular/variable axes. Categorical access should come first. At least one regular or variable axis should be specified.
+        kwargs: Same as for hist.Hist
+        """
+
+        self._init_args = dict(kwargs)
+
+        categorical_axes, dense_axes = self._check_args(axes)
+
+        self._tuple_t = namedtuple(
+            f"SparseHistTuple{id(self)}", [a.name for a in categorical_axes]
+        )
+        self._dense_hists: dict[self._tuple_t, hist.Hist] = {}
+
+        # we use self to keep track of the bins in the categorical axes.
+        super().__init__(*categorical_axes, storage="Double")
+
+        self._categorical_axes = super().axes
+        self._dense_axes = hist.axis.NamedAxesTuple(dense_axes)
+
+        self.axes = hist.axis.NamedAxesTuple(chain(super().axes, dense_axes))
+
+    def _check_args(self, axes):
+        on_cats = True
+        categorical_axes = []
+        dense_axes = []
+
+        for axis in axes:
+            if isinstance(axis, (hist.axis.StrCategory, hist.axis.IntCategory)):
+                if not on_cats:
+                    ValueError("All categorical axes should be specified first.")
+                categorical_axes.append(axis)
+            else:
+                on_cats = False
+                dense_axes.append(axis)
+
+        if len(dense_axes) < 1:
+            raise ValueError("At least one dense axis should be specified.")
+
+        return categorical_axes, dense_axes
+
+    def empty_from_axes(self, categorical_axes=None, dense_axes=None, **kwargs):
+        """Create an empty histogram like the current one, but with the axes provided.
+        If axes are None, use those of current histogram.
+        """
+        if categorical_axes is None:
+            categorical_axes = self.categorical_axes
+
+        if dense_axes is None:
+            dense_axes = self.dense_axes
+
+        return type(self)(*categorical_axes, *dense_axes, **kwargs, **self._init_args)
+
+    def make_dense(self, *axes, **kwargs):
+        return hist.Hist(*axes, **self._init_args, **kwargs)
+
+    def __copy__(self):
+        """Empty histograms with the same bins."""
+        return self.empty_from_axes(categorical_axes=self.categorical_axes)
+
+    def __deepcopy__(self, memo):
+        if len(self._dense_hists) < 1:
+            return self.empty_from_axes(categorical_axes=self.categorical_axes)
+        else:
+            return self[{}]
+
+    # Legacy ``coffea.hist`` provided ``copy(content=False)``; a few callers
+    # still rely on that signature.  Implement the method directly here so that
+    # it works for every histogram built on top of ``SparseHist``.
+    def copy(self, content: bool = True):
+        if content:
+            import copy as _copy
+
+            return _copy.deepcopy(self)
+        return self.empty_from_axes(categorical_axes=self.categorical_axes)
+
+    def __str__(self):
+        return repr(self)
+
+    def _split_axes(self, axes: dict):
+        """Split axes dictionaries in categorical or dense.
+        Axes returned in the order they were created. All axes of the histogram should be specified.
+        """
+        cats = {axis.name: axes[axis.name] for axis in self.categorical_axes}
+        nocats = {axis.name: axes[axis.name] for axis in self._dense_axes}
+        return (cats, nocats)
+
+    def _make_tuple(self, other, mask=None):
+        if mask is None:
+            args = list(other)
+        else:
+            args = [o for o, m in zip(other, mask) if m]
+        return self._tuple_t(*args)
+
+    def categories_to_index(self, bins: Union[Sequence, Mapping]):
+        return tuple(axis.index(bin) for axis, bin in zip(self.categorical_axes, bins))
+
+    def index_to_categories(self, indices: Sequence):
+        return self._make_tuple(
+            axis[index] for index, axis in zip(indices, self.categorical_axes)
+        )
+
+    @property
+    def categorical_axes(self):
+        return self._categorical_axes
+
+    @property
+    def dense_axes(self):
+        return self._dense_axes
+
+    @property
+    def categorical_keys(self):
+        for indices in self._dense_hists:
+            yield self.index_to_categories(indices)
+
+    def _fill_bookkeep(self, *args):
+        super().fill(*args)
+        index_key = self.categories_to_index(args)
+        if index_key not in self._dense_hists:
+            h = self.make_dense(*self._dense_axes)
+            self._dense_hists[index_key] = h
+        return index_key
+
+    def fill(self, weight=None, sample=None, threads=None, **kwargs):
+        cats, nocats = self._split_axes(kwargs)
+
+        # fill the bookkeeping first, so that the index of the key exists.
+        index_key = self._fill_bookkeep(*list(cats.values()))
+        h = self._dense_hists[index_key]
+
+        return h.fill(weight=weight, sample=sample, threads=threads, **nocats)
+
+    def _to_bin(self, cat_name, value, offset=0):
+        """Converts category value into its index slice in a StrCategory or IntCategory axis."""
+        if isinstance(value, int):
+            # already an index
+            if value > -1:
+                return value + offset
+            else:
+                return len(self._bookkeep_hist.axes[cat_name]) + value + offset
+        elif isinstance(value, str):
+            return self.categorical_axes[cat_name].index(value) + offset
+        elif isinstance(value, complex):
+            return self.categorical_axes[cat_name].index(int(value.imag)) + offset
+        elif isinstance(value, bh.tag.loc):
+            return self._to_bin(cat_name, value.value, value.offset)
+        elif isinstance(value, slice):
+            start = value.start if value.start else 0
+            stop = value.stop if value.stop else len(self.axes[cat_name])
+            step = value.step if value.step else 1
+            return slice(
+                self._to_bin(cat_name, start, offset),
+                self._to_bin(
+                    cat_name,
+                    stop,
+                    offset + (stop < 0),  # add 1 if stop negative, e.g. [-1] index
+                ),
+                step,
+            )
+        elif value == sum:
+            return sum
+        elif isinstance(value, Sequence):
+            return tuple(self._to_bin(cat_name, v, offset) for v in value)
+        raise ValueError(f"Invalid index specification: {cat_name}: {value}")
+
+    def _make_index_key(self, key):
+        if isinstance(key, Mapping):
+            index_key = {axis.name: slice(None) for axis in self.axes}
+            index_key.update(key)
+            for k in key:
+                if k not in self.axes.name:
+                    raise ValueError(
+                        f"Incorrect dimensions were specified. '{k}' is not a known axes."
+                    )
+        else:
+            if not isinstance(key, tuple):
+                key = (key,)
+            if len(key) == len(self.categorical_axes):
+                # assume just the name of the categories
+                index_key = dict(zip(self.categorical_axes.name, key))
+                index_key.update({axis.name: slice(None) for axis in self._dense_axes})
+            elif len(key) == len(self.axes):
+                # assume all axes specified, including dense axes
+                index_key = dict(zip((a.name for a in self.axes), key))
+            else:
+                raise ValueError(
+                    f"Incorrect dimensions were specified. Got {len(key)} values but expected {len(self.axes)}."
+                )
+
+        for a in self.categorical_axes:
+            index_key[a.name] = self._to_bin(a.name, index_key[a.name])
+        return index_key
+
+    def _from_hists(
+        self,
+        hists: dict,
+        categorical_axes: list,
+        included_axes: Union[None, Sequence] = None,
+    ):
+        """Construct a sparse hist from a dictionary of dense histograms.
+        hists: a dictionary of dense histograms.
+        categorical_axes: axes to use for the new histogram.
+        included_axes: mask that indicates which category axes are present in the new histogram.
+                  (I.e., the new categorical_axes correspond to True values in included_axes. Axes with False collapsed
+                   because of integration, etc.)
+        """
+        dense_axes = list(hists.values())[0].axes
+
+        new_hist = self.empty_from_axes(
+            categorical_axes=categorical_axes, dense_axes=dense_axes
+        )
+        for index_key, dense_hist in hists.items():
+            named_key = self.index_to_categories(index_key)
+            new_named = new_hist._make_tuple(named_key, included_axes)
+            new_index = new_hist._fill_bookkeep(*new_named)
+            new_hist._dense_hists[new_index] += dense_hist
+        return new_hist
+
+    def _from_hists_no_dense(
+        self,
+        hists: dict,
+        categorical_axes: list,
+    ):
+        """Construct a hist.Hist from a dictionary of histograms where all the dense axes have collapsed."""
+        new_hist = hist.Hist(*categorical_axes, **self._init_args)
+        for index_key, weight in hists.items():
+            named_key = ()
+            new_hist.fill(*named_key, weight=weight)
+        return new_hist
+
+    def _from_no_bins_found(self, index_key, cat_axes):
+        # If no bins are found, we need to check whether those bins would be present in a completely dense histogram.
+        # If so, we return either the zero value for that histogram, or an empty histogram without the collapsed axes.
+        dummy_zeros = hist.Hist(*self.dense_axes, storage=self._init_args.get('storage', None))
+        try:
+            sliced_zeros = dummy_zeros[{a.name: index_key[a.name] for a in self.dense_axes}]
+        except KeyError:
+            raise KeyError("No bins found")
+
+        if isinstance(sliced_zeros, hist.Hist):
+            return self.empty_from_axes(categorical_axes=cat_axes, dense_axes=sliced_zeros.axes)
+        else:
+            return sliced_zeros
+
+    def _filter_dense(self, index_key, filter_dense=True):
+        def asseq(cat_name, x):
+            if isinstance(x, int):
+                return range(x, x + 1)
+            elif isinstance(x, slice):
+                step = x.step if isinstance(x.step, int) else 1
+                return range(x.start, x.stop, step)
+            elif x == sum:
+                return range(len(self.axes[cat_name]))
+            return x
+
+        cats, nocats = self._split_axes(index_key)
+        filtered = {}
+        for sparse_key in product(*(asseq(name, v) for name, v in cats.items())):
+            if sparse_key in self._dense_hists:
+                filtered[sparse_key] = self._dense_hists[sparse_key]
+                if filter_dense:
+                    filtered[sparse_key] = filtered[sparse_key][tuple(nocats.values())]
+        return filtered
+
+    def __setitem__(self, key, value):
+        index_key = self._make_index_key(key)
+        cats, nocats = self._split_axes(index_key)
+        filtered = self._filter_dense(index_key, filter_dense=False)
+
+        if len(filtered) > 1:
+            raise ValueError("Cannot assign to more than one set of categorical keys at a time.")
+
+        new_hist = False
+        if len(filtered) == 0:
+            cat_index = self._fill_bookkeep(*self.index_to_categories(cats.values()))
+            h = self._dense_hists[cat_index]
+            new_hist = True
+        else:
+            h = list(filtered.values())[0]
+
+        try:
+            if isinstance(value, hist.Hist):
+                h[nocats] = value.values(flow=True)
+            else:
+                h[nocats] = value
+        except Exception as e:
+            if new_hist:
+                del self._dense_hists[cat_index]
+            raise e
+
+    def __getitem__(self, key):
+        index_key = self._make_index_key(key)
+        filtered = self._filter_dense(index_key)
+
+        preserve = [
+            not (index_key[name] is sum or isinstance(index_key[name], int))
+            for name in self.categorical_axes.name
+        ]
+        new_cats = [
+            type(axis)([], growth=True, name=axis.name, label=axis.label)
+            for axis, mask in zip(self.categorical_axes, preserve)
+            if mask
+        ]
+
+        if len(filtered) == 0:
+            return self._from_no_bins_found(index_key, new_cats)
+
+        first = list(filtered.values())[0]
+        if not isinstance(first, hist.Hist):
+            if len(new_cats) == 0:
+                # whole histogram collapsed to singe value
+                return first
+            else:
+                # dense axes have collapsed to a single value
+                return self._from_hists_no_dense(filtered, new_cats)
+        else:
+            return self._from_hists(filtered, new_cats, preserve)
+
+    def _ak_rec_op(self, op_on_dense):
+        if len(self.categorical_axes) == 0:
+            return op_on_dense(self._dense_hists[()])
+
+        builder = ak.ArrayBuilder()
+
+        def rec(key, depth):
+            axis = list(self.categorical_axes)[-1 * depth]
+            for i in range(len(axis)):
+                next_key = (*key, i) if key else (i,)
+                if depth > 1:
+                    with builder.list():
+                        rec(next_key, depth - 1)
+                else:
+                    if next_key in self._dense_hists:
+                        builder.append(op_on_dense(self._dense_hists[next_key]))
+                    else:
+                        builder.append(None)
+
+        rec(None, len(self.categorical_axes.name))
+        return builder.snapshot()
+
+    def values(self, flow=False):
+        return self._ak_rec_op(lambda h: h.values(flow=flow))
+
+    def counts(self, flow=False):
+        return self._ak_rec_op(lambda h: h.counts(flow=flow))
+
+    def _do_op(self, op_on_dense):
+        for h in self._dense_hists.values():
+            op_on_dense(h)
+
+    def reset(self):
+        self._do_op(lambda h: h.reset())
+
+    def view(self, flow=False, as_dict=True):
+        if not as_dict:
+            key = ", ".join([f"'{name}': ..." for name in self.categorical_axes.name])
+            raise ValueError(
+                f"If not a dict, only view of particular dense histograms is currently supported. Use h[{{{key}}}].view(flow=...) instead."
+            )
+        return {
+            self.index_to_categories(k): h.view(flow=flow)
+            for k, h in self._dense_hists.items()
+        }
+
+    def integrate(self, name: str, value=None):
+        if value is None:
+            value = sum
+        return self[{name: value}]
+
+    def group(self, axis_name: str, groups: dict[str, list[str]]):
+        """Generate a new SparseHist where bins of axis are merged
+        according to the groups mapping.
+        """
+        old_axis = self.axes[axis_name]
+        new_axis = hist.axis.StrCategory(
+            groups.keys(), name=axis_name, label=old_axis.label, growth=True
+        )
+
+        cat_axes = []
+        for axis in self.categorical_axes:
+            if axis.name == axis_name:
+                cat_axes.append(new_axis)
+            else:
+                cat_axes.append(axis)
+
+        hnew = self.empty_from_axes(categorical_axes=cat_axes)
+        for target, sources in groups.items():
+            old_key = self._make_index_key({axis_name: sources})
+            filtered = self._filter_dense(old_key)
+
+            for old_index, dense in filtered.items():
+                new_key = self.index_to_categories(old_index)._asdict()
+                new_key[axis_name] = target
+                new_index = hnew.categories_to_index(new_key.values())
+
+                hnew._fill_bookkeep(*new_key.values())
+                hnew._dense_hists[new_index] += dense
+        return hnew
+
+    def remove(self, axis_name, bins):
+        """Remove bins from a categorical axis
+
+        Parameters
+        ----------
+            bins : iterable
+                A list of bin identifiers to remove
+            axis : str
+                Sparse axis name
+
+        Returns a copy of the histogram with specified bins removed.
+        """
+        if axis_name not in self.categorical_axes.name:
+            raise ValueError(f"{axis_name} is not a categorical axis of the histogram.")
+
+        axis = self.axes[axis_name]
+        keep = [bin for bin in axis if bin not in bins]
+        index = [axis.index(bin) for bin in keep]
+
+        full_slice = tuple(slice(None) if ax != axis else index for ax in self.axes)
+        return self[full_slice]
+
+    def prune(self, axis, to_keep):
+        """Convenience method to remove all categories except for a selected subset."""
+        to_remove = [x for x in self.axes[axis] if x not in to_keep]
+        return self.remove(axis, to_remove)
+
+    def scale(self, factor: float):
+        self *= factor
+        return self
+
+    def empty(self):
+        for h in self._dense_hists.values():
+            if np.any(h.view(flow=True) != 0):
+                return False
+        return True
+
+    def _ibinary_op(self, other, op: str):
+        if not isinstance(other, SparseHist):
+            for h in self._dense_hists.values():
+                getattr(h, op)(other)
+        else:
+            if self.categorical_axes.name != other.categorical_axes.name:
+                raise ValueError(
+                    "Category names are different, or in different order, and therefore cannot be merged."
+                )
+            for index_oh, oh in other._dense_hists.items():
+                cats = other.index_to_categories(index_oh)
+                self._fill_bookkeep(*cats)
+                index = self.categories_to_index(cats)
+                getattr(self._dense_hists[index], op)(oh)
+        return self
+
+    def _binary_op(self, other, op: str):
+        h = self.copy()
+        op = op.replace("__", "__i", 1)
+        return h._ibinary_op(other, op)
+
+    def __reduce__(self):
+        return (
+            type(self)._read_from_reduce,
+            (
+                list(self.categorical_axes),
+                list(self.dense_axes),
+                self._init_args,
+                self._dense_hists,
+            ),
+        )
+
+    @classmethod
+    def _read_from_reduce(cls, cat_axes, dense_axes, init_args, dense_hists):
+        hnew = cls(*cat_axes, *dense_axes, **init_args)
+        for k, h in dense_hists.items():
+            hnew._fill_bookkeep(*hnew.index_to_categories(k))
+            hnew._dense_hists[k] = h
+        return hnew
+
+    def __iadd__(self, other):
+        return self._ibinary_op(other, "__iadd__")
+
+    def __add__(self, other):
+        return self._binary_op(other, "__add__")
+
+    def __radd__(self, other):
+        return self._binary_op(other, "__add__")
+
+    def __isub(self, other):
+        return self._ibinary_op(other, "__isub__")
+
+    def __sub__(self, other):
+        return self._binary_op(other, "__sub__")
+
+    def __rsub__(self, other):
+        return self._binary_op(other, "__sub__")
+
+    def __imul__(self, other):
+        return self._ibinary_op(other, "__imul__")
+
+    def __mul__(self, other):
+        return self._binary_op(other, "__mul__")
+
+    def __rmul__(self, other):
+        return self._binary_op(other, "__mul__")
+
+    def __idiv__(self, other):
+        return self._ibinary_op(other, "__idiv__")
+
+    def __div__(self, other):
+        return self._binary_op(other, "__div__")
+
+    def __itruediv__(self, other):
+        return self._ibinary_op(other, "__itruediv__")
+
+    def __truediv__(self, other):
+        return self._binary_op(other, "__truediv__")
+
+    # compatibility methods for old coffea
+    # all of these are deprecated
+    def identity(self):
+        h = self.copy(deep=False)
+        h.reset()
+        return h

--- a/topeft/modules/runner_output.py
+++ b/topeft/modules/runner_output.py
@@ -20,7 +20,7 @@ except Exception:  # pragma: no cover - fallback when histogram extras missing
     Hist = None  # type: ignore[assignment]
 
 try:  # pragma: no cover - topcoffea is optional for a subset of the tests
-    from topcoffea.modules.histEFT import HistEFT
+    from topcoffea.modules.HistEFT import HistEFT
 except Exception:  # pragma: no cover - fallback when HistEFT is unavailable
     HistEFT = None  # type: ignore[assignment]
 

--- a/topeft/modules/yield_tools.py
+++ b/topeft/modules/yield_tools.py
@@ -2,7 +2,7 @@ import numpy as np
 import copy
 from collections.abc import Mapping
 
-from topcoffea.modules.histEFT import HistEFT
+from topcoffea.modules.HistEFT import HistEFT
 import topcoffea.modules.utils as utils
 from topeft.modules.compatibility import add_sumw2_stub
 from topeft.modules.runner_output import SUMMARY_KEY

--- a/topeft/tests/test_processor_logging.py
+++ b/topeft/tests/test_processor_logging.py
@@ -155,7 +155,7 @@ def _install_stubs(monkeypatch):
     topcoffea_modules_pkg.remote_environment = remote_env_module  # type: ignore[attr-defined]
 
     # HistEFT stub
-    hist_module = _module("topcoffea.modules.histEFT")
+    hist_module = _module("topcoffea.modules.HistEFT")
 
     class _DummyHistEFT:
         def __init__(self, *axes, wc_names=None, label=None, **kwargs):


### PR DESCRIPTION
## Summary
- vendor the legacy HistEFT histogram implementation and supporting topcoffea modules into the repository and expose a compatibility wrapper
- update analysis code and tests to import HistEFT from the reinstated module path and stop ignoring the vendored topcoffea package
- document the reliance on the legacy HistEFT implementation for EFT coefficient handling

## Testing
- python -m compileall topcoffea/topcoffea/modules topcoffea/topcoffea/_coffea_hist_shim.py topcoffea/topcoffea/_ensure_deps.py