### PR TITLE
Normalize topcoffea imports

### DIFF
--- a/analysis/btagMCeff/btagMCeff.py
+++ b/analysis/btagMCeff/btagMCeff.py
@@ -9,11 +9,12 @@ from hist import storage
 from coffea.util import load
 import coffea.analysis_tools
 
+import topcoffea
 import topeft.modules.object_selection as te_os
-import topcoffea.modules.object_selection as tc_os
 from topeft.modules.paths import topeft_path
 
-from topcoffea.modules.get_param_from_jsons import GetParam
+tc_os = topcoffea.modules.object_selection
+GetParam = topcoffea.modules.get_param_from_jsons.GetParam
 get_te_param = GetParam(topeft_path("params/params.json"))
 
 #coffea.deprecations_as_errors = True

--- a/analysis/extreme_events_study/extreme_events.py
+++ b/analysis/extreme_events_study/extreme_events.py
@@ -8,11 +8,24 @@ from coffea.analysis_tools import PackedSelection
 from coffea.lumi_tools import LumiMask
 from coffea.processor.accumulator import AccumulatorABC
 
-from topcoffea.modules.GetValuesFromJsons import get_param
-from topcoffea.modules.objects import *
-from topcoffea.modules.corrections import AttachMuonSF, AttachElectronSF, AttachPerLeptonFR, ApplyRochesterCorrections
-from topcoffea.modules.selection import *
-from topcoffea.modules.paths import topcoffea_path
+import importlib
+import topcoffea
+
+def _inject_module_exports(module):
+    names = getattr(module, "__all__", None)
+    if names is None:
+        names = [name for name in dir(module) if not name.startswith("_")]
+    globals().update({name: getattr(module, name) for name in names})
+
+_inject_module_exports(importlib.import_module("topcoffea.modules.objects"))
+_inject_module_exports(importlib.import_module("topcoffea.modules.selection"))
+tc_corrections = importlib.import_module("topcoffea.modules.corrections")
+AttachMuonSF = tc_corrections.AttachMuonSF
+AttachElectronSF = tc_corrections.AttachElectronSF
+AttachPerLeptonFR = tc_corrections.AttachPerLeptonFR
+ApplyRochesterCorrections = tc_corrections.ApplyRochesterCorrections
+topcoffea_path = topcoffea.modules.paths.topcoffea_path
+get_param = topcoffea.modules.GetValuesFromJsons.get_param
 
 
 class dataframe_accumulator(AccumulatorABC):

--- a/analysis/extreme_events_study/get_histo_yield.py
+++ b/analysis/extreme_events_study/get_histo_yield.py
@@ -1,6 +1,8 @@
-import topcoffea.modules.utils as utils
-from topcoffea.modules.YieldTools import YieldTools
+import topcoffea
 from make_cr_and_sr_plots import get_lumi_for_sample
+
+YieldTools = topcoffea.modules.YieldTools.YieldTools
+utils = topcoffea.modules.utils
 
 
 def get_bins_sum(histo):

--- a/analysis/extreme_events_study/run_extreme_events.py
+++ b/analysis/extreme_events_study/run_extreme_events.py
@@ -7,11 +7,11 @@ import time
 
 import coffea.processor as processor
 from coffea.nanoevents import NanoAODSchema
-import topcoffea.modules.remote_environment as remote_environment
+
+import topcoffea
 
 import extreme_events
 
-from topcoffea.modules.utils import load_sample_json_file, read_cfg_file, update_cfg
 from topeft.modules.executor import build_futures_executor, taskvine_log_configurator
 from topeft.modules.executor_cli import (
     ExecutorCLIHelper,
@@ -19,6 +19,12 @@ from topeft.modules.executor_cli import (
     TaskVineArgumentSpec,
 )
 from topeft.modules.runner_output import normalise_runner_output
+
+remote_environment = topcoffea.modules.remote_environment
+tc_utils = topcoffea.modules.utils
+load_sample_json_file = tc_utils.load_sample_json_file
+read_cfg_file = tc_utils.read_cfg_file
+update_cfg = tc_utils.update_cfg
 
 
 parser = argparse.ArgumentParser(

--- a/analysis/flip_measurement/flip_ar_processor.py
+++ b/analysis/flip_measurement/flip_ar_processor.py
@@ -14,12 +14,25 @@ import coffea.processor as processor
 from coffea.analysis_tools import PackedSelection, Weights
 from coffea.lumi_tools import LumiMask
 
-from topcoffea.modules.objects import *
-from topcoffea.modules.corrections import AttachMuonSF, AttachElectronSF, AttachPerLeptonFR
-from topcoffea.modules.selection import *
-from topcoffea.modules.paths import topcoffea_path
+import importlib
+import topcoffea
 
 from topeft.modules.runner_output import SUMMARY_KEY, materialise_tuple_dict
+
+
+def _inject_module_exports(module):
+    names = getattr(module, "__all__", None)
+    if names is None:
+        names = [name for name in dir(module) if not name.startswith("_")]
+    globals().update({name: getattr(module, name) for name in names})
+
+_inject_module_exports(importlib.import_module("topcoffea.modules.objects"))
+_inject_module_exports(importlib.import_module("topcoffea.modules.selection"))
+tc_corrections = importlib.import_module("topcoffea.modules.corrections")
+AttachMuonSF = tc_corrections.AttachMuonSF
+AttachElectronSF = tc_corrections.AttachElectronSF
+AttachPerLeptonFR = tc_corrections.AttachPerLeptonFR
+topcoffea_path = topcoffea.modules.paths.topcoffea_path
 
 
 def _resolve_nested_field(array, *field_paths):

--- a/analysis/flip_measurement/flip_mr_processor.py
+++ b/analysis/flip_measurement/flip_mr_processor.py
@@ -11,8 +11,10 @@ import awkward as ak
 import hist
 import coffea.processor as processor
 
-import topcoffea.modules.objects as obj
+import topcoffea
 from topeft.modules.runner_output import SUMMARY_KEY, materialise_tuple_dict
+
+obj = topcoffea.modules.objects
 
 
 def _resolve_nested_field(array, *field_paths):

--- a/analysis/flip_measurement/run_flip.py
+++ b/analysis/flip_measurement/run_flip.py
@@ -11,7 +11,8 @@ from typing import Any, Mapping, MutableMapping, Sequence
 
 import coffea.processor as processor
 from coffea.nanoevents import NanoAODSchema
-import topcoffea.modules.remote_environment as remote_environment
+
+import topcoffea
 
 try:  # pragma: no cover - import resolution depends on execution context
     from . import flip_mr_processor  # type: ignore[import]
@@ -20,7 +21,6 @@ except ImportError:  # pragma: no cover - fallback for script execution
     import flip_mr_processor  # type: ignore[no-redef]
     import flip_ar_processor  # type: ignore[no-redef]
 
-from topcoffea.modules.utils import load_sample_json_file, read_cfg_file, update_cfg
 from topeft.modules.executor import build_futures_executor, taskvine_log_configurator
 from topeft.modules.executor_cli import (
     ExecutorCLIHelper,
@@ -33,6 +33,12 @@ from topeft.modules.runner_output import (
     materialise_tuple_dict,
     normalise_runner_output,
 )
+
+remote_environment = topcoffea.modules.remote_environment
+tc_utils = topcoffea.modules.utils
+load_sample_json_file = tc_utils.load_sample_json_file
+read_cfg_file = tc_utils.read_cfg_file
+update_cfg = tc_utils.update_cfg
 
 parser = argparse.ArgumentParser(
     description=(

--- a/analysis/mc_validation/mc_validation_gen_plotter.py
+++ b/analysis/mc_validation/mc_validation_gen_plotter.py
@@ -3,7 +3,6 @@
 #   - Was used during the June 2022 MC validation studies (for TOP-22-006 pre approval checks)
 
 import os
-import sys
 import datetime
 import argparse
 import gzip
@@ -14,14 +13,13 @@ from hist import axis, storage
 
 from pathlib import Path
 
-from topcoffea.modules.YieldTools import YieldTools
-from topcoffea.scripts.make_html import make_html
+import importlib
+import topcoffea
 
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.append(str(PROJECT_ROOT))
+YieldTools = topcoffea.modules.YieldTools.YieldTools
+make_html = importlib.import_module("topcoffea.scripts.make_html").make_html
 
-from analysis.mc_validation.plot_utils import (  # noqa: E402
+from analysis.mc_validation.plot_utils import (
     build_dataset_histograms,
     component_labels,
     component_values,

--- a/analysis/mc_validation/mc_validation_gen_processor.py
+++ b/analysis/mc_validation/mc_validation_gen_processor.py
@@ -8,13 +8,23 @@ import coffea.processor as processor
 from collections import OrderedDict, defaultdict
 from typing import Any, Dict, Tuple, Union
 
-from topcoffea.modules.GetValuesFromJsons import get_lumi
-from topcoffea.modules.objects import *
-#from topcoffea.modules.corrections import get_ht_sf
-from topcoffea.modules.selection import *
-from topcoffea.modules.HistEFT import HistEFT
-import topcoffea.modules.eft_helper as efth
+import importlib
+import topcoffea
+
 from topeft.modules.runner_output import SUMMARY_KEY, materialise_tuple_dict
+
+
+def _inject_module_exports(module):
+    names = getattr(module, "__all__", None)
+    if names is None:
+        names = [name for name in dir(module) if not name.startswith("_")]
+    globals().update({name: getattr(module, name) for name in names})
+
+_inject_module_exports(importlib.import_module("topcoffea.modules.objects"))
+_inject_module_exports(importlib.import_module("topcoffea.modules.selection"))
+HistEFT = topcoffea.modules.HistEFT.HistEFT
+efth = topcoffea.modules.eft_helper
+get_lumi = topcoffea.modules.GetValuesFromJsons.get_lumi
 
 
 def _ensure_ak_array(values, dtype=None):

--- a/analysis/mc_validation/mc_validation_plotter.py
+++ b/analysis/mc_validation/mc_validation_plotter.py
@@ -4,23 +4,20 @@
 
 import numpy as np
 import os
-import sys
 import datetime
 import argparse
 
 from pathlib import Path
 
 import uproot
+import importlib
+import topcoffea
 
-from topcoffea.modules.paths import topcoffea_path
-from topcoffea.modules.YieldTools import YieldTools
-from topcoffea.scripts.make_html import make_html
+topcoffea_path = topcoffea.modules.paths.topcoffea_path
+YieldTools = topcoffea.modules.YieldTools.YieldTools
+make_html = importlib.import_module("topcoffea.scripts.make_html").make_html
 
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.append(str(PROJECT_ROOT))
-
-from analysis.mc_validation.plot_utils import (  # noqa: E402
+from analysis.mc_validation.plot_utils import (
     build_dataset_histograms,
     component_labels,
     component_values,

--- a/analysis/mc_validation/plot_utils.py
+++ b/analysis/mc_validation/plot_utils.py
@@ -18,8 +18,13 @@ from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional, Seque
 import hist
 
 try:  # pragma: no cover - HistEFT is optional in some environments
-    from topcoffea.modules.HistEFT import HistEFT
-except Exception:  # pragma: no cover - fallback when HistEFT is unavailable
+    import topcoffea
+except ModuleNotFoundError:  # pragma: no cover - fallback when HistEFT is unavailable
+    topcoffea = None  # type: ignore[assignment]
+
+if topcoffea is not None:
+    HistEFT = getattr(topcoffea.modules.HistEFT, "HistEFT", None)
+else:  # pragma: no cover - fallback when HistEFT is unavailable
     HistEFT = None  # type: ignore[assignment]
 
 

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -18,17 +18,11 @@ import re
 import logging
 
 import hist
-from topcoffea.modules.HistEFT import HistEFT
+import topcoffea
 import coffea.processor as processor
 from coffea.analysis_tools import PackedSelection
 from coffea.lumi_tools import LumiMask
 from typing import Dict, List, Optional, Tuple
-
-from topcoffea.modules.paths import topcoffea_path
-import topcoffea.modules.eft_helper as efth
-import topcoffea.modules.event_selection as tc_es
-import topcoffea.modules.object_selection as tc_os
-import topcoffea.modules.corrections as tc_cor
 
 from topeft.modules.paths import topeft_path
 from topeft.modules.corrections import ApplyJetCorrections, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, ApplyRochesterCorrections, ApplyJetSystematics
@@ -43,7 +37,14 @@ from topeft.modules.systematics import (
     register_weight_variation,
     validate_data_weight_variations,
 )
-from topcoffea.modules.get_param_from_jsons import GetParam
+
+HistEFT = topcoffea.modules.HistEFT.HistEFT
+topcoffea_path = topcoffea.modules.paths.topcoffea_path
+efth = topcoffea.modules.eft_helper
+tc_es = topcoffea.modules.event_selection
+tc_os = topcoffea.modules.object_selection
+tc_cor = topcoffea.modules.corrections
+GetParam = topcoffea.modules.get_param_from_jsons.GetParam
 
 logger = logging.getLogger(__name__)
 get_tc_param = GetParam(topcoffea_path("params/params.json"))

--- a/analysis/topeft_run2/check_for_lepMVA.py
+++ b/analysis/topeft_run2/check_for_lepMVA.py
@@ -3,9 +3,11 @@ import json
 
 from coffea.nanoevents import NanoEventsFactory
 
-from topcoffea.modules.utils import regex_match
+import topcoffea
 
 CFG_PATH = "../../input_samples/cfgs/"
+
+regex_match = topcoffea.modules.utils.regex_match
 
 pjoin = os.path.join
 

--- a/analysis/topeft_run2/comp.py
+++ b/analysis/topeft_run2/comp.py
@@ -20,11 +20,13 @@ import argparse
 import time
 import json
 import os
-from topcoffea.modules.get_param_from_jsons import GetParam
-from topcoffea.modules.paths import topcoffea_path
-get_tc_param = GetParam(topcoffea_path("params/params.json"))
+import topcoffea
 import yaml
 from topeft.modules.paths import topeft_path
+
+GetParam = topcoffea.modules.get_param_from_jsons.GetParam
+topcoffea_path = topcoffea.modules.paths.topcoffea_path
+get_tc_param = GetParam(topcoffea_path("params/params.json"))
 
 metadata_path = topeft_path("params/metadata.yml")
 with open(metadata_path, "r") as f:

--- a/analysis/topeft_run2/comp_yields.py
+++ b/analysis/topeft_run2/comp_yields.py
@@ -2,9 +2,12 @@ import argparse
 import json
 import sys
 
-import topcoffea.modules.MakeLatexTable as mlt
-from topcoffea.modules import utils
+import topcoffea
+
 from topeft.modules.yield_tools import YieldTools
+
+mlt = topcoffea.modules.MakeLatexTable
+utils = topcoffea.modules.utils
 
 # This script takes two json files of yields, and prints out information about how they compare
 #   - The second file is optional, will default to the reference yield file

--- a/analysis/topeft_run2/get_datacard_yields.py
+++ b/analysis/topeft_run2/get_datacard_yields.py
@@ -4,7 +4,9 @@ import datetime
 import argparse
 import json
 
-import topcoffea.modules.MakeLatexTable as mlt
+import topcoffea
+
+mlt = topcoffea.modules.MakeLatexTable
 
 BKG_PROC_LST = ["tWZ_sm", "convs_sm","Diboson_sm","Triboson_sm","charge_flips_sm","fakes_sm"]
 SIG_PROC_LST = ["ttH_sm", "ttlnu_sm", "ttll_sm", "tllq_sm", "tHq_sm", "tttt_sm"]

--- a/analysis/topeft_run2/get_yield_json.py
+++ b/analysis/topeft_run2/get_yield_json.py
@@ -1,9 +1,13 @@
 import argparse
 import json
 import datetime
+
+import topcoffea
+
 from topeft.modules.yield_tools import YieldTools
-import topcoffea.modules.MakeLatexTable as mlt
-from topcoffea.modules import utils
+
+mlt = topcoffea.modules.MakeLatexTable
+utils = topcoffea.modules.utils
 
 # This script takes a pkl file, finds the yields in the analysis categories, saves the yields to a json
 #   - If you do not specify a pkl file path, will default to "hists/plotsTopEFT.pkl.gz"

--- a/analysis/topeft_run2/make_1d_quad_plots.py
+++ b/analysis/topeft_run2/make_1d_quad_plots.py
@@ -3,9 +3,12 @@ import argparse
 import datetime
 from coffea.nanoevents import NanoEventsFactory
 
-import topcoffea.modules.quad_fit_tools as qft
-from topcoffea.modules import utils
-from topcoffea.scripts.make_html import make_html
+import importlib
+import topcoffea
+
+qft = topcoffea.modules.quad_fit_tools
+utils = topcoffea.modules.utils
+make_html = importlib.import_module("topcoffea.scripts.make_html").make_html
 
 # This is more or less a placeholder script
 #   - It shows  an example of how we might want to access the quadratic fit information using topcoffea.modules.quad_fit_tools

--- a/analysis/topeft_run2/make_1d_quad_plots_from_template_histos.py
+++ b/analysis/topeft_run2/make_1d_quad_plots_from_template_histos.py
@@ -34,10 +34,13 @@
 #     - So to run it is just:
 #       python make_1d_quad_plots_from_template_histos.py
 
-
 import os
-import topcoffea.modules.quad_fit_tools as qft
-from topcoffea.scripts.make_html import make_html
+import importlib
+
+import topcoffea
+
+qft = topcoffea.modules.quad_fit_tools
+make_html = importlib.import_module("topcoffea.scripts.make_html").make_html
 
 # Load the input dict (with all of the values from the template histos)
 # Note this is a PLACEHOLDER (should be a command line argument?)

--- a/analysis/topeft_run2/make_cards.py
+++ b/analysis/topeft_run2/make_cards.py
@@ -5,8 +5,13 @@ import shutil
 import argparse
 import numpy as np
 
-from topcoffea.modules.utils import regex_match,clean_dir,dict_comp
+import topcoffea
+
 from topeft.modules.datacard_tools import *
+
+regex_match = topcoffea.modules.utils.regex_match
+clean_dir = topcoffea.modules.utils.clean_dir
+dict_comp = topcoffea.modules.utils.dict_comp
 
 # Note:
 #   Not sure if constructing the condor related files this way is good or bad practice. It already

--- a/analysis/topeft_run2/make_jsons.py
+++ b/analysis/topeft_run2/make_jsons.py
@@ -6,9 +6,11 @@ import os
 import re
 import subprocess
 
-import topcoffea.modules.sample_lst_jsons_tools as sjt
+import topcoffea
 from topeft.modules.combine_json_ext import combine_json_ext
 from topeft.modules.combine_json_batch import combine_json_batch
+
+sjt = topcoffea.modules.sample_lst_jsons_tools
 
 
 ########### Private UL signal samples ###########

--- a/analysis/topeft_run2/make_skim_jsons.py
+++ b/analysis/topeft_run2/make_skim_jsons.py
@@ -1,10 +1,12 @@
 import os
 import argparse
 
-from topcoffea.modules.update_json import update_json
-from topcoffea.modules.utils import get_files
+import topcoffea
 
 pjoin = os.path.join
+
+update_json = topcoffea.modules.update_json.update_json
+get_files = topcoffea.modules.utils.get_files
 
 # Attempts to match a hadoop dataset to a json dataset based on the file name
 def find_json_match(hadoop_skim_dir,json_fpaths):

--- a/analysis/topeft_run2/missing_parton.py
+++ b/analysis/topeft_run2/missing_parton.py
@@ -13,11 +13,15 @@ import mplhep as hep
 import math
 from topeft.modules.comp_datacard import strip
 import re
+import importlib
 
 from topeft.modules.paths import topeft_path
-from topcoffea.modules.paths import topcoffea_path
-from topcoffea.modules.get_param_from_jsons import GetParam
+import topcoffea
+
+topcoffea_path = topcoffea.modules.paths.topcoffea_path
+GetParam = topcoffea.modules.get_param_from_jsons.GetParam
 get_tc_param = GetParam(topcoffea_path("params/params.json"))
+make_html = importlib.import_module("topcoffea.scripts.make_html").make_html
 
 files = ['2lss_4t_m', '2lss_4t_p', '2lss_fwd_m', '2lss_fwd_p', '2lss_m', '2lss_p', '3l_m_offZ_1b', '3l_m_offZ_2b', '3l_onZ_1b', '3l_onZ_2b', '3l_p_offZ_1b', '3l_p_offZ_2b', '4l']
 files = ['2lss_fwd_m', '2lss_fwd_p']
@@ -81,7 +85,6 @@ if __name__ == '__main__':
     import argparse
     import datetime
     import os
-    from topcoffea.scripts.make_html import make_html
 
     parser = argparse.ArgumentParser(description='You can select which file to run over')
     parser.add_argument('--years',          default=[], action='extend', nargs='+', help = 'Specify a list of years')

--- a/analysis/topeft_run2/parse_datacard_templates.py
+++ b/analysis/topeft_run2/parse_datacard_templates.py
@@ -6,10 +6,13 @@
 
 import os
 import argparse
+import importlib
 import ROOT
 
-from topcoffea.scripts.make_html import make_html
+import topcoffea
 import get_datacard_yields as dy # Note the functions we're using from this script should probably go in topeft/modules
+
+make_html = importlib.import_module("topcoffea.scripts.make_html").make_html
 
 
 # Get the list of histo names from a root file

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -14,9 +14,9 @@ from __future__ import annotations
 import argparse
 from typing import Sequence
 
-from run_analysis_helpers import RunConfigBuilder
+import topcoffea
 
-import topcoffea.modules.remote_environment as remote_environment
+from run_analysis_helpers import RunConfigBuilder
 from topeft.modules.executor_cli import (
     ExecutorCLIHelper,
     FuturesArgumentSpec,
@@ -24,14 +24,9 @@ from topeft.modules.executor_cli import (
 )
 from topeft.modules.executor import resolve_environment_file
 
-if __package__ in (None, ""):
-    import pathlib
-    import sys
+from analysis.topeft_run2.workflow import run_workflow
 
-    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
-    from analysis.topeft_run2.workflow import run_workflow
-else:
-    from .workflow import run_workflow
+remote_environment = topcoffea.modules.remote_environment
 
 
 EXECUTOR_CLI = ExecutorCLIHelper(

--- a/analysis/topeft_run2/run_sow.py
+++ b/analysis/topeft_run2/run_sow.py
@@ -10,26 +10,31 @@ from typing import Any
 import coffea.processor as processor
 from coffea.nanoevents import NanoEventsFactory, NanoAODSchema
 
+import topcoffea
+
 if hasattr(NanoEventsFactory, "warn_missing_crossrefs"):
     NanoEventsFactory.warn_missing_crossrefs = False
 elif hasattr(NanoAODSchema, "warn_missing_crossrefs"):
     NanoAODSchema.warn_missing_crossrefs = False
-import topcoffea.modules.remote_environment as remote_environment
 
 import sow_processor
 
-from topcoffea.modules.executor import (
-    build_futures_executor,
-    futures_runner_overrides,
-    taskvine_log_configurator,
-)
-from topcoffea.modules.utils import load_sample_json_file, read_cfg_file, update_cfg
 from topeft.modules.executor_cli import (
     ExecutorCLIHelper,
     FuturesArgumentSpec,
     TaskVineArgumentSpec,
 )
 
+
+remote_environment = topcoffea.modules.remote_environment
+tc_executor = topcoffea.modules.executor
+build_futures_executor = tc_executor.build_futures_executor
+futures_runner_overrides = tc_executor.futures_runner_overrides
+taskvine_log_configurator = tc_executor.taskvine_log_configurator
+tc_utils = topcoffea.modules.utils
+load_sample_json_file = tc_utils.load_sample_json_file
+read_cfg_file = tc_utils.read_cfg_file
+update_cfg = tc_utils.update_cfg
 
 parser = argparse.ArgumentParser(description='You can customize your run')
 parser.add_argument('inputFiles'       , nargs='?', default='', help = 'Json or cfg file(s) containing files and metadata')

--- a/analysis/topeft_run2/sow_processor.py
+++ b/analysis/topeft_run2/sow_processor.py
@@ -8,9 +8,11 @@ np.seterr(divide="ignore", invalid="ignore", over="ignore")
 import coffea.processor as processor
 
 import hist
-from topcoffea.modules.HistEFT import HistEFT
-import topcoffea.modules.eft_helper as efth
-import topcoffea.modules.corrections as corrections
+import topcoffea
+
+HistEFT = topcoffea.modules.HistEFT.HistEFT
+efth = topcoffea.modules.eft_helper
+corrections = topcoffea.modules.corrections
 
 try:  # pragma: no cover - best effort optional import
     from coffea.nanoevents import NanoEventsFactory, NanoAODSchema

--- a/analysis/topeft_run2/tauFitter.py
+++ b/analysis/topeft_run2/tauFitter.py
@@ -19,8 +19,11 @@ from scipy.optimize import curve_fit
 from numpy.linalg import eig
 from scipy.odr import *
 
+import topcoffea
+
 from topeft.modules.yield_tools import YieldTools
-import topcoffea.modules.utils as utils
+
+utils = topcoffea.modules.utils
 
 yt = YieldTools()
 

--- a/analysis/topeft_run2/update_json_sow.py
+++ b/analysis/topeft_run2/update_json_sow.py
@@ -1,12 +1,18 @@
 import os
 import argparse
 
-from topcoffea.modules.paths import topcoffea_path
-from topcoffea.modules.utils import regex_match, load_sample_json_file, get_files, get_hist_from_pkl
-from topcoffea.modules.update_json import update_json
+import topcoffea
+
 from topeft.modules.yield_tools import YieldTools
 
 pjoin = os.path.join
+
+topcoffea_path = topcoffea.modules.paths.topcoffea_path
+regex_match = topcoffea.modules.utils.regex_match
+load_sample_json_file = topcoffea.modules.utils.load_sample_json_file
+get_files = topcoffea.modules.utils.get_files
+get_hist_from_pkl = topcoffea.modules.utils.get_hist_from_pkl
+update_json = topcoffea.modules.update_json.update_json
 
 # Description:
 #   This script runs on a histogram file produced by the sow_processor. It extracts the individual

--- a/analysis/topeft_run2/workflow.py
+++ b/analysis/topeft_run2/workflow.py
@@ -48,6 +48,8 @@ from typing import (
     TYPE_CHECKING,
 )
 
+import topcoffea
+
 from topeft.modules.executor import (
     build_futures_executor,
     build_taskvine_args,
@@ -58,6 +60,9 @@ from topeft.modules.executor import (
     taskvine_log_configurator,
 )
 from topeft.modules.runner_output import normalise_runner_output, tuple_dict_stats
+
+topcoffea_path = topcoffea.modules.paths.topcoffea_path
+topcoffea_utils = topcoffea.modules.utils
 
 from .run_analysis_helpers import (
     DEFAULT_WEIGHT_VARIATIONS,
@@ -600,9 +605,10 @@ class ExecutorFactory:
     def create_runner(self) -> Any:
         import coffea.processor as processor
         from coffea.nanoevents import NanoAODSchema
-        from topcoffea.modules import remote_environment
 
         executor = (self._config.executor or "taskvine").lower()
+
+        remote_environment = topcoffea.modules.remote_environment
 
         def _build_runner(exec_instance: Any, **runner_kwargs: Any) -> Any:
             return processor.Runner(
@@ -801,7 +807,6 @@ class RunWorkflow:
 
     def run(self) -> None:
         from topeft.modules.systematics import SystematicsHelper
-        from topcoffea.modules.paths import topcoffea_path
         from . import analysis_processor
 
         self._validate_config()
@@ -1147,15 +1152,14 @@ class RunWorkflow:
                 from topeft.modules.get_renormfact_envelope import (
                     get_renormfact_envelope,
                 )
-                import topcoffea.modules.utils as utils
 
-                dict_of_histos = utils.get_hist_from_pkl(
+                dict_of_histos = topcoffea_utils.get_hist_from_pkl(
                     out_pkl_file_name_np, allow_empty=False
                 )
                 dict_of_histos_after_applying_envelope = get_renormfact_envelope(
                     dict_of_histos
                 )
-                utils.dump_to_pkl(
+                topcoffea_utils.dump_to_pkl(
                     out_pkl_file_name_np, dict_of_histos_after_applying_envelope
                 )
 

--- a/analysis/training/intro_coffea.hist.ipynb
+++ b/analysis/training/intro_coffea.hist.ipynb
@@ -745,8 +745,9 @@
     "import pickle #read pickle file\n",
     "import coffea\n",
     "from coffea import hist\n",
-    "import topcoffea.modules.HistEFT as HistEFT\n",
-    "import topcoffea.modules.eft_helper as efth\n",
+    "import topcoffea\n",
+    "HistEFT = topcoffea.modules.HistEFT.HistEFT\n",
+    "efth = topcoffea.modules.eft_helper\n",
     "import gzip #read zipped pickle file\n",
     "import matplotlib.pyplot as plt #plot histograms\n",
     "import numpy as np"
@@ -778,7 +779,7 @@
      "text": [
       "/bin/bash: /opt/conda/lib/libtinfo.so.6: no version information available (required by /bin/bash)\n",
       "/bin/bash: /opt/conda/lib/libtinfo.so.6: no version information available (required by /bin/bash)\n",
-      "File ‘../histos/all2017mcsigsamples_skipSR_2022sept13_topcoffeatutorial.pkl.gz’ already there; not retrieving.\n",
+      "File \u2018../histos/all2017mcsigsamples_skipSR_2022sept13_topcoffeatutorial.pkl.gz\u2019 already there; not retrieving.\n",
       "<HistEFT (sample,channel,systematic,appl,invmass) instance at 0x7fd4fe99ec10>\n",
       "<HistEFT (sample,channel,systematic,appl,ptbl) instance at 0x7fd4fe92d910>\n",
       "<HistEFT (sample,channel,systematic,appl,ptz) instance at 0x7fd4fe93d400>\n",

--- a/analysis/training/simple_processor.py
+++ b/analysis/training/simple_processor.py
@@ -8,10 +8,19 @@ from coffea.analysis_tools import PackedSelection
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
-from topcoffea.modules.objects import *
-from topcoffea.modules.selection import *
-from topcoffea.modules.HistEFT import HistEFT
-import topcoffea.modules.eft_helper as efth
+import importlib
+import topcoffea
+
+def _inject_module_exports(module):
+    names = getattr(module, "__all__", None)
+    if names is None:
+        names = [name for name in dir(module) if not name.startswith("_")]
+    globals().update({name: getattr(module, name) for name in names})
+
+_inject_module_exports(importlib.import_module("topcoffea.modules.objects"))
+_inject_module_exports(importlib.import_module("topcoffea.modules.selection"))
+HistEFT = topcoffea.modules.HistEFT.HistEFT
+efth = topcoffea.modules.eft_helper
 
 
 class HistWithIdentity(hist.Hist):

--- a/analysis/training/simple_run.py
+++ b/analysis/training/simple_run.py
@@ -19,9 +19,11 @@ import hist
 import coffea.processor as processor
 from coffea.nanoevents import NanoAODSchema
 
-from topcoffea.modules.HistEFT import HistEFT
+import topcoffea
 
 import simple_processor
+
+HistEFT = topcoffea.modules.HistEFT.HistEFT
 
 
 def _ensure_numpy(array: Any) -> np.ndarray:

--- a/tests/test_btag_weights.py
+++ b/tests/test_btag_weights.py
@@ -1,10 +1,4 @@
-from pathlib import Path
 from types import SimpleNamespace
-import sys
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
-if str(REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(REPO_ROOT))
 
 import numpy as np
 

--- a/tests/test_channel_features.py
+++ b/tests/test_channel_features.py
@@ -1,12 +1,4 @@
-from pathlib import Path
-
 import pytest
-
-import sys
-
-_REPO_ROOT = Path(__file__).resolve().parents[1]
-if str(_REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(_REPO_ROOT))
 
 from analysis.topeft_run2.workflow import ChannelPlanner, normalize_jet_category
 from topeft.modules.channel_metadata import ChannelMetadataHelper

--- a/tests/test_corrections_smoke.py
+++ b/tests/test_corrections_smoke.py
@@ -2,6 +2,8 @@ import correctionlib
 import numpy as np
 import pytest
 
+import topcoffea
+
 from coffea.btag_tools import BTagScaleFactor
 
 from topeft.modules.corrections import (
@@ -11,7 +13,8 @@ from topeft.modules.corrections import (
     get_jerc_keys,
 )
 from topeft.modules.paths import topeft_path
-from topcoffea.modules.paths import topcoffea_path
+
+topcoffea_path = topcoffea.modules.paths.topcoffea_path
 
 
 @pytest.mark.parametrize("year", ["2018", "2023", "2023BPix"])

--- a/tests/test_executor_factory.py
+++ b/tests/test_executor_factory.py
@@ -2,9 +2,6 @@ import importlib
 import inspect
 import sys
 import types
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import coffea  # ensure the real coffea package is available during tests
 

--- a/tests/test_flavor_split_histograms.py
+++ b/tests/test_flavor_split_histograms.py
@@ -63,10 +63,6 @@ except ModuleNotFoundError:
     sys.modules["numpy"] = np_module
     np = np_module  # type: ignore[assignment]
 import pytest
-
-_REPO_ROOT = Path(__file__).resolve().parents[1]
-if str(_REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(_REPO_ROOT))
 class _DummyHistEFT:
     def __init__(self, *args, **kwargs):
         self._sumw = 0.0

--- a/tests/test_histogram_planner.py
+++ b/tests/test_histogram_planner.py
@@ -1,13 +1,6 @@
 from __future__ import annotations
 
-from pathlib import Path
-import sys
-
 import pytest
-
-_REPO_ROOT = Path(__file__).resolve().parents[1]
-if str(_REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(_REPO_ROOT))
 
 from analysis.topeft_run2.workflow import (
     ChannelPlanner,

--- a/tests/test_mc_validation_plot_utils.py
+++ b/tests/test_mc_validation_plot_utils.py
@@ -7,6 +7,11 @@ import numpy as np
 import pytest
 from hist import Hist, axis, storage
 
+try:  # pragma: no cover - optional dependency in CI
+    import topcoffea
+except ModuleNotFoundError:  # pragma: no cover - fallback used when topcoffea is absent
+    topcoffea = None  # type: ignore[assignment]
+
 from analysis.mc_validation.plot_utils import (
     build_dataset_histograms,
     component_labels,
@@ -16,9 +21,9 @@ from analysis.mc_validation.plot_utils import (
     tuple_histogram_items,
 )
 
-try:  # pragma: no cover - optional dependency in CI
-    from topcoffea.modules.HistEFT import HistEFT as _HistEFT
-except ModuleNotFoundError:  # pragma: no cover - fallback used when topcoffea is absent
+if topcoffea is not None:  # pragma: no branch - optional dependency in CI
+    _HistEFT = getattr(topcoffea.modules.HistEFT, "HistEFT", None)
+else:  # pragma: no cover - fallback used when topcoffea is absent
     _HistEFT = None
 
 

--- a/tests/test_simple_processor_hooks.py
+++ b/tests/test_simple_processor_hooks.py
@@ -1,13 +1,7 @@
 import sys
 import types
-from pathlib import Path
 
 import pytest
-
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
-if str(REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(REPO_ROOT))
 
 
 def _install_test_stubs():

--- a/tests/test_systematics_grouping.py
+++ b/tests/test_systematics_grouping.py
@@ -1,10 +1,3 @@
-from pathlib import Path
-import sys
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
-if str(REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(REPO_ROOT))
-
 from topeft.modules.systematics import SystematicsHelper
 
 

--- a/tests/test_topcoffea_import_style.py
+++ b/tests/test_topcoffea_import_style.py
@@ -1,0 +1,61 @@
+"""Ensure top-level topcoffea imports follow the namespace style."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Iterable, Iterator, List, Tuple
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_BANNED_PATTERNS: Tuple[Tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"^\s*from\s+topcoffea\."), "use 'import topcoffea' and attribute access"),
+    (re.compile(r"^\s*import\s+topcoffea\.modules"), "import the top-level package instead of submodules"),
+)
+
+
+def _iter_source_files() -> Iterator[Path]:
+    for pattern in ("*.py", "*.ipynb"):
+        yield from _REPO_ROOT.rglob(pattern)
+
+
+def _is_vendor_file(path: Path) -> bool:
+    relative = path.relative_to(_REPO_ROOT)
+    return relative.parts and relative.parts[0] == "topcoffea"
+
+
+def _scan_text_lines(path: Path, lines: Iterable[str]) -> List[str]:
+    violations: List[str] = []
+    for lineno, line in enumerate(lines, 1):
+        for pattern, guidance in _BANNED_PATTERNS:
+            if pattern.search(line):
+                violations.append(
+                    f"{path.relative_to(_REPO_ROOT)}:{lineno}: {guidance} -> {line.rstrip()}"
+                )
+    return violations
+
+
+def _scan_ipynb(path: Path) -> List[str]:
+    data = json.loads(path.read_text())
+    lines: List[str] = []
+    for cell in data.get("cells", []):
+        if cell.get("cell_type") != "code":
+            continue
+        lines.extend(cell.get("source", []))
+    return _scan_text_lines(path, lines)
+
+
+def _scan_py(path: Path) -> List[str]:
+    return _scan_text_lines(path, path.read_text().splitlines())
+
+
+def test_topcoffea_import_style() -> None:
+    violations: List[str] = []
+    for path in _iter_source_files():
+        if _is_vendor_file(path):
+            continue
+        if path.suffix == ".ipynb":
+            violations.extend(_scan_ipynb(path))
+        else:
+            violations.extend(_scan_py(path))
+    assert not violations, "\n".join(violations)

--- a/tests/test_training_tuple_output.py
+++ b/tests/test_training_tuple_output.py
@@ -5,17 +5,12 @@ from __future__ import annotations
 import importlib
 import sys
 import types
-from pathlib import Path
 from typing import Tuple
 
 import awkward as ak
 import numpy as np
 import pytest
 from hist import Hist, axis, storage
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
-if str(REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(REPO_ROOT))
 
 
 def _install_training_stubs() -> None:

--- a/tests/test_trigger_sf_weight.py
+++ b/tests/test_trigger_sf_weight.py
@@ -1,14 +1,8 @@
-from pathlib import Path
-import sys
 from types import SimpleNamespace
 
 import pytest
 
 pytest.importorskip("numpy")
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
-if str(REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(REPO_ROOT))
 
 from topeft.modules.systematics import register_trigger_sf_weight
 

--- a/topeft/modules/btag_weights.py
+++ b/topeft/modules/btag_weights.py
@@ -5,6 +5,11 @@ from typing import Mapping, MutableMapping, Optional
 
 import awkward as ak
 
+try:
+    import topcoffea
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    topcoffea = None  # type: ignore[assignment]
+
 
 @dataclass
 class BTagWeightResult:
@@ -63,9 +68,12 @@ def register_btag_sf_weights(
     """
 
     if corrections_api is None:
-        import topcoffea.modules.corrections as tc_cor  # Local import to avoid heavy dependencies during testing
+        if topcoffea is not None:
+            corrections_api = topcoffea.modules.corrections
+        else:  # pragma: no cover - fallback for testing without topcoffea
+            from topeft.modules import corrections as tc_cor
 
-        corrections_api = tc_cor
+            corrections_api = tc_cor
 
     flavour_info: MutableMapping[str, MutableMapping[str, object]] = {
         "light": {

--- a/topeft/modules/corrections.py
+++ b/topeft/modules/corrections.py
@@ -4,7 +4,6 @@
 '''
 
 from coffea import lookup_tools
-from topcoffea.modules.paths import topcoffea_path
 from topeft.modules.paths import topeft_path
 import numpy as np
 import awkward as ak
@@ -14,13 +13,15 @@ import pickle
 import correctionlib
 import json
 from coffea.jetmet_tools import CorrectedMETFactory
-### workaround while waiting the correcion-lib integration will be provided in the coffea package
-from topcoffea.modules.CorrectedJetsFactory import CorrectedJetsFactory
-from topcoffea.modules.JECStack import JECStack
 from coffea.btag_tools import BTagScaleFactor
 from coffea.lookup_tools import txt_converters, rochester_lookup
 
-from topcoffea.modules.get_param_from_jsons import GetParam
+import topcoffea
+
+topcoffea_path = topcoffea.modules.paths.topcoffea_path
+CorrectedJetsFactory = topcoffea.modules.CorrectedJetsFactory.CorrectedJetsFactory
+JECStack = topcoffea.modules.JECStack.JECStack
+GetParam = topcoffea.modules.get_param_from_jsons.GetParam
 get_tc_param = GetParam(topcoffea_path("params/params.json"))
 get_te_param = GetParam(topeft_path("params/params.json"))
 

--- a/topeft/modules/dataDrivenEstimation.py
+++ b/topeft/modules/dataDrivenEstimation.py
@@ -1,12 +1,15 @@
 import argparse
-import topcoffea.modules.utils as utils
 import cloudpickle
 from collections import defaultdict
 import re
 import gzip
 
+import topcoffea
+
 from topeft.modules.paths import topeft_path
-from topcoffea.modules.get_param_from_jsons import GetParam
+
+utils = topcoffea.modules.utils
+GetParam = topcoffea.modules.get_param_from_jsons.GetParam
 get_te_param = GetParam(topeft_path("params/params.json"))
 
 

--- a/topeft/modules/datacard_tools.py
+++ b/topeft/modules/datacard_tools.py
@@ -11,9 +11,13 @@ import time
 import yaml
 
 from collections import defaultdict
-from topcoffea.modules.utils import regex_match
+
+import topcoffea
+
 from topeft.modules.paths import topeft_path
 from topeft.modules.compatibility import add_sumw2_stub
+
+regex_match = topcoffea.modules.utils.regex_match
 
 with open(topeft_path("params/metadata.yml"), "r") as f:
     metadata = yaml.safe_load(f)

--- a/topeft/modules/get_renormfact_envelope.py
+++ b/topeft/modules/get_renormfact_envelope.py
@@ -1,9 +1,11 @@
 import numpy as np
 import argparse
 
-import topcoffea.modules.utils as utils
+import topcoffea
 from topeft.modules.yield_tools import YieldTools
 yt = YieldTools()
+
+utils = topcoffea.modules.utils
 
 
 # The names of the 6 renorm and fact variations

--- a/topeft/modules/object_selection.py
+++ b/topeft/modules/object_selection.py
@@ -7,9 +7,12 @@
 import numpy as np
 import awkward as ak
 
-from topcoffea.modules.get_param_from_jsons import GetParam
-from topcoffea.modules.paths import topcoffea_path
+import topcoffea
+
 from topeft.modules.paths import topeft_path
+
+GetParam = topcoffea.modules.get_param_from_jsons.GetParam
+topcoffea_path = topcoffea.modules.paths.topcoffea_path
 get_tc_param = GetParam(topcoffea_path("params/params.json"))
 get_te_param = GetParam(topeft_path("params/params.json"))
 

--- a/topeft/modules/parsejec.py
+++ b/topeft/modules/parsejec.py
@@ -13,7 +13,9 @@ and writes out the new corrections.
 
 
 import numpy as np
-from topcoffea.modules.paths import topcoffea_path
+import topcoffea
+
+topcoffea_path = topcoffea.modules.paths.topcoffea_path
 
 files = ['data/JEC/RegroupedV2_Summer19UL16APV_V7_MC_UncertaintySources_AK4PFchs.junc.txt', 'data/JEC/RegroupedV2_Summer19UL16_V7_MC_UncertaintySources_AK4PFchs.junc.txt', 'data/JEC/RegroupedV2_Summer19UL17_V5_MC_UncertaintySources_AK4PFchs.junc.txt', 'data/JEC/RegroupedV2_Summer19UL18_V5_MC_UncertaintySources_AK4PFchs.junc.txt']
 header='{1 JetEta 1 JetPt "" Correction JECSource}\n'

--- a/topeft/modules/runner_output.py
+++ b/topeft/modules/runner_output.py
@@ -23,8 +23,13 @@ except Exception:  # pragma: no cover - fallback when histogram extras missing
     axis = None  # type: ignore[assignment]
 
 try:  # pragma: no cover - topcoffea is optional for a subset of the tests
-    from topcoffea.modules.HistEFT import HistEFT
-except Exception:  # pragma: no cover - fallback when HistEFT is unavailable
+    import topcoffea
+except ModuleNotFoundError:
+    topcoffea = None  # type: ignore[assignment]
+
+if topcoffea is not None:  # pragma: no branch - runtime optional dependency
+    HistEFT = getattr(topcoffea.modules.HistEFT, "HistEFT", None)
+else:  # pragma: no cover - fallback when HistEFT is unavailable
     HistEFT = None  # type: ignore[assignment]
 
 

--- a/topeft/modules/systematics.py
+++ b/topeft/modules/systematics.py
@@ -20,10 +20,16 @@ from typing import (
 )
 
 import numpy as np
+
 try:
-    import topcoffea.modules.corrections as tc_cor
-except ImportError:  # pragma: no cover - fallback for standalone usage
-    import topeft.modules.corrections as tc_cor
+    import topcoffea
+except ModuleNotFoundError:  # pragma: no cover - fallback for standalone usage
+    topcoffea = None  # type: ignore[assignment]
+
+if topcoffea is not None:
+    tc_cor = topcoffea.modules.corrections
+else:  # pragma: no cover - fallback when topcoffea is absent
+    from topeft.modules import corrections as tc_cor
 
 from topeft.modules.paths import topeft_path
 

--- a/topeft/modules/yield_tools.py
+++ b/topeft/modules/yield_tools.py
@@ -2,8 +2,10 @@ import numpy as np
 import copy
 from collections.abc import Mapping
 
-from topcoffea.modules.HistEFT import HistEFT
-import topcoffea.modules.utils as utils
+import topcoffea
+
+HistEFT = topcoffea.modules.HistEFT.HistEFT
+utils = topcoffea.modules.utils
 from topeft.modules.compatibility import add_sumw2_stub
 from topeft.modules.runner_output import SUMMARY_KEY
 


### PR DESCRIPTION
## Summary
- update the analysis, module, and test code to import the topcoffea package once and access modules via the namespace
- remove ad-hoc sys.path tweaks and path shims that were used to reach topcoffea modules
- add a pytest guard that fails when new code re-introduces `from topcoffea` or `import topcoffea.modules`

## Testing
- `pytest tests/test_topcoffea_import_style.py`