### PR TITLE
Patch HistEFT import without vendoring

### DIFF
--- a/analysis/topeft_run2/run_data_driven.py
+++ b/analysis/topeft_run2/run_data_driven.py
@@ -94,6 +94,13 @@ def _resolve_path(
     if not metadata_value:
         return None
     if metadata_dir and not os.path.isabs(metadata_value):
+        metadata_value_norm = os.path.normpath(metadata_value)
+        metadata_dir_base = os.path.basename(metadata_dir)
+        if metadata_dir_base and (
+            metadata_value_norm == metadata_dir_base
+            or metadata_value_norm.startswith(f"{metadata_dir_base}{os.sep}")
+        ):
+            return metadata_value_norm
         return os.path.normpath(os.path.join(metadata_dir, metadata_value))
     return metadata_value
 

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -2,8 +2,14 @@
 import getpass
 import os
 
+from topeft.compat.topcoffea import ensure_histEFT_py39_compat
+
 # Ensure tests that expect a USER variable have a sensible default in CI.
 # getpass.getuser() falls back to LOGNAME/USER/..., but may raise in
 # containerized environments. Using os.getuid provides a stable suffix.
 _default_user = f"user{os.getuid()}"
 os.environ.setdefault("USER", getpass.getuser() if os.environ.get("USER") else _default_user)
+
+# Ensure ``topcoffea.modules.histEFT`` is patched for Python 3.9 before any
+# modules import it at module scope.
+ensure_histEFT_py39_compat()

--- a/topeft/compat/__init__.py
+++ b/topeft/compat/__init__.py
@@ -1,0 +1,1 @@
+"""Compatibility helpers for third-party dependencies."""

--- a/topeft/compat/topcoffea.py
+++ b/topeft/compat/topcoffea.py
@@ -1,0 +1,53 @@
+"""Runtime helpers that patch ``topcoffea`` for older Python versions."""
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+from typing import Optional
+
+_PATCH_TARGET = "ArrayLike | Mapping | None"
+_PATCH_REPLACEMENT = "Union[ArrayLike, Mapping, None]"
+
+
+def _patched_histEFT_source(source: str) -> Optional[str]:
+    if _PATCH_TARGET not in source:
+        return None
+    return source.replace(_PATCH_TARGET, _PATCH_REPLACEMENT)
+
+
+def ensure_histEFT_py39_compat() -> None:
+    """Load ``topcoffea.modules.histEFT`` with Python 3.9 friendly annotations."""
+
+    if sys.version_info >= (3, 10):
+        return
+
+    fullname = "topcoffea.modules.histEFT"
+    if fullname in sys.modules:
+        return
+
+    spec = importlib.util.find_spec(fullname)
+    if spec is None or spec.loader is None or not hasattr(spec.loader, "get_source"):
+        return
+
+    source = spec.loader.get_source(fullname)
+    if source is None:
+        return
+
+    patched_source = _patched_histEFT_source(source)
+    if patched_source is None:
+        # Nothing to patch, so fall back to the regular import path.
+        importlib.import_module(fullname)
+        return
+
+    module = importlib.util.module_from_spec(spec)
+    try:
+        sys.modules[fullname] = module
+        exec(compile(patched_source, spec.origin or fullname, "exec"), module.__dict__)
+    except Exception:
+        sys.modules.pop(fullname, None)
+        raise
+
+    package_name, _, attr = fullname.rpartition(".")
+    package = importlib.import_module(package_name)
+    setattr(package, attr, module)

--- a/topeft/compat/topcoffea.py
+++ b/topeft/compat/topcoffea.py
@@ -5,6 +5,7 @@ import importlib
 import importlib.util
 import sys
 from typing import Optional
+import typing
 
 _PATCH_TARGET = "ArrayLike | Mapping | None"
 _PATCH_REPLACEMENT = "Union[ArrayLike, Mapping, None]"
@@ -41,6 +42,7 @@ def ensure_histEFT_py39_compat() -> None:
         return
 
     module = importlib.util.module_from_spec(spec)
+    module.__dict__.setdefault("Union", typing.Union)
     try:
         sys.modules[fullname] = module
         exec(compile(patched_source, spec.origin or fullname, "exec"), module.__dict__)

--- a/topeft/modules/yield_tools.py
+++ b/topeft/modules/yield_tools.py
@@ -1,11 +1,16 @@
 import numpy as np
 import copy
 import logging
+
+from topeft.compat.topcoffea import ensure_histEFT_py39_compat
+from topeft.modules.compatibility import add_sumw2_stub
+from topeft.modules.utils import canonicalize_process_name
+
+ensure_histEFT_py39_compat()
+
 from topcoffea.modules.histEFT import HistEFT
 from topcoffea.modules.sparseHist import SparseHist
 import topcoffea.modules.utils as utils
-from topeft.modules.compatibility import add_sumw2_stub
-from topeft.modules.utils import canonicalize_process_name
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- remove the previously vendored `topcoffea` overlays and instead introduce a runtime compatibility shim that patches `topcoffea.modules.histEFT` when running on Python 3.9
- call the new shim from `YieldTools` before importing topcoffea modules so the upstream installation can be used unchanged

## Testing
- pytest tests/test_run_data_driven.py