### PR TITLE
Preserve application metadata in Run2 histogram keys

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -393,6 +393,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                     key_ch,
                     key_sample,
                     syst_label,
+                    application=key_appl,
                 )
 
                 histogram[hist_key] = HistEFT(
@@ -422,6 +423,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                         self._channel,
                         key_sample,
                         syst_label,
+                        application=self._appregion,
                     )
 
                     histogram[sumw2_key] = HistEFT(
@@ -534,9 +536,20 @@ class AnalysisProcessor(processor.ProcessorABC):
         return ch_name, base_ch_name
 
     def _build_histogram_key(
-        self, variable: str, channel: str, sample: str, systematic: str
-    ) -> Tuple[str, str, str, str]:
-        return (variable, channel, sample, systematic)
+        self,
+        variable: str,
+        channel: str,
+        sample: str,
+        systematic: str,
+        application: Optional[str] = None,
+    ) -> Tuple[str, str, str, str, str]:
+        return (
+            variable,
+            channel,
+            application if application is not None else self._appregion,
+            sample,
+            systematic,
+        )
 
     def _build_dataset_context(self, events) -> DatasetContext:
         events_metadata = self._metadata_to_mapping(getattr(events, "metadata", None))
@@ -1975,6 +1988,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                     ch_name,
                     dataset.dataset,
                     hist_variation_label,
+                    application=self._appregion,
                 )
 
                 if histkey not in hout:
@@ -1983,6 +1997,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                         base_ch_name,
                         dataset.dataset,
                         hist_variation_label,
+                        application=self._appregion,
                     )
                     if fallback_histkey not in hout:
                         continue
@@ -2008,6 +2023,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                     base_ch_name,
                     dataset.dataset,
                     hist_variation_label,
+                    application=self._appregion,
                 )
                 if histkey not in hout.keys():
                     continue

--- a/docs/analysis_processing.md
+++ b/docs/analysis_processing.md
@@ -56,7 +56,11 @@ aspects are worth keeping in mind when extending it:
 * **Histogram keys** – the processor accepts either a single 5-tuple or a list
   of tuples per systematic label.  The normalization in the constructor ensures
   that the internal representation always uses ordered tuples, making it safe to
-  extend the histogram planning logic without breaking call sites.
+  extend the histogram planning logic without breaking call sites.  The
+  pickled histograms keep the full ``(variable, channel, application, sample,
+  systematic)`` tuple so downstream data-driven estimation helpers (for
+  example :class:`topeft.modules.dataDrivenEstimation.DataDrivenProducer`)
+  receive the application tag without relying on categorical axes.
 
 Because the constructor performs strict validation (checking for ``None``
 arguments, verifying tuple lengths, etc.), deviations are caught early.  The

--- a/tests/test_flavor_split_histograms.py
+++ b/tests/test_flavor_split_histograms.py
@@ -470,18 +470,21 @@ def test_flavor_split_registers_flavored_histograms(processor):
     base_hist_key = (
         "dummy",
         "3l_p_offZ_1b_2j",
+        "isSR_3l",
         _DATASET_NAME,
         "nominal",
     )
     flavored_hist_key = (
         "dummy",
         "3l_eee_p_offZ_1b_2j",
+        "isSR_3l",
         _DATASET_NAME,
         "nominal",
     )
     base_sumw2_key = (
         "dummy_sumw2",
         "3l_p_offZ_1b_2j",
+        "isSR_3l",
         _DATASET_NAME,
         "nominal",
     )
@@ -526,12 +529,14 @@ def test_histogram_fallback_finds_base_channel(processor):
     histkey = (
         dense_axis_name,
         missing_flavor_channel,
+        processor.appregion,
         dataset_hist,
         hist_variation_label,
     )
     fallback_histkey = (
         dense_axis_name,
         base_ch_name,
+        processor.appregion,
         dataset_hist,
         hist_variation_label,
     )
@@ -548,6 +553,7 @@ def test_histogram_tuple_structure_includes_channel_metadata(processor):
     expected_key = (
         dense_axis_name,
         processor.channel,
+        processor.appregion,
         dataset_hist,
         processor.syst,
     )


### PR DESCRIPTION
## Summary
- ensure Run2 histogram keys preserve the application element when constructing and filling histograms
- update tests and workflow documentation to reflect the five-part histogram key schema used by data-driven estimation

## Testing
- python -m pytest tests/test_flavor_split_histograms.py