### PR TITLE
Enforce 5-tuple histogram inputs in MC validation utilities

### DIFF
--- a/analysis/mc_validation/mc_validation_gen_plotter.py
+++ b/analysis/mc_validation/mc_validation_gen_plotter.py
@@ -25,7 +25,7 @@ from analysis.mc_validation.plot_utils import (  # noqa: E402
     build_dataset_histograms,
     component_labels,
     component_values,
-    tuple_histogram_items,
+    require_tuple_histogram_items,
 )
 
 
@@ -49,20 +49,13 @@ def save_pkl_for_arr(sf_arr,tag):
 
 # Main wrapper script for making the private vs central comparison plots
 def make_mc_validation_plots(dict_of_hists,year,skip_syst_errs,save_dir_path):
-    tuple_entries = tuple_histogram_items(dict_of_hists)
-    using_tuple_entries = bool(tuple_entries)
-    rebuilt_hists = build_dataset_histograms(dict_of_hists) if using_tuple_entries else {}
+    tuple_entries = require_tuple_histogram_items(dict_of_hists)
+    rebuilt_hists = build_dataset_histograms(dict_of_hists)
 
-    if using_tuple_entries:
-        vars_lst = sorted(rebuilt_hists.keys())
-        sample_lst = component_values(tuple_entries, "sample")
-        sample_labels = component_labels(tuple_entries, "sample", include_application=True)
-        dataset_axis_name = "dataset"
-    else:
-        vars_lst = yt.get_hist_list(dict_of_hists)
-        sample_lst = yt.get_cat_lables(dict_of_hists, "sample")
-        sample_labels = sample_lst
-        dataset_axis_name = "sample"
+    vars_lst = sorted(rebuilt_hists.keys())
+    sample_lst = component_values(tuple_entries, "sample")
+    sample_labels = component_labels(tuple_entries, "sample", include_application=True)
+    dataset_axis_name = "dataset"
 
     print("\nSamples:",sample_labels)
     print("\nVariables:",vars_lst)

--- a/analysis/mc_validation/mc_validation_plotter.py
+++ b/analysis/mc_validation/mc_validation_plotter.py
@@ -24,7 +24,7 @@ from analysis.mc_validation.plot_utils import (  # noqa: E402
     build_dataset_histograms,
     component_labels,
     component_values,
-    tuple_histogram_items,
+    require_tuple_histogram_items,
 )
 
 
@@ -105,24 +105,15 @@ def get_missing_parton_sf_dict(per_jet_bin=True):
 
 # Main wrapper script for making the private vs central comparison plots
 def make_mc_validation_plots(dict_of_hists,year,skip_syst_errs,save_dir_path):
-    tuple_entries = tuple_histogram_items(dict_of_hists)
-    using_tuple_entries = bool(tuple_entries)
-    rebuilt_hists = build_dataset_histograms(dict_of_hists) if using_tuple_entries else {}
+    tuple_entries = require_tuple_histogram_items(dict_of_hists)
+    rebuilt_hists = build_dataset_histograms(dict_of_hists)
 
-    if using_tuple_entries:
-        vars_lst = sorted(rebuilt_hists.keys())
-        sample_lst = component_values(tuple_entries, "sample")
-        sample_labels = component_labels(tuple_entries, "sample", include_application=True)
-        cat_lst = component_values(tuple_entries, "channel")
-        cat_labels = component_labels(tuple_entries, "channel", include_application=True)
-        dataset_axis_name = "dataset"
-    else:
-        vars_lst = yt.get_hist_list(dict_of_hists)
-        sample_lst = yt.get_cat_lables(dict_of_hists,"sample")
-        sample_labels = sample_lst
-        cat_lst = yt.get_cat_lables(dict_of_hists,"channel")
-        cat_labels = cat_lst
-        dataset_axis_name = "sample"
+    vars_lst = sorted(rebuilt_hists.keys())
+    sample_lst = component_values(tuple_entries, "sample")
+    sample_labels = component_labels(tuple_entries, "sample", include_application=True)
+    cat_lst = component_values(tuple_entries, "channel")
+    cat_labels = component_labels(tuple_entries, "channel", include_application=True)
+    dataset_axis_name = "dataset"
 
     print("\nSamples:",sample_labels)
     print("\nVariables:",vars_lst)

--- a/analysis/mc_validation/plot_utils.py
+++ b/analysis/mc_validation/plot_utils.py
@@ -70,6 +70,17 @@ def tuple_histogram_items(hist_store: Mapping[Any, Any]) -> Dict[TupleKey, Any]:
     return entries
 
 
+def require_tuple_histogram_items(hist_store: Mapping[Any, Any]) -> Dict[TupleKey, Any]:
+    """Return tuple-keyed histogram entries or raise if none are present."""
+
+    entries = tuple_histogram_items(hist_store)
+    if not entries:
+        raise ValueError(
+            "Histogram payload must contain 5-tuple keys: (variable, channel, application, sample, systematic)"
+        )
+    return entries
+
+
 def component_values(tuple_entries: Mapping[TupleKey, Any], component: str) -> Sequence[str]:
     """Return sorted unique values for *component* within *tuple_entries*."""
 
@@ -259,6 +270,7 @@ __all__ = [
     "component_labels",
     "component_values",
     "filter_tuple_histograms",
+    "require_tuple_histogram_items",
     "tuple_histogram_items",
 ]
 

--- a/tests/test_mc_validation_plot_utils.py
+++ b/tests/test_mc_validation_plot_utils.py
@@ -1,8 +1,10 @@
-import gzip
 from pathlib import Path
+import gzip
 
 import cloudpickle
+
 import numpy as np
+import pytest
 from hist import Hist, axis, storage
 
 from analysis.mc_validation.plot_utils import (
@@ -10,6 +12,7 @@ from analysis.mc_validation.plot_utils import (
     component_labels,
     component_values,
     filter_tuple_histograms,
+    require_tuple_histogram_items,
     tuple_histogram_items,
 )
 
@@ -118,4 +121,16 @@ def test_filter_tuple_histograms_supports_application_component():
 
     filtered = filter_tuple_histograms(tuple_entries, application="appA")
     assert set(filtered.keys()) == {("observable", "chan", "appA", "sampleA", "nominal")}
+
+
+def test_require_tuple_histogram_items_rejects_legacy_keys():
+    hist_store = {("observable", "channel", "sample", "nominal"): _constant_histogram(1.0)}
+
+    with pytest.raises(ValueError):
+        require_tuple_histogram_items(hist_store)
+
+
+def test_require_tuple_histogram_items_rejects_missing_tuple_entries():
+    with pytest.raises(ValueError):
+        require_tuple_histogram_items({"not_a_tuple": _constant_histogram(1.0)})
 


### PR DESCRIPTION
## Summary
- require tuple-keyed histogram payloads with application-aware labels in MC validation plotters
- add a helper to enforce five-element histogram keys and surface errors when missing
- extend MC validation plot utility tests to reject legacy 4-tuple payloads

## Testing
- python -m pytest tests/test_mc_validation_plot_utils.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ca6e5e0c883239ee3f1aa9a76d5bc)