### PR TITLE
Enforce 5-tuple histogram keys for flip and data-driven outputs

### DIFF
--- a/tests/test_flip_plotting.py
+++ b/tests/test_flip_plotting.py
@@ -41,9 +41,10 @@ def test_flip_application_plot_labels():
     entries = list(tuple_histogram_entries(payload))
     grouped = flip_ar_plotter.group_by_variable(entries)
 
-    histograms = grouped["observable"]["SampleA"]
-    ssz_label = flip_ar_plotter.build_channel_label("SampleA", "ssz")
-    osz_label = flip_ar_plotter.build_channel_label("SampleA", "osz")
+    sample_label = "SampleA (flip_application)"
+    histograms = grouped["observable"][sample_label]
+    ssz_label = flip_ar_plotter.build_channel_label(sample_label, "ssz")
+    osz_label = flip_ar_plotter.build_channel_label(sample_label, "osz")
 
     fig = flip_ar_plotter.make_fig(
         histograms["ssz"],

--- a/tests/test_tuple_key_pickles.py
+++ b/tests/test_tuple_key_pickles.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import cloudpickle
+import gzip
+
+import pytest
+from hist import Hist, axis, storage
+
+from analysis.flip_measurement.plot_utils import load_tuple_histogram_entries
+from topeft.modules.dataDrivenEstimation import _validate_tuple_histograms
+
+
+def _write_payload(tmp_path, payload):
+    out = tmp_path / "payload.pkl.gz"
+    with gzip.open(out, "wb") as fout:
+        cloudpickle.dump(payload, fout)
+    return out
+
+
+def _basic_hist():
+    histogram = Hist(axis.Regular(2, 0.0, 2.0, name="var"), storage=storage.Double())
+    histogram.fill(var=[0.5, 1.5])
+    return histogram
+
+
+def test_tuple_histogram_entries_require_application(tmp_path):
+    histogram = _basic_hist()
+    payload = {
+        ("var", "chan", None, "sample", "nominal"): histogram,
+    }
+    path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match="application region"):
+        list(load_tuple_histogram_entries(str(path)))
+
+
+def test_tuple_histogram_entries_reject_legacy_keys(tmp_path):
+    histogram = _basic_hist()
+    payload = {
+        ("var", "chan", "sample", "nominal"): histogram,
+    }
+    path = _write_payload(tmp_path, payload)
+
+    with pytest.raises(ValueError, match="5-tuples"):
+        list(load_tuple_histogram_entries(str(path)))
+
+
+def test_tuple_histogram_entries_accept_application_tag(tmp_path):
+    histogram = _basic_hist()
+    payload = {
+        ("var", "chan", "isAR", "sample", "nominal"): histogram,
+        "meta": {"note": "representative"},
+    }
+    path = _write_payload(tmp_path, payload)
+
+    entries = list(load_tuple_histogram_entries(str(path)))
+    assert entries
+    assert all(entry.application == "isAR" for entry in entries)
+    assert all(entry.sample == "sample" for entry in entries)
+
+
+def test_data_driven_validator_requires_application(tmp_path):
+    payload = {
+        ("var", "chan", "", "sample", "nominal"): object(),
+    }
+    path = _write_payload(tmp_path, payload)
+    with gzip.open(path, "rb") as fin:
+        loaded = cloudpickle.load(fin)
+
+    with pytest.raises(ValueError, match="application region"):
+        _validate_tuple_histograms(loaded)

--- a/topeft/modules/dataDrivenEstimation.py
+++ b/topeft/modules/dataDrivenEstimation.py
@@ -9,6 +9,25 @@ from topeft.modules.paths import topeft_path
 from topcoffea.modules.get_param_from_jsons import GetParam
 get_te_param = GetParam(topeft_path("params/params.json"))
 
+
+def _validate_tuple_histograms(hist_map):
+    """Ensure histogram mappings carry 5-tuple identifiers with application tags."""
+
+    if not hasattr(hist_map, "keys"):
+        raise TypeError("Histogram container must implement .keys()")
+
+    for key in hist_map.keys():
+        if key == "meta":
+            continue
+        if not isinstance(key, tuple):
+            continue
+        if len(key) != 5:
+            raise ValueError(
+                "Histogram keys must be 5-tuples of (variable, channel, application, sample, systematic)"
+            )
+        if key[2] in (None, ""):
+            raise ValueError(f"Histogram key {key!r} is missing an application region")
+
 def hist_remove(histo, axis, lst):
     if axis == "channel":
         index = 1
@@ -152,6 +171,7 @@ class DataDrivenProducer:
             self.inhist=utils.get_hist_from_pkl(inputHist)
         else: # we already have the histogram
             self.inhist=inputHist
+        _validate_tuple_histograms(self.inhist)
         self.outputName=outputName
         self.verbose=False
         self.dataName='data'


### PR DESCRIPTION
## Summary
- require 5-tuple histogram keys with application regions in the flip plotting utilities and data-driven estimation code
- adjust flip plotting expectations to carry application-tagged sample labels
- add regression tests that load tuple-keyed pickles to check application coverage

## Testing
- pytest tests/test_tuple_key_pickles.py tests/test_flip_plotting.py tests/test_run_flip_output.py