### PR TITLE
Preserve application field in estimation histograms

### DIFF
--- a/analysis/flip_measurement/flip_ar_plotter.py
+++ b/analysis/flip_measurement/flip_ar_plotter.py
@@ -24,7 +24,15 @@ def load_histograms(path: str) -> Iterable[TupleHistogramEntry]:
 def group_by_variable(
     entries: Iterable[TupleHistogramEntry],
 ) -> MutableMapping[str, MutableMapping[str, MutableMapping[str, hist.Hist]]]:
-    return summarise_by_variable(entries, systematic="nominal")
+    grouped = summarise_by_variable(
+        entries, systematic="nominal", application="flip_application"
+    )
+    channel_grouped: MutableMapping[str, MutableMapping[str, MutableMapping[str, hist.Hist]]] = {}
+    for variable, application_map in grouped.items():
+        application_histograms = application_map.get("flip_application")
+        if application_histograms:
+            channel_grouped[variable] = application_histograms
+    return channel_grouped
 
 
 def make_fig(

--- a/analysis/flip_measurement/flip_ar_plotter.py
+++ b/analysis/flip_measurement/flip_ar_plotter.py
@@ -34,9 +34,13 @@ def group_by_variable(
         if preferred_histograms and legacy_histograms:
             # Avoid double counting when both tagged and legacy entries are present by
             # preferring the application-specific histograms while keeping samples only
-            # available in the legacy map.
+            # available in the legacy map. Merge per sample to preserve any channels
+            # present only in legacy histograms.
             application_histograms = {**legacy_histograms}
-            application_histograms.update(preferred_histograms)
+            for sample, channel_map in preferred_histograms.items():
+                merged_channels = {**application_histograms.get(sample, {})}
+                merged_channels.update(channel_map)
+                application_histograms[sample] = merged_channels
         else:
             application_histograms = preferred_histograms or legacy_histograms
         if application_histograms:

--- a/analysis/flip_measurement/flip_ar_plotter.py
+++ b/analysis/flip_measurement/flip_ar_plotter.py
@@ -29,7 +29,9 @@ def group_by_variable(
     )
     channel_grouped: MutableMapping[str, MutableMapping[str, MutableMapping[str, hist.Hist]]] = {}
     for variable, application_map in grouped.items():
-        application_histograms = application_map.get("flip_application")
+        application_histograms = application_map.get("flip_application") or application_map.get(
+            ""
+        )
         if application_histograms:
             channel_grouped[variable] = application_histograms
     return channel_grouped

--- a/analysis/flip_measurement/flip_ar_plotter.py
+++ b/analysis/flip_measurement/flip_ar_plotter.py
@@ -33,8 +33,10 @@ def group_by_variable(
         application_histograms: MutableMapping[str, MutableMapping[str, hist.Hist]] | None
         if preferred_histograms and legacy_histograms:
             # Avoid double counting when both tagged and legacy entries are present by
-            # preferring the application-specific histograms.
-            application_histograms = preferred_histograms
+            # preferring the application-specific histograms while keeping samples only
+            # available in the legacy map.
+            application_histograms = {**legacy_histograms}
+            application_histograms.update(preferred_histograms)
         else:
             application_histograms = preferred_histograms or legacy_histograms
         if application_histograms:

--- a/analysis/flip_measurement/flip_ar_plotter.py
+++ b/analysis/flip_measurement/flip_ar_plotter.py
@@ -32,17 +32,9 @@ def group_by_variable(
 
         application_histograms: MutableMapping[str, MutableMapping[str, hist.Hist]] | None
         if preferred_histograms and legacy_histograms:
-            merged: MutableMapping[str, MutableMapping[str, hist.Hist]] = {
-                sample: channel_map.copy() for sample, channel_map in legacy_histograms.items()
-            }
-            for sample, channel_map in preferred_histograms.items():
-                merged_channels = merged.setdefault(sample, {})
-                for channel, histogram in channel_map.items():
-                    existing = merged_channels.get(channel)
-                    merged_channels[channel] = (
-                        existing + histogram if existing is not None else histogram
-                    )
-            application_histograms = merged
+            # Avoid double counting when both tagged and legacy entries are present by
+            # preferring the application-specific histograms.
+            application_histograms = preferred_histograms
         else:
             application_histograms = preferred_histograms or legacy_histograms
         if application_histograms:

--- a/analysis/flip_measurement/flip_ar_processor.py
+++ b/analysis/flip_measurement/flip_ar_processor.py
@@ -398,13 +398,13 @@ class AnalysisProcessor(processor.ProcessorABC):
         return hout
 
     def postprocess(self, accumulator):
-        tuple_entries: Dict[Tuple[str, str, str, str], hist.Hist] = {
+        tuple_entries: Dict[Tuple[str, str, str, str, str], hist.Hist] = {
             key: value
             for key, value in accumulator.items()
-            if isinstance(key, tuple) and len(key) == 4
+            if isinstance(key, tuple) and len(key) == 5
         }
 
-        ordered_entries: "OrderedDict[Tuple[str, str, str, str], hist.Hist]" = OrderedDict(
+        ordered_entries: "OrderedDict[Tuple[str, str, str, str, str], hist.Hist]" = OrderedDict(
             sorted(tuple_entries.items(), key=lambda item: item[0])
         )
 
@@ -427,10 +427,11 @@ class AnalysisProcessor(processor.ProcessorABC):
         variable: str,
         channel: str,
         sample: str,
-    ) -> Tuple[str, str, str, str]:
+    ) -> Tuple[str, str, str, str, str]:
         return (
             variable,
             channel,
+            self._application_region,
             sample,
             self._systematic,
         )

--- a/analysis/flip_measurement/flip_mr_plotter.py
+++ b/analysis/flip_measurement/flip_mr_plotter.py
@@ -51,8 +51,13 @@ def group_by_year(
 
     # Aggregate histograms per sample/flip status first so that duplicate entries
     # for the same tuple accumulate before we project to the year level.
-    variable_map = summarise_by_variable(entries, systematic="nominal")
-    sample_map: MutableMapping[str, MutableMapping[str, hist.Hist]] = variable_map.get("ptabseta", {})
+    variable_map = summarise_by_variable(
+        entries, systematic="nominal", application="flip_measurement"
+    )
+    application_map: MutableMapping[str, MutableMapping[str, MutableMapping[str, hist.Hist]]] = variable_map.get("ptabseta", {})
+    sample_map: MutableMapping[str, MutableMapping[str, hist.Hist]] = application_map.get(
+        "flip_measurement", {}
+    )
 
     for sample, flip_map in sample_map.items():
         year = determine_year(sample)

--- a/analysis/flip_measurement/flip_mr_plotter.py
+++ b/analysis/flip_measurement/flip_mr_plotter.py
@@ -51,12 +51,10 @@ def group_by_year(
 
     # Aggregate histograms per sample/flip status first so that duplicate entries
     # for the same tuple accumulate before we project to the year level.
-    variable_map = summarise_by_variable(
-        entries, systematic="nominal", application="flip_measurement"
-    )
+    variable_map = summarise_by_variable(entries, systematic="nominal", application=None)
     application_map: MutableMapping[str, MutableMapping[str, MutableMapping[str, hist.Hist]]] = variable_map.get("ptabseta", {})
     sample_map: MutableMapping[str, MutableMapping[str, hist.Hist]] = application_map.get(
-        "flip_measurement", {}
+        "flip_measurement", application_map.get("", {})
     )
 
     for sample, flip_map in sample_map.items():

--- a/analysis/flip_measurement/flip_mr_plotter.py
+++ b/analysis/flip_measurement/flip_mr_plotter.py
@@ -51,11 +51,11 @@ def group_by_year(
 
     # Aggregate histograms per sample/flip status first so that duplicate entries
     # for the same tuple accumulate before we project to the year level.
-    variable_map = summarise_by_variable(entries, systematic="nominal", application=None)
-    application_map: MutableMapping[str, MutableMapping[str, MutableMapping[str, hist.Hist]]] = variable_map.get("ptabseta", {})
-    sample_map: MutableMapping[str, MutableMapping[str, hist.Hist]] = application_map.get(
-        "flip_measurement", application_map.get("", {})
+    variable_map = summarise_by_variable(
+        entries, systematic="nominal", application="flip_measurement"
     )
+    application_map: MutableMapping[str, MutableMapping[str, MutableMapping[str, hist.Hist]]] = variable_map.get("ptabseta", {})
+    sample_map: MutableMapping[str, MutableMapping[str, hist.Hist]] = application_map.get("flip_measurement", {})
 
     for sample, flip_map in sample_map.items():
         year = determine_year(sample)

--- a/analysis/flip_measurement/flip_mr_processor.py
+++ b/analysis/flip_measurement/flip_mr_processor.py
@@ -145,13 +145,13 @@ class AnalysisProcessor(processor.ProcessorABC):
         return hout
 
     def postprocess(self, accumulator):
-        tuple_entries: Dict[Tuple[str, str, str, str], hist.Hist] = {
+        tuple_entries: Dict[Tuple[str, str, str, str, str], hist.Hist] = {
             key: value
             for key, value in accumulator.items()
-            if isinstance(key, tuple) and len(key) == 4
+            if isinstance(key, tuple) and len(key) == 5
         }
 
-        ordered_entries: "OrderedDict[Tuple[str, str, str, str], hist.Hist]" = OrderedDict(
+        ordered_entries: "OrderedDict[Tuple[str, str, str, str, str], hist.Hist]" = OrderedDict(
             sorted(tuple_entries.items(), key=lambda item: item[0])
         )
 
@@ -172,10 +172,11 @@ class AnalysisProcessor(processor.ProcessorABC):
         *,
         flipstatus: str,
         sample: str,
-    ) -> Tuple[str, str, str, str]:
+    ) -> Tuple[str, str, str, str, str]:
         return (
             self._variable,
             flipstatus,
+            self._application_region,
             sample,
             self._systematic,
         )

--- a/analysis/flip_measurement/plot_utils.py
+++ b/analysis/flip_measurement/plot_utils.py
@@ -106,7 +106,7 @@ def filter_entries(
     for entry in entries:
         if variable is not None and entry.variable != variable:
             continue
-        if application is not None and entry.application != application:
+        if application is not None and entry.application not in (application, ""):
             continue
         if region is not None and entry.channel != region:
             continue
@@ -166,6 +166,8 @@ def summarise_by_variable(
     for variable, application_map in grouped.items():
         application_mapping: MutableMapping[str, MutableMapping[str, MutableMapping[str, hist.Hist]]] = {}
         for application_name, sample_map in application_map.items():
+            if application is not None and application_name == "":
+                application_name = application
             sample_mapping: MutableMapping[str, MutableMapping[str, hist.Hist]] = {}
             for sample, channel_map in sample_map.items():
                 sample_mapping[sample] = channel_map  # type: ignore[assignment]

--- a/analysis/flip_measurement/run_flip.py
+++ b/analysis/flip_measurement/run_flip.py
@@ -139,7 +139,7 @@ def _summarise_tuple_entries(
 
     tuple_entries: "OrderedDict[TupleKey, Any]" = OrderedDict()
     for key, value in payload.items():
-        if isinstance(key, tuple) and len(key) == 4:
+        if isinstance(key, tuple) and len(key) == 5:
             tuple_entries[key] = value
 
     if not tuple_entries:

--- a/analysis/flip_measurement/run_flip.py
+++ b/analysis/flip_measurement/run_flip.py
@@ -139,7 +139,7 @@ def _summarise_tuple_entries(
 
     tuple_entries: "OrderedDict[TupleKey, Any]" = OrderedDict()
     for key, value in payload.items():
-        if isinstance(key, tuple) and len(key) == 5:
+        if isinstance(key, tuple) and len(key) in (4, 5):
             tuple_entries[key] = value
 
     if not tuple_entries:

--- a/analysis/mc_validation/mc_validation_gen_processor.py
+++ b/analysis/mc_validation/mc_validation_gen_processor.py
@@ -320,8 +320,14 @@ class AnalysisProcessor(processor.ProcessorABC):
         for key, hist_obj in ordered_tuple_entries.items():
             variable = key[0]
             channel = key[1] if len(key) > 1 else ""
-            sample = key[3] if len(key) > 3 else key[2]
-            systematic = key[4] if len(key) > 4 else key[3]
+            if len(key) == 4:
+                # Legacy 4-element tuples: (variable, channel, sample, systematic)
+                sample = key[2]
+                systematic = key[3]
+            else:
+                # New 5-element tuples: (variable, channel, application, sample, systematic)
+                sample = key[3]
+                systematic = key[4]
             label_parts = [sample]
             if channel and channel != self._default_channel:
                 label_parts.append(channel)

--- a/analysis/mc_validation/mc_validation_gen_processor.py
+++ b/analysis/mc_validation/mc_validation_gen_processor.py
@@ -307,7 +307,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         tuple_entries = {
             key: value
             for key, value in accumulator.items()
-            if isinstance(key, tuple) and len(key) == 4
+            if isinstance(key, tuple) and len(key) in (4, 5)
         }
 
         ordered_tuple_entries: "OrderedDict[Tuple[str, str, str, str], HistEFT]" = OrderedDict(
@@ -318,7 +318,10 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         aggregated: Dict[str, Dict[str, HistEFT]] = defaultdict(dict)
         for key, hist_obj in ordered_tuple_entries.items():
-            variable, channel, sample, systematic = key
+            variable = key[0]
+            channel = key[1] if len(key) > 1 else ""
+            sample = key[3] if len(key) > 3 else key[2]
+            systematic = key[4] if len(key) > 4 else key[3]
             label_parts = [sample]
             if channel and channel != self._default_channel:
                 label_parts.append(channel)

--- a/tests/test_flip_plotting.py
+++ b/tests/test_flip_plotting.py
@@ -22,8 +22,20 @@ def _build_histogram(values: np.ndarray) -> Hist:
 
 def test_flip_application_plot_labels():
     payload = {
-        ("observable", "ssz", "SampleA", "nominal"): _build_histogram(np.asarray([0.5, 1.5])),
-        ("observable", "osz", "SampleA", "nominal"): _build_histogram(np.asarray([0.5, 2.5])),
+        (
+            "observable",
+            "ssz",
+            "flip_application",
+            "SampleA",
+            "nominal",
+        ): _build_histogram(np.asarray([0.5, 1.5])),
+        (
+            "observable",
+            "osz",
+            "flip_application",
+            "SampleA",
+            "nominal",
+        ): _build_histogram(np.asarray([0.5, 2.5])),
     }
 
     entries = list(tuple_histogram_entries(payload))

--- a/topeft/modules/yield_tools.py
+++ b/topeft/modules/yield_tools.py
@@ -357,19 +357,30 @@ class YieldTools():
                     raise missing_axis_error
                 raise Exception(f"No histograms found for variable {target_variable!r}")
 
+            query_axis = "sample" if axis == "process" else axis
             metadata_index = {
-                "variable": 0,
-                "channel": 1,
-                "application": 2,
-                "sample": 3,
-                "systematic": 4,
+                5: {
+                    "variable": 0,
+                    "channel": 1,
+                    "application": 2,
+                    "sample": 3,
+                    "systematic": 4,
+                },
+                4: {
+                    "variable": 0,
+                    "channel": 1,
+                    "sample": 2,
+                    "systematic": 3,
+                },
             }
 
-            query_axis = "sample" if axis == "process" else axis
-            if query_axis in metadata_index:
-                idx = metadata_index[query_axis]
+            if any(query_axis in mapping for mapping in metadata_index.values()):
                 values = []
                 for key in sorted(relevant_keys):
+                    mapping = metadata_index.get(len(key), {})
+                    if query_axis not in mapping:
+                        continue
+                    idx = mapping[query_axis]
                     if idx >= len(key):
                         continue
                     entry = key[idx]
@@ -377,7 +388,8 @@ class YieldTools():
                         continue
                     if entry not in values:
                         values.append(entry)
-                return values
+                if values:
+                    return values
 
             representative = tuple_entries[relevant_keys[0]]
             if isinstance(representative, HistEFT) and query_axis in representative.axes.name:

--- a/topeft/modules/yield_tools.py
+++ b/topeft/modules/yield_tools.py
@@ -358,29 +358,18 @@ class YieldTools():
                 raise Exception(f"No histograms found for variable {target_variable!r}")
 
             query_axis = "sample" if axis == "process" else axis
-            metadata_index = {
-                5: {
-                    "variable": 0,
-                    "channel": 1,
-                    "application": 2,
-                    "sample": 3,
-                    "systematic": 4,
-                },
-                4: {
-                    "variable": 0,
-                    "channel": 1,
-                    "sample": 2,
-                    "systematic": 3,
-                },
+            tuple_axis_positions = {
+                5: ("variable", "channel", "application", "sample", "systematic"),
+                4: ("variable", "channel", "sample", "systematic"),
             }
 
-            if any(query_axis in mapping for mapping in metadata_index.values()):
+            if any(query_axis in axes for axes in tuple_axis_positions.values()):
                 values = []
                 for key in sorted(relevant_keys):
-                    mapping = metadata_index.get(len(key), {})
-                    if query_axis not in mapping:
+                    axes = tuple_axis_positions.get(len(key))
+                    if not axes or query_axis not in axes:
                         continue
-                    idx = mapping[query_axis]
+                    idx = axes.index(query_axis)
                     if idx >= len(key):
                         continue
                     entry = key[idx]

--- a/topeft/modules/yield_tools.py
+++ b/topeft/modules/yield_tools.py
@@ -279,7 +279,7 @@ class YieldTools():
                 if isinstance(key, str):
                     if key != "SumOfEFTweights":
                         string_keys.append(key)
-                elif isinstance(key, tuple) and len(key) == 4:
+                elif isinstance(key, tuple) and len(key) in (4, 5):
                     tuple_variables.append(key[0])
             if string_keys:
                 return string_keys
@@ -324,7 +324,7 @@ class YieldTools():
             tuple_entries = {
                 key: value
                 for key, value in hin_dict.items()
-                if isinstance(key, tuple) and len(key) == 4
+                if isinstance(key, tuple) and len(key) in (4, 5)
             }
 
             selected_hist = None
@@ -360,8 +360,9 @@ class YieldTools():
             metadata_index = {
                 "variable": 0,
                 "channel": 1,
-                "sample": 2,
-                "systematic": 3,
+                "application": 2,
+                "sample": 3,
+                "systematic": 4,
             }
 
             query_axis = "sample" if axis == "process" else axis
@@ -369,6 +370,8 @@ class YieldTools():
                 idx = metadata_index[query_axis]
                 values = []
                 for key in sorted(relevant_keys):
+                    if idx >= len(key):
+                        continue
                     entry = key[idx]
                     if entry is None:
                         continue


### PR DESCRIPTION
## Summary
- emit and consume five-field histogram tuple keys (variable, channel, application, sample, systematic) throughout the flip measurement workflow
- update runner output, plotting, and yield utilities to handle application-aware tuples alongside legacy 4-tuples
- add regression coverage ensuring the flip estimation pipeline preserves application-region identifiers

## Testing
- python -m pytest tests/test_run_flip_output.py tests/test_flip_plotting.py