### PR TITLE
Preserve application labels in tuple plotting utilities

### DIFF
--- a/analysis/mc_validation/mc_validation_gen_plotter.py
+++ b/analysis/mc_validation/mc_validation_gen_plotter.py
@@ -23,6 +23,7 @@ if str(PROJECT_ROOT) not in sys.path:
 
 from analysis.mc_validation.plot_utils import (  # noqa: E402
     build_dataset_histograms,
+    component_labels,
     component_values,
     tuple_histogram_items,
 )
@@ -55,13 +56,15 @@ def make_mc_validation_plots(dict_of_hists,year,skip_syst_errs,save_dir_path):
     if using_tuple_entries:
         vars_lst = sorted(rebuilt_hists.keys())
         sample_lst = component_values(tuple_entries, "sample")
+        sample_labels = component_labels(tuple_entries, "sample", include_application=True)
         dataset_axis_name = "dataset"
     else:
         vars_lst = yt.get_hist_list(dict_of_hists)
         sample_lst = yt.get_cat_lables(dict_of_hists, "sample")
+        sample_labels = sample_lst
         dataset_axis_name = "sample"
 
-    print("\nSamples:",sample_lst)
+    print("\nSamples:",sample_labels)
     print("\nVariables:",vars_lst)
 
     comp_proc_dict = {

--- a/analysis/mc_validation/mc_validation_plotter.py
+++ b/analysis/mc_validation/mc_validation_plotter.py
@@ -22,6 +22,7 @@ if str(PROJECT_ROOT) not in sys.path:
 
 from analysis.mc_validation.plot_utils import (  # noqa: E402
     build_dataset_histograms,
+    component_labels,
     component_values,
     tuple_histogram_items,
 )
@@ -111,17 +112,21 @@ def make_mc_validation_plots(dict_of_hists,year,skip_syst_errs,save_dir_path):
     if using_tuple_entries:
         vars_lst = sorted(rebuilt_hists.keys())
         sample_lst = component_values(tuple_entries, "sample")
+        sample_labels = component_labels(tuple_entries, "sample", include_application=True)
         cat_lst = component_values(tuple_entries, "channel")
+        cat_labels = component_labels(tuple_entries, "channel", include_application=True)
         dataset_axis_name = "dataset"
     else:
         vars_lst = yt.get_hist_list(dict_of_hists)
         sample_lst = yt.get_cat_lables(dict_of_hists,"sample")
+        sample_labels = sample_lst
         cat_lst = yt.get_cat_lables(dict_of_hists,"channel")
+        cat_labels = cat_lst
         dataset_axis_name = "sample"
 
-    print("\nSamples:",sample_lst)
+    print("\nSamples:",sample_labels)
     print("\nVariables:",vars_lst)
-    print("\nChannels:",cat_lst)
+    print("\nChannels:",cat_labels)
 
     # Get the dictionary of histograms that we want to group together in the plots
     # This is way more hard coded than it probably should be


### PR DESCRIPTION
## Summary
- add helpers to extract normalized labels and filter tuple-keyed histograms while keeping application regions
- rebuild dataset histograms with application axes and surface application tags in mc validation plotters and flip AR legends
- extend mc validation plot utility tests to cover application-aware labeling and filtering

## Testing
- python -m pytest (fails: topcoffea.modules.HistEFT missing in environment)
- python -m pytest tests/test_mc_validation_plot_utils.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c95753b708323bf5ef30b91cc4a4d)