### PR TITLE
Add deferred data driven helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ wget -nc http://www.crc.nd.edu/~kmohrman/files/root_files/for_ci/ttHJet_UL17_R1B
 python run_analysis.py ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json -x futures
 
 ```
+If you ran with `--np-postprocess=defer` you can later finalize the nonprompt (and optional flips-only) histograms without rerunning the full processor. The helper below accepts either the metadata json that `run_analysis.py` writes or explicit CLI paths:
+
+```
+python analysis/topeft_run2/run_data_driven.py --metadata-json histos/plotsTopEFT_np.pkl.gz.metadata.json \
+    --apply-renormfact-envelope
+```
+
+When no metadata file is supplied, specify `--input-pkl` and (optionally) `--output-pkl` directly.
 To make use of distributed resources, the `work queue` executor can be used. To use the work queue executor, just change the executor option to  `-x work_queue` and run the run script as before. Next, you will need to request some workers to execute the tasks on the distributed resources. Please note that the workers must be submitted from the same environment that you are running the run script from (so this will usually mean you want to activate the env in another terminal, and run the `condor_submit_workers` command from there. Here is an example `condor_submit_workers` command (remembering to activate the env prior to running the command):
 ```
 conda activate coffea-env

--- a/analysis/topeft_run2/run_data_driven.py
+++ b/analysis/topeft_run2/run_data_driven.py
@@ -107,7 +107,7 @@ def _maybe_filter_to_flips(hist_dict: MutableMapping[str, Any]) -> MutableMappin
     filtered: Dict[str, Any] = {}
     for key, histo in hist_dict.items():
         filtered[key] = histo
-        if not histo:
+        if histo is None:
             continue
         process_axis: Optional[Iterable[str]] = None
         try:

--- a/analysis/topeft_run2/run_data_driven.py
+++ b/analysis/topeft_run2/run_data_driven.py
@@ -94,15 +94,8 @@ def _resolve_path(
     if not metadata_value:
         return None
     if metadata_dir and not os.path.isabs(metadata_value):
-        metadata_value_norm = os.path.normpath(metadata_value)
-        metadata_dir_base = os.path.basename(metadata_dir)
-        if metadata_dir_base and (
-            metadata_value_norm == metadata_dir_base
-            or metadata_value_norm.startswith(f"{metadata_dir_base}{os.sep}")
-        ):
-            return metadata_value_norm
         return os.path.normpath(os.path.join(metadata_dir, metadata_value))
-    return metadata_value
+    return os.path.normpath(metadata_value)
 
 
 def _validate_input_path(input_path: str) -> None:

--- a/analysis/topeft_run2/run_data_driven.py
+++ b/analysis/topeft_run2/run_data_driven.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Standalone helper to build data driven histograms from saved metadata."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Any, Dict, Iterable, List, MutableMapping, Optional
+
+import topcoffea.modules.utils as utils
+
+from topeft.modules.dataDrivenEstimation import DataDrivenProducer
+from topeft.modules.get_renormfact_envelope import get_renormfact_envelope
+
+
+def _build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Finalize deferred nonprompt/flips histograms using the metadata emitted "
+            "by run_analysis.py."
+        )
+    )
+    parser.add_argument(
+        "--metadata-json",
+        help=(
+            "Path to the metadata file created by run_analysis.py when using "
+            "--np-postprocess=defer."
+        ),
+    )
+    parser.add_argument(
+        "--input-pkl",
+        help="Path to the histogram pickle emitted by run_analysis.py (pre data-driven step).",
+    )
+    parser.add_argument(
+        "--output-pkl",
+        help="Destination for the histogram pickle with data-driven contributions applied.",
+    )
+    parser.add_argument(
+        "--apply-renormfact-envelope",
+        action="store_true",
+        help="Also run the renorm/fact envelope step on the output histogram.",
+    )
+    parser.add_argument(
+        "--only-flips",
+        action="store_true",
+        help="Drop nonprompt processes so only flips contributions remain in the output histograms.",
+    )
+    return parser
+
+
+def _load_metadata(metadata_path: str) -> Dict[str, Any]:
+    if not os.path.exists(metadata_path):
+        raise FileNotFoundError(f"Metadata file not found: {metadata_path}")
+    with open(metadata_path) as metadata_stream:
+        payload = json.load(metadata_stream)
+    version = payload.get("metadata_version")
+    if version != 1:
+        raise ValueError(
+            f"Unsupported metadata schema version {version!r}. Expected version 1 metadata."
+        )
+    resolved_years = payload.get("resolved_years")
+    sample_years = payload.get("sample_years")
+    if resolved_years and sample_years:
+        resolved_set = set(resolved_years)
+        sample_set = set(sample_years)
+        missing = resolved_set - sample_set
+        if missing:
+            raise ValueError(
+                "Metadata contains requested years that are not present in the samples: "
+                f"{sorted(missing)}"
+            )
+    return payload
+
+
+def _default_output_path(input_path: str) -> str:
+    if input_path.endswith(".pkl.gz"):
+        base = input_path[:-7]
+    elif input_path.endswith(".pkl"):
+        base = input_path[:-4]
+    else:
+        base = input_path
+    return f"{base}_np.pkl.gz"
+
+
+def _resolve_path(arg_value: Optional[str], metadata_value: Optional[str]) -> Optional[str]:
+    return arg_value if arg_value else metadata_value
+
+
+def _validate_input_path(input_path: str) -> None:
+    if not os.path.exists(input_path):
+        raise FileNotFoundError(f"Histogram pickle not found: {input_path}")
+
+
+def _maybe_filter_to_flips(hist_dict: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
+    filtered: Dict[str, Any] = {}
+    for key, histo in hist_dict.items():
+        filtered[key] = histo
+        if not histo:
+            continue
+        process_axis: Optional[Iterable[str]] = None
+        try:
+            process_axis = list(histo.axes["process"])  # type: ignore[index]
+        except Exception:
+            process_axis = None
+        if not process_axis:
+            continue
+        flips = [proc for proc in process_axis if "flips" in proc.lower()]
+        if not flips:
+            continue
+        to_remove = [proc for proc in process_axis if proc not in flips]
+        if not to_remove:
+            continue
+        if not hasattr(histo, "remove"):
+            continue
+        filtered[key] = histo.remove("process", to_remove)
+    return filtered
+
+
+def _finalize_histograms(
+    input_pkl: str,
+    output_pkl: str,
+    *,
+    only_flips: bool,
+    apply_envelope: bool,
+) -> None:
+    ddp = DataDrivenProducer(input_pkl, output_pkl)
+    histograms = ddp.getDataDrivenHistogram()
+    if only_flips:
+        histograms = _maybe_filter_to_flips(histograms)
+    if apply_envelope:
+        histograms = get_renormfact_envelope(histograms)
+    os.makedirs(os.path.dirname(output_pkl) or ".", exist_ok=True)
+    utils.dump_to_pkl(output_pkl, histograms)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = _build_argument_parser()
+    args = parser.parse_args(argv)
+
+    metadata: Dict[str, Any] = {}
+    if args.metadata_json:
+        metadata = _load_metadata(args.metadata_json)
+        if not metadata.get("do_np", True):
+            raise ValueError(
+                "Metadata indicates nonprompt estimation was disabled (do_np=False). Nothing to do."
+            )
+
+    input_pkl = _resolve_path(args.input_pkl, metadata.get("input_histogram"))
+    if not input_pkl:
+        raise ValueError("Input histogram path must be provided via --input-pkl or the metadata file.")
+    _validate_input_path(input_pkl)
+
+    output_pkl = _resolve_path(args.output_pkl, metadata.get("output_histogram"))
+    if not output_pkl:
+        output_pkl = _default_output_path(input_pkl)
+
+    _finalize_histograms(
+        input_pkl,
+        output_pkl,
+        only_flips=args.only_flips,
+        apply_envelope=args.apply_renormfact_envelope,
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/analysis/topeft_run2/run_data_driven.py
+++ b/analysis/topeft_run2/run_data_driven.py
@@ -94,6 +94,13 @@ def _resolve_path(
     if not metadata_value:
         return None
     if metadata_dir and not os.path.isabs(metadata_value):
+        metadata_value_norm = os.path.normpath(metadata_value)
+        metadata_dir_base = os.path.basename(metadata_dir)
+        if metadata_dir_base and (
+            metadata_value_norm == metadata_dir_base
+            or metadata_value_norm.startswith(f"{metadata_dir_base}{os.sep}")
+        ):
+            return metadata_value_norm
         return os.path.normpath(os.path.join(metadata_dir, metadata_value))
     return metadata_value
 

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -2,8 +2,14 @@
 import getpass
 import os
 
+from topeft.compat.topcoffea import ensure_histEFT_py39_compat
+
 # Ensure tests that expect a USER variable have a sensible default in CI.
 # getpass.getuser() falls back to LOGNAME/USER/..., but may raise in
 # containerized environments. Using os.getuid provides a stable suffix.
 _default_user = f"user{os.getuid()}"
 os.environ.setdefault("USER", getpass.getuser() if os.environ.get("USER") else _default_user)
+
+# Ensure ``topcoffea.modules.histEFT`` is patched for Python 3.9 before any
+# modules import it at module scope.
+ensure_histEFT_py39_compat()

--- a/tests/test_run_data_driven.py
+++ b/tests/test_run_data_driven.py
@@ -1,0 +1,121 @@
+import gzip
+import importlib.util
+import json
+from pathlib import Path
+
+import cloudpickle
+import pytest
+
+
+def _load_run_data_driven_module():
+    repo_root = Path(__file__).resolve().parents[1]
+    module_path = repo_root / "analysis" / "topeft_run2" / "run_data_driven.py"
+    spec = importlib.util.spec_from_file_location("run_data_driven", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+    return module
+
+
+run_data_driven = _load_run_data_driven_module()
+
+
+class FakeHist:
+    def __init__(self, processes):
+        self._processes = list(processes)
+        self.axes = {"process": tuple(self._processes)}
+
+    def remove(self, axis_name, labels):
+        assert axis_name == "process"
+        keep = [p for p in self._processes if p not in set(labels)]
+        return FakeHist(keep)
+
+
+class DummyProducer:
+    output_hist = {}
+    calls = []
+
+    def __init__(self, inputHist, outputName):
+        self.inputHist = inputHist
+        self.outputName = outputName
+        DummyProducer.calls.append((inputHist, outputName))
+
+    def getDataDrivenHistogram(self):
+        return DummyProducer.output_hist
+
+
+@pytest.fixture(autouse=True)
+def clear_dummy_state():
+    DummyProducer.calls.clear()
+    DummyProducer.output_hist = {}
+    yield
+    DummyProducer.calls.clear()
+    DummyProducer.output_hist = {}
+
+
+def _write_metadata(tmp_path: Path, *, input_path: Path, output_path: Path) -> Path:
+    metadata = {
+        "metadata_version": 1,
+        "do_np": True,
+        "resolved_years": ["16", "17"],
+        "sample_years": ["16", "17", "18"],
+        "input_histogram": str(input_path),
+        "output_histogram": str(output_path),
+    }
+    metadata_path = tmp_path / "metadata.json"
+    metadata_path.write_text(json.dumps(metadata))
+    return metadata_path
+
+
+def _load_pkl(pkl_path: Path):
+    with gzip.open(pkl_path, "rb") as stream:
+        return cloudpickle.load(stream)
+
+
+def test_run_data_driven_from_metadata(tmp_path, monkeypatch):
+    input_path = tmp_path / "input.pkl.gz"
+    input_path.write_bytes(b"content")
+    output_path = tmp_path / "output.pkl.gz"
+    metadata_path = _write_metadata(tmp_path, input_path=input_path, output_path=output_path)
+
+    DummyProducer.output_hist = {"njets": FakeHist(["flipsUL17"])}
+    monkeypatch.setattr(run_data_driven, "DataDrivenProducer", DummyProducer)
+
+    run_data_driven.main(["--metadata-json", str(metadata_path)])
+
+    assert DummyProducer.calls == [(str(input_path), str(output_path))]
+    result = _load_pkl(output_path)
+    assert list(result["njets"].axes["process"]) == ["flipsUL17"]
+
+
+def test_run_data_driven_only_flips_and_envelope(tmp_path, monkeypatch):
+    input_path = tmp_path / "input.pkl.gz"
+    input_path.write_bytes(b"content")
+    output_path = tmp_path / "output.pkl.gz"
+    metadata_path = _write_metadata(tmp_path, input_path=input_path, output_path=output_path)
+
+    DummyProducer.output_hist = {
+        "njets": FakeHist(["flipsUL18", "nonpromptUL18", "ttbarUL18"])
+    }
+    monkeypatch.setattr(run_data_driven, "DataDrivenProducer", DummyProducer)
+
+    envelope_calls = {}
+
+    def fake_envelope(hist_dict):
+        envelope_calls["value"] = hist_dict
+        return hist_dict
+
+    monkeypatch.setattr(run_data_driven, "get_renormfact_envelope", fake_envelope)
+
+    run_data_driven.main(
+        [
+            "--metadata-json",
+            str(metadata_path),
+            "--only-flips",
+            "--apply-renormfact-envelope",
+        ]
+    )
+
+    assert "value" in envelope_calls
+    result = _load_pkl(output_path)
+    assert list(result["njets"].axes["process"]) == ["flipsUL18"]

--- a/topcoffea/__init__.py
+++ b/topcoffea/__init__.py
@@ -1,0 +1,4 @@
+"""Namespace package placeholder for topcoffea extensions shipped with topeft tests."""
+from pkgutil import extend_path
+
+__path__ = extend_path(__path__, __name__)

--- a/topcoffea/modules/__init__.py
+++ b/topcoffea/modules/__init__.py
@@ -1,0 +1,4 @@
+"""Namespace package placeholder for topcoffea.modules extensions shipped with topeft tests."""
+from pkgutil import extend_path
+
+__path__ = extend_path(__path__, __name__)

--- a/topcoffea/modules/histEFT.py
+++ b/topcoffea/modules/histEFT.py
@@ -1,0 +1,412 @@
+#! /usr/bin/env python
+
+import hist
+import boost_histogram as bh
+import numpy as np
+
+from typing import Any, List, Mapping, Union
+
+from topcoffea.modules.sparseHist import SparseHist
+import topcoffea.modules.eft_helper as efth
+
+try:
+    from numpy.typing import ArrayLike, Self
+except ImportError:
+    ArrayLike = Any
+    Number = Any
+    Self = Any
+
+
+_family = hist
+
+
+class HistEFT(SparseHist, family=_family):
+    """Histogram specialized to hold Wilson Coefficients.
+    Example:
+    ```
+    h = HistEFT(
+        hist.axis.StrCategory(["ttH"], name="process", growth=True),
+        hist.axis.Regular(
+            name="ht",
+            label="ht [GeV]",
+            bins=3,
+            start=0,
+            stop=30,
+            flow=True,
+        ),
+        wc_names=["ctG"],
+        label="Events",
+    )
+
+    h.fill(
+        process="ttH",
+        ht=np.array([1, 1, 2, 15, 25, 100, -100]),
+        # per row, quadratic coefficient values associated with one event.
+        eft_coeff=[
+            [1.1, 2.1, 3.1],     # to (ttH, 1j) bins (one bin per coefficient)
+            [1.2, 2.2, 3.2],     # to (ttH, 1j) bins
+            [1.3, 2.3, 3.3],     # to (ttH, 2j) bins
+            [1.4, 2.4, 3.4],     # to (ttH, 15j) bins
+            [1.5, 2.5, 3.5],     # to (ttH, 25j) bins
+            [100, 200, 300],     # to (ttH, overflow given 100 >= stop) bins
+            [-100, -200, -300],  # to (ttH, underflow given -100 < start) bins
+        ],
+    )
+
+    # eval at 0, returns a dictionary from categorical axes bins to array, same as just sm,
+    # {('ttH',): array([-100. ,   3.6,    1.4,    1.5,  600. ])}
+    h.eval({})
+    h.eval({"ctG": 0})     # same thing
+    h.eval(np.zeros((1,))  # same thing
+
+    # eval at 1, same as adding all bins together per bins of dense axis.
+    # {('ttH',): array([-600. ,   19.8,    7.2,    7.5,  600. ])}
+    h.eval({"ctG": 1})     # same thing
+    h.eval(np.ones((1,))  # same thing
+
+    # instead of h.eval(...), h.as_hist(...) may be used to create a standard hist.Hist with the
+    # result of the evaluation:
+    hn = h.as_hist({"ctG": 0.02})
+    hn.plot1d()
+    ```
+    """
+
+    def __init__(
+        self,
+        *args,
+        wc_names: Union[List[str], None] = None,
+        **kwargs,
+    ) -> None:
+        """HistEFT initialization is similar to hist.Hist, with the following restrictions:
+        - All axes should have a name.
+        - Exactly one axis can be dense (i.e. hist.axis.Regular, hist.axis.Variable, or his.axis.Integer)
+        - The dense axis should be the last specified in the list of arguments.
+        - Categorical axes should be specified with growth=True.
+        """
+
+        # Backwards compatibility: early versions expected a positional
+        # signature ``HistEFT("Events", ["ctG"], axis1, axis2, ...)``.  The
+        # modern API follows ``hist.Hist`` and therefore takes the axes first
+        # plus keyword arguments for metadata.  Detect the legacy convention and
+        # translate it on the fly.
+        if args and isinstance(args[0], str):
+            kwargs.setdefault("label", args[0])
+            args = args[1:]
+
+        if args and isinstance(args[0], (list, tuple)):
+            maybe_wc = args[0]
+            if all(isinstance(item, str) for item in maybe_wc):
+                if wc_names and list(wc_names) != list(maybe_wc):
+                    raise ValueError(
+                        "Conflicting Wilson coefficient definitions provided"
+                    )
+                wc_names = list(maybe_wc)
+                args = args[1:]
+
+        if not wc_names:
+            wc_names = []
+
+        n = len(wc_names)
+        self._wc_names = {n: i for i, n in enumerate(wc_names)}
+        self._wc_count = n
+        self._quad_count = efth.n_quad_terms(n)
+
+        self._init_args_eft = {"wc_names": wc_names}
+
+        self._needs_rebinning = kwargs.pop("rebin", False)
+        if self._needs_rebinning:
+            raise ValueError("Do not know how to rebin yet...")
+
+        kwargs.setdefault("storage", hist.storage.Double())
+        if isinstance(kwargs["storage"], str):
+            if kwargs["storage"].lower() == "double":
+                kwargs["storage"] = hist.storage.Double()
+            else:
+                raise ValueError("only 'Double' storage is supported")
+        if not isinstance(kwargs["storage"], hist.storage.Double):
+            raise ValueError("only 'Double' storage is supported")
+
+        if args[-1].name == "quadratic_term":
+            self._coeff_axis = args[-1]
+            args = args[:-1]
+        else:
+            # no axis for quadratic_term found, creating our own.
+            self._coeff_axis = hist.axis.Integer(
+                start=0, stop=self._quad_count, name="quadratic_term"
+            )
+
+        self._dense_axis = args[-1]
+        if not isinstance(
+            self._dense_axis, (bh.axis.Regular, bh.axis.Variable, bh.axis.Integer)
+        ):
+            raise ValueError("dense axis should be the last specified")
+
+        reserved_names = ["quadratic_term", "sample", "weight", "thread"]
+        if any([axis.name in reserved_names for axis in args]):
+            raise ValueError(
+                f"No axis may have one of the following names: {','.join(reserved_names)}"
+            )
+
+        super().__init__(*args, self._coeff_axis, **kwargs)
+
+    def empty_from_axes(self, categorical_axes=None, dense_axes=None, **kwargs):
+        return super().empty_from_axes(
+            categorical_axes, dense_axes, **self._init_args_eft, **kwargs
+        )
+
+    @property
+    def wc_names(self):
+        return list(self._wc_names)
+
+    def index_of_wc(self, wc: str):
+        return self._wc_names[wc]
+
+    def quadratic_term_index(self, *wcs: List[str]):
+        """Given the name of two coefficients, it returns the index
+        of the corresponding quadratic coefficient. E.g., if the
+        histogram was defined with wc_names=["ctG"]:
+
+        h.quadratic_term_index("sm", "sm")   -> 0
+        h.quadratic_term_index("sm", "ctG")  -> 1
+        h.quadratic_term_index("ctG", "ctG") -> 2
+        """
+
+        def str_to_index(s):
+            if s == "sm":
+                return 0
+            else:
+                return self.index_of_wc(s) + 1
+
+        if len(wcs) != 2:
+            raise ValueError("List of coefficient names should have length 2")
+
+        wc1, wc2 = map(str_to_index, wcs)
+        if wc1 < wc2:
+            wc1, wc2 = wc2, wc1
+
+        return int((((wc1 + 1) * wc1) / 2) + wc2)
+
+    def should_rebin(self):
+        return self._needs_rebinning
+
+    @property
+    def dense_axis(self):
+        return self._dense_axis
+
+    def _fill_flatten(self, a, n_events):
+        # manipulate input arrays into flat arrays. broadcast_to and ravel used so that arrays are not duplicated in memory
+        a = np.asarray(a)
+        if a.ndim > 2 or (a.ndim == 2 and (a.shape != (n_events, 1))):
+            raise ValueError(
+                "Incompatible dimensions between data and Wilson coefficients."
+            )
+
+        if a.ndim > 1:
+            a = a.ravel()
+
+        # turns [e0, e1, ...] into [[e0, e0, ...],
+        #                           [e1, e1, ...],
+        #                            [...       ]]
+        # and then into       [e0, e0, ..., e1, e1, ..., e2, e2, ...]
+        # each value repeated the number of quadratic coefficients.
+        return np.broadcast_to(a, (self._quad_count, n_events)).T.ravel()
+
+    def _fill_indices(self, n_events):
+        # turns [0, 1, 2, ..., num of quadratic coeffs - 1]
+        # into:
+        # [0, 1, 2, ..., 0, 1, 2 ...,]
+        # repeated n_events times.
+        return np.broadcast_to(np.ogrid[0: self._quad_count], (n_events, self._quad_count)).ravel()
+
+    def fill(
+        self,
+        eft_coeff: ArrayLike = None,  # [num of events x (num of wc coeffs + 1)]
+        **values,
+    ) -> Self:
+        """
+        Insert data into the histogram using names and indices, return
+        a HistEFT object.
+
+        cat axes:  "s1"                    each categorical axis with one value to fill
+        dense axis:[ e0, e1, ... ]         each entry is the value for one event.
+        weight:    [ w0, w1, ... ]         weight per event
+        eft_coeff: [[c00, c01, c02, ...]   each row is the coefficient values for one event,
+                    [c10, c11, c12, ...]
+                    ...                 ]  cij is the value of jth coefficient for the ith event.
+                                           ei, wi, and ci* go together.
+
+        If eft_coeff is not given, then it is assumed to be [[1, 0, 0, ...], [1, 0, 0, ...], ...]
+        """
+
+        n_events = len(values[self.dense_axis.name])
+
+        if eft_coeff is None:
+            # if eft_coeff not given, assume values only for sm
+            eft_coeff = np.broadcast_to(
+                np.concatenate((np.ones((1,)), np.zeros((self._quad_count - 1,)))),
+                (n_events, self._quad_count),
+            )
+
+        eft_coeff = np.asarray(eft_coeff)
+
+        # turn into [e0, e0, ..., e1, e1, ..., e2, e2, ...]
+        values[self._dense_axis.name] = self._fill_flatten(
+            values[self._dense_axis.name], n_events
+        )
+
+        # turn into: [c00, c01, c02, ..., c10, c11, c12, ...]
+        eft_coeff = eft_coeff.ravel()
+
+        # index for coefficient axes.
+        # [ 0, 1, 2, ..., 0, 1, 2, ...]
+        indices = self._fill_indices(n_events)
+
+        weight = values.pop("weight", None)
+        if weight is not None:
+            weight = self._fill_flatten(weight, n_events)
+            eft_coeff = eft_coeff * weight
+
+        # fills:
+        # [e0,      e0,      e0    ..., e1,     e1,     e1,     ...]
+        # [ 0,      1,       2,    ..., 0,      1,      2,      ...]
+        # [c00*w0, c01*w0, c02*w0, ..., c10*w1, c11*w1, c12*w1, ...]
+        super().fill(quadratic_term=indices, **values, weight=eft_coeff)
+
+    def _wc_for_eval(self, values: Union[ArrayLike, Mapping, None]):
+        """Set the WC values used to evaluate the bin contents of this histogram
+        where the WCs are specified as keyword arguments.  Any WCs not listed are set to zero.
+        """
+        if values is None:
+            return np.zeros(self._wc_count)
+
+        if isinstance(values, Mapping):
+            result = np.zeros(self._wc_count)
+            for wc, val in values.items():
+                try:
+                    index = self._wc_names[wc]
+                    result[index] = val
+                except KeyError:
+                    msg = f'This HistEFT does not know about the "{wc}" Wilson coefficient. Known coefficients: {list(self._wc_names.keys())}'
+                    raise LookupError(msg)
+            return result
+
+        result = np.asarray(values, dtype=float)
+
+        if result.shape != (self._wc_count,):
+            raise ValueError(
+                f"Expected {self._wc_count} Wilson coefficients, received shape {result.shape}"
+            )
+
+        return result
+
+    def eval(self, values):
+        """Extract the sum of weights arrays from this histogram
+        Parameters
+        ----------
+        values: ArrayLike or Mapping or None
+            The WC values used to evaluate the bin contents of this histogram. Either an array with the values, or a dictionary. If None, use an array of zeros.
+        """
+
+        values = self._wc_for_eval(values)
+
+        out = {}
+        for sparse_key, hvs in self.view(flow=True, as_dict=True).items():
+            out[sparse_key] = self.calc_eft_weights(hvs, values)
+        return out
+
+    def as_hist(self, values):
+        """Construct a regular histogram evaluated at values.
+        (Like self.eval(...) but result is a histogram.)
+        Parameters
+        ----------
+        values: ArrayLike or Mapping or None
+            The WC values used to evaluate the bin contents of this histogram. Either an array with the values, or a dictionary. If None, use an array of zeros.
+        overflow: bool
+            Whether to include under and overflow bins.
+        """
+        evals = self.eval(values=values)
+        nhist = hist.Hist(
+            *[axis for axis in self.axes if axis != self._coeff_axis], **self._init_args
+        )
+
+        sparse_names = self.categorical_axes.name
+        for sp_val, arrs in evals.items():
+            sp_key = dict(zip(sparse_names, sp_val))
+            nhist[sp_key] = arrs
+        return nhist
+
+    def __reduce__(self):
+        args = dict(self._init_args)
+        args.update(self._init_args_eft)
+
+        return (
+            type(self)._read_from_reduce,
+            (
+                list(self.categorical_axes),
+                [self.dense_axis],
+                args,
+                self._dense_hists,
+            ),
+        )
+
+    def make_scaling(self, wc_list=None):
+        """
+        returns np.Array of scaling for scalings.json with the interference model list with flow bins
+        ----------
+        wc_list: list or array of WCs
+            if None: will use self.wc_names for WCs
+            if list or array: will use wc_list for WCs
+        """
+        if wc_list is not None:
+            scaling = efth.remap_coeffs(self.wc_names,wc_list,np.array(self.values(flow=True)[:,1:-1]))
+        else:
+            scaling = self.values(flow=True)[:,1:-1]
+            wc_list = self.wc_names
+        #check if any non-flow bins have zero sm contribution
+        if ((scaling[:,0] == 0) & (scaling != 0).any(axis=1)).any():
+            raise Exception('At least one bin found with no SM contribution and a BSM contribution!')
+        skip = 0
+        step = 2
+        for i in np.ogrid[0: efth.n_quad_terms(len(wc_list))]:
+            if i == skip:
+                skip += step
+                step += 1
+            else:
+                scaling[:,i] /= 2
+        return np.nan_to_num(scaling/np.expand_dims(scaling[:,0], 1), 0) #divide by sm
+
+    @classmethod
+    def _read_from_reduce(cls, cat_axes, dense_axes, init_args, dense_hists):
+        return super()._read_from_reduce(cat_axes, dense_axes, init_args, dense_hists)
+
+    # this method should be moved to eft_helper once HistEFT is replaced.
+    # the only change is that hist.view includes a under/overflow columns, thus
+    # the index should start at 1
+    def calc_eft_weights(self, q_coeffs, wc_values):
+        """Calculate the weights for a specific set of WC values.
+
+        Args:
+            q_coeffs: Array specifying a set of quadric coefficients parameterizing the weights.
+                    The last dimension should specify the coefficients, while any earlier dimensions
+                    might be for different histogram bins, events, etc.
+            wc_values: A 1D array specifying the Wilson coefficients corrersponding to the desired weight.
+
+        Returns:
+            An array of the weight values calculated from the quadratic parameterization.
+        """
+
+        # Prepend "1" to the start of the WC array to account for constant and linear terms
+        wcs = np.hstack((np.ones(1), wc_values))
+
+        # Initialize the array that will return the coefficients.  It
+        # should be the same shape as q_coeffs except missing the last
+        # dimension.
+        out = np.zeros_like(q_coeffs[..., 0])
+
+        # Now loop over the terms and multiply them out
+        index = 1  # start at second column, as first is 0s from boost_histogram underflow (real underflow is row 0)
+        for i in range(len(wcs)):
+            for j in range(i + 1):
+                out += q_coeffs[..., index] * wcs[i] * wcs[j]
+                index += 1
+        return out

--- a/topeft/compat/__init__.py
+++ b/topeft/compat/__init__.py
@@ -1,0 +1,1 @@
+"""Compatibility helpers for third-party dependencies."""

--- a/topeft/compat/topcoffea.py
+++ b/topeft/compat/topcoffea.py
@@ -1,0 +1,53 @@
+"""Runtime helpers that patch ``topcoffea`` for older Python versions."""
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+from typing import Optional
+
+_PATCH_TARGET = "ArrayLike | Mapping | None"
+_PATCH_REPLACEMENT = "Union[ArrayLike, Mapping, None]"
+
+
+def _patched_histEFT_source(source: str) -> Optional[str]:
+    if _PATCH_TARGET not in source:
+        return None
+    return source.replace(_PATCH_TARGET, _PATCH_REPLACEMENT)
+
+
+def ensure_histEFT_py39_compat() -> None:
+    """Load ``topcoffea.modules.histEFT`` with Python 3.9 friendly annotations."""
+
+    if sys.version_info >= (3, 10):
+        return
+
+    fullname = "topcoffea.modules.histEFT"
+    if fullname in sys.modules:
+        return
+
+    spec = importlib.util.find_spec(fullname)
+    if spec is None or spec.loader is None or not hasattr(spec.loader, "get_source"):
+        return
+
+    source = spec.loader.get_source(fullname)
+    if source is None:
+        return
+
+    patched_source = _patched_histEFT_source(source)
+    if patched_source is None:
+        # Nothing to patch, so fall back to the regular import path.
+        importlib.import_module(fullname)
+        return
+
+    module = importlib.util.module_from_spec(spec)
+    try:
+        sys.modules[fullname] = module
+        exec(compile(patched_source, spec.origin or fullname, "exec"), module.__dict__)
+    except Exception:
+        sys.modules.pop(fullname, None)
+        raise
+
+    package_name, _, attr = fullname.rpartition(".")
+    package = importlib.import_module(package_name)
+    setattr(package, attr, module)

--- a/topeft/compat/topcoffea.py
+++ b/topeft/compat/topcoffea.py
@@ -5,6 +5,7 @@ import importlib
 import importlib.util
 import sys
 from typing import Optional
+import typing
 
 _PATCH_TARGET = "ArrayLike | Mapping | None"
 _PATCH_REPLACEMENT = "Union[ArrayLike, Mapping, None]"
@@ -41,6 +42,7 @@ def ensure_histEFT_py39_compat() -> None:
         return
 
     module = importlib.util.module_from_spec(spec)
+    module.__dict__.setdefault("Union", typing.Union)
     try:
         sys.modules[fullname] = module
         exec(compile(patched_source, spec.origin or fullname, "exec"), module.__dict__)

--- a/topeft/modules/yield_tools.py
+++ b/topeft/modules/yield_tools.py
@@ -1,11 +1,16 @@
 import numpy as np
 import copy
 import logging
+
+from topeft.compat.topcoffea import ensure_histEFT_py39_compat
+from topeft.modules.compatibility import add_sumw2_stub
+from topeft.modules.utils import canonicalize_process_name
+
+ensure_histEFT_py39_compat()
+
 from topcoffea.modules.histEFT import HistEFT
 from topcoffea.modules.sparseHist import SparseHist
 import topcoffea.modules.utils as utils
-from topeft.modules.compatibility import add_sumw2_stub
-from topeft.modules.utils import canonicalize_process_name
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- add a standalone `run_data_driven.py` helper that can rebuild deferred nonprompt histograms from the metadata sidecar or manual CLI arguments
- document how to invoke the helper and add regression tests that exercise the metadata workflow and flips-only mode

## Testing
- pytest tests/test_run_data_driven.py