### PR TITLE
Fix CR/SR plotter imports and document topcoffea setup

### DIFF
--- a/analysis/topeft_run2/README.md
+++ b/analysis/topeft_run2/README.md
@@ -120,9 +120,11 @@ This directory contains scripts for the Full Run 2 EFT analysis. This README doc
 ### Scripts for finding, comparing and plotting yields from histograms (from the processor)
 
 * `make_cr_and_sr_plots.py`:
-    - This script makes plots for all CRs categories, also has the ability to make SR plots. 
-    - The script takes as input a pkl file that should have both data and background MC included.
-    - Example usage: `python make_cr_plots.py -f histos/your.pkl.gz -o ~/www/some/dir -n some_dir_name -y 2018 -t -u`
+    - This script makes plots for all CRs categories and can also make SR plots.
+    - The script takes as input the 5-tuple histogram pickle produced by the current topcoffea runners (e.g. TaskVine output that has both data and background MC).
+    - Ensure the bundled `topcoffea` source is on `PYTHONPATH` (or install it once with `pip install -e ./topcoffea` from the repo root) before running the plotter so `topcoffea.modules` imports resolve.
+    - Example usage (smoke test with TaskVine-style output): `python make_cr_and_sr_plots.py -f /path/to/taskvine/output/plotsTopEFT.pkl.gz -o /tmp/cr_sr_smoke -n plots -y 2018 --skip-syst`
+    - See `examples/run_make_cr_and_sr_plots_smoke.sh` for a ready-to-run wrapper that expects an existing runner output pickle.
 
 * `get_yield_json.py`:
     - This script takes a pkl file produced by the processor, finds the yields in the analysis categories, and saves the yields to a json file. It can also print the info to the screen. The default pkl file to process is `hists/plotsTopEFT.pkl.gz`.

--- a/analysis/topeft_run2/examples/run_make_cr_and_sr_plots_smoke.sh
+++ b/analysis/topeft_run2/examples/run_make_cr_and_sr_plots_smoke.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+cd "${PROJECT_ROOT}"
+
+export PYTHONPATH="${PROJECT_ROOT}:${PROJECT_ROOT}/topcoffea:${PYTHONPATH:-}"
+
+PKL_PATH=${1:-"${PROJECT_ROOT}/example_outputs_taskvine/plotsTopEFT.pkl.gz"}
+OUTDIR=$(mktemp -d -t cr_sr_plots_XXXX)
+
+if [[ ! -f "${PKL_PATH}" ]]; then
+  echo "Expected a TaskVine/topcoffea 5-tuple histogram pickle at ${PKL_PATH}." >&2
+  echo "Pass the pickle path explicitly if it lives elsewhere." >&2
+  exit 1
+fi
+
+echo "Using histogram pickle: ${PKL_PATH}" >&2
+python make_cr_and_sr_plots.py \
+  -f "${PKL_PATH}" \
+  -o "${OUTDIR}" \
+  -n taskvine_smoke \
+  -y 2018 \
+  --skip-syst
+
+echo "Plots written to ${OUTDIR}" >&2


### PR DESCRIPTION
## Summary
- ensure the CR/SR plotter promotes the repository and sibling topcoffea paths and dynamically resolves the HistEFT module
- extend the plotter to search the sibling topcoffea package for scripts while keeping the bundled HistEFT implementation
- document the required topcoffea installation/PYTHONPATH setup and export it in the smoke-test wrapper

## Testing
- python analysis/topeft_run2/make_cr_and_sr_plots.py --help