### PR TITLE
Make topcoffea install instructions branch agnostic

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,15 +85,14 @@ jobs:
           conda env create -f environment.yml -n coffea-env
           conda list -n coffea-env
 
-      - name: Install local pip packages
+      - name: Install editable packages
         run: |
-          mkdir dir_for_topcoffea
-          cd dir_for_topcoffea
-          git clone https://github.com/TopEFT/topcoffea.git
-          cd topcoffea
           conda run -n coffea-env pip install -e .
-          cd ../..
-          conda run -n coffea-env pip install -e .
+          conda run -n coffea-env bash scripts/install_topcoffea.sh
+
+      - name: Verify imports
+        run: |
+          conda run -n coffea-env python -c "import topeft, topcoffea"
 
       - name: Conda list
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ MANIFEST
 
 # Per-project virtualenvs
 .venv*/
+
+# Vendored dependencies installed by helper scripts
+external/

--- a/README.md
+++ b/README.md
@@ -26,20 +26,20 @@ The topeft directory is set up to be installed as a python package. First clone 
 ```
 git clone https://github.com/TopEFT/topeft.git
 cd topeft
-unset PYTHONPATH # To avoid conflicts.  
+unset PYTHONPATH # To avoid conflicts.
 conda env create -f environment.yml
 conda activate coffea-env
 pip install -e .
+# Install the matching topcoffea checkout into the active env
+scripts/install_topcoffea.sh
+# Smoke test the imports so "import topcoffea" works everywhere
+python -c "import topeft, topcoffea"
 ```
-The `-e` option installs the project in editable mode (i.e. setuptools "develop mode"). If you wish to uninstall the package, you can do so by running `pip uninstall topcoffea`. 
-The `topcoffea` package upon which this analysis also depends is not yet available on `PyPI`, so we need to clone the `topcoffea` repo and install it ourselves.
-```
-cd /your/favorite/directory
-git clone https://github.com/TopEFT/topcoffea.git
-cd topcoffea
-pip install -e .  
-```
-Now all of the dependencies have been installed and the `topeft` repository is ready to be used. The next time you want to use it, all you have to do is to activate the environment via `conda activate coffea-env`. 
+The `-e` option installs the project in editable mode (i.e. setuptools "develop mode"). If you wish to uninstall the package, you can do so by running `pip uninstall topeft` (or `pip uninstall topcoffea` for the dependency).
+
+`scripts/install_topcoffea.sh` vendors `topcoffea` into `external/topcoffea`, checks out the repository's default branch (or whichever branch you request via `TOPCOFFEA_GIT_REF`), and performs an editable install so that the `topcoffea` package is immediately importable inside the current virtual environment. Override `TOPCOFFEA_GIT_REF`, `TOPCOFFEA_REPO_URL`, or `TOPCOFFEA_DIR` if you need a different branch, fork, or destination.
+
+Now all of the dependencies have been installed and the `topeft` repository is ready to be used. The next time you want to use it, all you have to do is to activate the environment via `conda activate coffea-env` (the editable installs keep `import topeft` and `import topcoffea` working).
 
 
 ### To run an example job 

--- a/README_WORKQUEUE.md
+++ b/README_WORKQUEUE.md
@@ -16,7 +16,10 @@ below.
 
 We highly recommend setting up topcoffea as git repository. This allows
 topcoffea to automatically detect changes that need to be included in the
-python environments sent to the workers:
+python environments sent to the workers. The helper script described below
+will automatically clone the canonical `TopEFT/topcoffea` repository into
+`external/topcoffea`, but you can also manage the checkout yourself if you
+prefer to develop inside an existing clone:
 
 ```sh
 git clone https://github.com/TopEFT/topcoffea.git
@@ -37,22 +40,24 @@ bash conda-install.sh
 ```
 
 Once `conda` is installed, open a new terminal and create the base python
-environment for topcoffea:
+environment for topeft:
 
 ```sh
 # you may choose other python version, e.g. 3.8
 conda env create -f environment.yml
 conda activate topcoffea-env
-
-# install topcoffea via pip. We install it in editable mode to ease the test of
-# changes in development. From the root directory of the topcoffea repository:
 pip install -e .
+
+# Install the editable topcoffea checkout used by topeft
+scripts/install_topcoffea.sh
 
 # You may install any other modules that you are developing, as:
 # cd /path/to/my/module
 # pip install -e .
 ```
-The same steps can be followed for `topeft` (i.e. clone the repo, `cd` into it, and then install the package via `pip install -e .`). 
+The helper script vendors `topcoffea` into `external/topcoffea` by default, checks out the repository's default branch (or whichever branch you request via `TOPCOFFEA_GIT_REF`), and installs it in editable mode so that every Work Queue payload sees `import topcoffea` without any `PYTHONPATH` hacks. Override `TOPCOFFEA_REPO_URL`, `TOPCOFFEA_GIT_REF`, or `TOPCOFFEA_DIR` to point at other forks, branches, or sandboxes.
+
+The same steps can be followed for `topeft` (i.e. clone the repo, `cd` into it, and then install the package via `pip install -e .`) whenever you need a separate checkout.
 
 ---
 **NOTE**

--- a/scripts/install_topcoffea.sh
+++ b/scripts/install_topcoffea.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+DEFAULT_DIR="${REPO_ROOT}/external/topcoffea"
+
+TOPCOFFEA_REPO_URL=${TOPCOFFEA_REPO_URL:-https://github.com/TopEFT/topcoffea.git}
+TOPCOFFEA_GIT_REF=${TOPCOFFEA_GIT_REF:-}
+TOPCOFFEA_DIR=${TOPCOFFEA_DIR:-${DEFAULT_DIR}}
+PARENT_DIR=$(dirname "${TOPCOFFEA_DIR}")
+
+mkdir -p "${PARENT_DIR}"
+
+if [[ -d "${TOPCOFFEA_DIR}/.git" ]]; then
+    echo "[install_topcoffea] Updating existing checkout at ${TOPCOFFEA_DIR}" >&2
+    git -C "${TOPCOFFEA_DIR}" remote set-url origin "${TOPCOFFEA_REPO_URL}"
+    git -C "${TOPCOFFEA_DIR}" fetch origin
+else
+    echo "[install_topcoffea] Cloning ${TOPCOFFEA_REPO_URL} into ${TOPCOFFEA_DIR}" >&2
+    git clone "${TOPCOFFEA_REPO_URL}" "${TOPCOFFEA_DIR}"
+fi
+
+if [[ -z "${TOPCOFFEA_GIT_REF}" ]]; then
+    DEFAULT_BRANCH=$(git -C "${TOPCOFFEA_DIR}" remote show origin | awk '/HEAD branch:/ {print $NF}')
+    TOPCOFFEA_GIT_REF=${DEFAULT_BRANCH:-master}
+fi
+
+echo "[install_topcoffea] Checking out ${TOPCOFFEA_GIT_REF}" >&2
+git -C "${TOPCOFFEA_DIR}" checkout "${TOPCOFFEA_GIT_REF}"
+git -C "${TOPCOFFEA_DIR}" pull --ff-only origin "${TOPCOFFEA_GIT_REF}" >/dev/null 2>&1 || true
+
+echo "[install_topcoffea] Installing topcoffea in editable mode" >&2
+python -m pip install -e "${TOPCOFFEA_DIR}"
+
+echo "[install_topcoffea] topcoffea is now importable from $(python -c 'import sys; print(sys.executable)')" >&2

--- a/tests/test_faketau_sf_fitter_cli.py
+++ b/tests/test_faketau_sf_fitter_cli.py
@@ -2,7 +2,6 @@ import gzip
 import json
 import logging
 import math
-import os
 import pathlib
 import re
 import subprocess
@@ -409,12 +408,6 @@ def test_cli_outputs_tau_fake_sf_json(tmp_path):
     json_path = tmp_path / "tau_sf.json"
     script_path = ROOT / "analysis" / "topeft_run2" / "faketau_sf_fitter.py"
 
-    env = os.environ.copy()
-    pythonpath = env.get("PYTHONPATH")
-    env["PYTHONPATH"] = (
-        f"{ROOT}:{pythonpath}" if pythonpath else str(ROOT)
-    )
-
     completed = subprocess.run(
         [
             sys.executable,
@@ -428,7 +421,6 @@ def test_cli_outputs_tau_fake_sf_json(tmp_path):
         ],
         check=True,
         cwd=str(ROOT),
-        env=env,
         capture_output=True,
         text=True,
     )

--- a/tests/test_topcoffea_import.py
+++ b/tests/test_topcoffea_import.py
@@ -1,0 +1,8 @@
+"""Smoke tests for external dependencies that we vendor locally."""
+
+import importlib
+
+
+def test_topcoffea_is_importable():
+    module = importlib.import_module("topcoffea")
+    assert module.__name__ == "topcoffea"


### PR DESCRIPTION
## Summary
- teach `scripts/install_topcoffea.sh` to fall back to the upstream repository's default branch unless `TOPCOFFEA_GIT_REF` is provided explicitly
- adjust the main and Work Queue READMEs so the installation instructions describe the branch-agnostic behaviour instead of hard-coding `run3_test_mmerged`

## Testing
- `pytest tests/test_topcoffea_import.py`