### PR TITLE
Standardize topcoffea namespace imports

### DIFF
--- a/analysis/extreme_events_study/extreme_events.py
+++ b/analysis/extreme_events_study/extreme_events.py
@@ -8,8 +8,8 @@ from coffea.analysis_tools import PackedSelection
 from coffea.lumi_tools import LumiMask
 from coffea.processor.accumulator import AccumulatorABC
 
-import importlib
 import topcoffea
+from topeft.modules.topcoffea_imports import require_module
 
 def _inject_module_exports(module):
     names = getattr(module, "__all__", None)
@@ -17,9 +17,9 @@ def _inject_module_exports(module):
         names = [name for name in dir(module) if not name.startswith("_")]
     globals().update({name: getattr(module, name) for name in names})
 
-_inject_module_exports(importlib.import_module("topcoffea.modules.objects"))
-_inject_module_exports(importlib.import_module("topcoffea.modules.selection"))
-tc_corrections = importlib.import_module("topcoffea.modules.corrections")
+_inject_module_exports(require_module("objects"))
+_inject_module_exports(require_module("selection"))
+tc_corrections = require_module("corrections")
 AttachMuonSF = tc_corrections.AttachMuonSF
 AttachElectronSF = tc_corrections.AttachElectronSF
 AttachPerLeptonFR = tc_corrections.AttachPerLeptonFR

--- a/analysis/flip_measurement/flip_ar_processor.py
+++ b/analysis/flip_measurement/flip_ar_processor.py
@@ -14,10 +14,10 @@ import coffea.processor as processor
 from coffea.analysis_tools import PackedSelection, Weights
 from coffea.lumi_tools import LumiMask
 
-import importlib
 import topcoffea
 
 from topeft.modules.runner_output import SUMMARY_KEY, materialise_tuple_dict
+from topeft.modules.topcoffea_imports import require_module
 
 
 def _inject_module_exports(module):
@@ -26,9 +26,9 @@ def _inject_module_exports(module):
         names = [name for name in dir(module) if not name.startswith("_")]
     globals().update({name: getattr(module, name) for name in names})
 
-_inject_module_exports(importlib.import_module("topcoffea.modules.objects"))
-_inject_module_exports(importlib.import_module("topcoffea.modules.selection"))
-tc_corrections = importlib.import_module("topcoffea.modules.corrections")
+_inject_module_exports(require_module("objects"))
+_inject_module_exports(require_module("selection"))
+tc_corrections = require_module("corrections")
 AttachMuonSF = tc_corrections.AttachMuonSF
 AttachElectronSF = tc_corrections.AttachElectronSF
 AttachPerLeptonFR = tc_corrections.AttachPerLeptonFR

--- a/analysis/mc_validation/mc_validation_gen_plotter.py
+++ b/analysis/mc_validation/mc_validation_gen_plotter.py
@@ -13,11 +13,11 @@ from hist import axis, storage
 
 from pathlib import Path
 
-import importlib
 import topcoffea
+from topeft.modules.topcoffea_imports import require_script
 
 YieldTools = topcoffea.modules.YieldTools.YieldTools
-make_html = importlib.import_module("topcoffea.scripts.make_html").make_html
+make_html = require_script("make_html").make_html
 
 from analysis.mc_validation.plot_utils import (
     build_dataset_histograms,

--- a/analysis/mc_validation/mc_validation_gen_processor.py
+++ b/analysis/mc_validation/mc_validation_gen_processor.py
@@ -8,8 +8,8 @@ import coffea.processor as processor
 from collections import OrderedDict, defaultdict
 from typing import Any, Dict, Tuple, Union
 
-import importlib
 import topcoffea
+from topeft.modules.topcoffea_imports import require_module
 
 from topeft.modules.runner_output import SUMMARY_KEY, materialise_tuple_dict
 
@@ -20,8 +20,8 @@ def _inject_module_exports(module):
         names = [name for name in dir(module) if not name.startswith("_")]
     globals().update({name: getattr(module, name) for name in names})
 
-_inject_module_exports(importlib.import_module("topcoffea.modules.objects"))
-_inject_module_exports(importlib.import_module("topcoffea.modules.selection"))
+_inject_module_exports(require_module("objects"))
+_inject_module_exports(require_module("selection"))
 HistEFT = topcoffea.modules.HistEFT.HistEFT
 efth = topcoffea.modules.eft_helper
 get_lumi = topcoffea.modules.GetValuesFromJsons.get_lumi

--- a/analysis/mc_validation/mc_validation_plotter.py
+++ b/analysis/mc_validation/mc_validation_plotter.py
@@ -10,12 +10,12 @@ import argparse
 from pathlib import Path
 
 import uproot
-import importlib
 import topcoffea
+from topeft.modules.topcoffea_imports import require_script
 
 topcoffea_path = topcoffea.modules.paths.topcoffea_path
 YieldTools = topcoffea.modules.YieldTools.YieldTools
-make_html = importlib.import_module("topcoffea.scripts.make_html").make_html
+make_html = require_script("make_html").make_html
 
 from analysis.mc_validation.plot_utils import (
     build_dataset_histograms,

--- a/analysis/topeft_run2/make_1d_quad_plots.py
+++ b/analysis/topeft_run2/make_1d_quad_plots.py
@@ -3,12 +3,12 @@ import argparse
 import datetime
 from coffea.nanoevents import NanoEventsFactory
 
-import importlib
 import topcoffea
+from topeft.modules.topcoffea_imports import require_script
 
 qft = topcoffea.modules.quad_fit_tools
 utils = topcoffea.modules.utils
-make_html = importlib.import_module("topcoffea.scripts.make_html").make_html
+make_html = require_script("make_html").make_html
 
 # This is more or less a placeholder script
 #   - It shows  an example of how we might want to access the quadratic fit information using topcoffea.modules.quad_fit_tools

--- a/analysis/topeft_run2/make_1d_quad_plots_from_template_histos.py
+++ b/analysis/topeft_run2/make_1d_quad_plots_from_template_histos.py
@@ -35,12 +35,11 @@
 #       python make_1d_quad_plots_from_template_histos.py
 
 import os
-import importlib
-
 import topcoffea
+from topeft.modules.topcoffea_imports import require_script
 
 qft = topcoffea.modules.quad_fit_tools
-make_html = importlib.import_module("topcoffea.scripts.make_html").make_html
+make_html = require_script("make_html").make_html
 
 # Load the input dict (with all of the values from the template histos)
 # Note this is a PLACEHOLDER (should be a command line argument?)

--- a/analysis/topeft_run2/make_cr_and_sr_plots.py
+++ b/analysis/topeft_run2/make_cr_and_sr_plots.py
@@ -3,7 +3,6 @@ import os
 import copy
 import datetime
 import argparse
-import importlib
 import yaml
 import matplotlib as mpl
 mpl.use('Agg')
@@ -15,6 +14,7 @@ import hist
 import topcoffea
 
 from topeft.modules.paths import topeft_path
+from topeft.modules.topcoffea_imports import require_script
 
 metadata_path = topeft_path("params/metadata.yml")
 with open(metadata_path, "r") as f:
@@ -29,7 +29,7 @@ topcoffea_path = topcoffea.modules.paths.topcoffea_path
 GetParam = topcoffea.modules.get_param_from_jsons.GetParam
 get_tc_param = GetParam(topcoffea_path("params/params.json"))
 utils = topcoffea.modules.utils
-make_html = importlib.import_module("topcoffea.scripts.make_html").make_html
+make_html = require_script("make_html").make_html
 
 
 # This script takes an input pkl file that should have both data and background MC included.

--- a/analysis/topeft_run2/missing_parton.py
+++ b/analysis/topeft_run2/missing_parton.py
@@ -13,15 +13,15 @@ import mplhep as hep
 import math
 from topeft.modules.comp_datacard import strip
 import re
-import importlib
 
 from topeft.modules.paths import topeft_path
 import topcoffea
+from topeft.modules.topcoffea_imports import require_script
 
 topcoffea_path = topcoffea.modules.paths.topcoffea_path
 GetParam = topcoffea.modules.get_param_from_jsons.GetParam
 get_tc_param = GetParam(topcoffea_path("params/params.json"))
-make_html = importlib.import_module("topcoffea.scripts.make_html").make_html
+make_html = require_script("make_html").make_html
 
 files = ['2lss_4t_m', '2lss_4t_p', '2lss_fwd_m', '2lss_fwd_p', '2lss_m', '2lss_p', '3l_m_offZ_1b', '3l_m_offZ_2b', '3l_onZ_1b', '3l_onZ_2b', '3l_p_offZ_1b', '3l_p_offZ_2b', '4l']
 files = ['2lss_fwd_m', '2lss_fwd_p']

--- a/analysis/topeft_run2/parse_datacard_templates.py
+++ b/analysis/topeft_run2/parse_datacard_templates.py
@@ -6,13 +6,13 @@
 
 import os
 import argparse
-import importlib
 import ROOT
 
 import topcoffea
 import get_datacard_yields as dy # Note the functions we're using from this script should probably go in topeft/modules
+from topeft.modules.topcoffea_imports import require_script
 
-make_html = importlib.import_module("topcoffea.scripts.make_html").make_html
+make_html = require_script("make_html").make_html
 
 
 # Get the list of histo names from a root file

--- a/analysis/training/simple_processor.py
+++ b/analysis/training/simple_processor.py
@@ -8,8 +8,8 @@ from coffea.analysis_tools import PackedSelection
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
-import importlib
 import topcoffea
+from topeft.modules.topcoffea_imports import require_module
 
 def _inject_module_exports(module):
     names = getattr(module, "__all__", None)
@@ -17,8 +17,8 @@ def _inject_module_exports(module):
         names = [name for name in dir(module) if not name.startswith("_")]
     globals().update({name: getattr(module, name) for name in names})
 
-_inject_module_exports(importlib.import_module("topcoffea.modules.objects"))
-_inject_module_exports(importlib.import_module("topcoffea.modules.selection"))
+_inject_module_exports(require_module("objects"))
+_inject_module_exports(require_module("selection"))
 HistEFT = topcoffea.modules.HistEFT.HistEFT
 efth = topcoffea.modules.eft_helper
 

--- a/tests/test_simple_processor_hooks.py
+++ b/tests/test_simple_processor_hooks.py
@@ -87,9 +87,11 @@ def _install_test_stubs():
     objects_module = types.ModuleType("topcoffea.modules.objects")
     objects_module.isClean = lambda *_, **__: True  # type: ignore[attr-defined]
     sys.modules["topcoffea.modules.objects"] = objects_module
+    modules_pkg.objects = objects_module  # type: ignore[attr-defined]
 
     selection_module = types.ModuleType("topcoffea.modules.selection")
     sys.modules["topcoffea.modules.selection"] = selection_module
+    modules_pkg.selection = selection_module  # type: ignore[attr-defined]
 
     class _DummyHistEFT:
         def __init__(self, *_, **__):
@@ -101,15 +103,18 @@ def _install_test_stubs():
     hist_eft_module = types.ModuleType("topcoffea.modules.HistEFT")
     hist_eft_module.HistEFT = _DummyHistEFT
     sys.modules["topcoffea.modules.HistEFT"] = hist_eft_module
+    modules_pkg.HistEFT = hist_eft_module  # type: ignore[attr-defined]
 
     hist_eft_lower_module = types.ModuleType("topcoffea.modules.histEFT")
     hist_eft_lower_module.HistEFT = _DummyHistEFT
     sys.modules["topcoffea.modules.histEFT"] = hist_eft_lower_module
+    modules_pkg.histEFT = hist_eft_lower_module  # type: ignore[attr-defined]
 
     eft_helper_module = types.ModuleType("topcoffea.modules.eft_helper")
     eft_helper_module.calc_w2_coeffs = lambda *_, **__: None  # type: ignore[attr-defined]
     eft_helper_module.remap_coeffs = lambda *args, **__: args[2] if len(args) > 2 else None  # type: ignore[attr-defined]
     sys.modules["topcoffea.modules.eft_helper"] = eft_helper_module
+    modules_pkg.eft_helper = eft_helper_module  # type: ignore[attr-defined]
 
 
 def _build_processor(monkeypatch, is_data):

--- a/tests/test_sow_processor.py
+++ b/tests/test_sow_processor.py
@@ -11,6 +11,10 @@ if "topcoffea.modules.corrections" not in sys.modules:
     corrections_stub.AttachPSWeights = lambda *args, **kwargs: None  # type: ignore[assignment]
     corrections_stub.AttachScaleWeights = lambda *args, **kwargs: None  # type: ignore[assignment]
     sys.modules["topcoffea.modules.corrections"] = corrections_stub
+    topcoffea_pkg = sys.modules.setdefault("topcoffea", types.ModuleType("topcoffea"))
+    modules_pkg = sys.modules.setdefault("topcoffea.modules", types.ModuleType("topcoffea.modules"))
+    topcoffea_pkg.modules = modules_pkg  # type: ignore[attr-defined]
+    modules_pkg.corrections = corrections_stub  # type: ignore[attr-defined]
 
 from analysis.topeft_run2 import sow_processor
 

--- a/tests/test_topcoffea_import_style.py
+++ b/tests/test_topcoffea_import_style.py
@@ -11,6 +11,10 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 _BANNED_PATTERNS: Tuple[Tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"^\s*from\s+topcoffea\."), "use 'import topcoffea' and attribute access"),
     (re.compile(r"^\s*import\s+topcoffea\.modules"), "import the top-level package instead of submodules"),
+    (
+        re.compile(r"importlib\.import_module\(\s*[\"']topcoffea\."),
+        "load through 'topcoffea.import_module' and attribute access",
+    ),
 )
 
 

--- a/tests/test_training_tuple_output.py
+++ b/tests/test_training_tuple_output.py
@@ -21,17 +21,20 @@ def _install_training_stubs() -> None:
     topcoffea_pkg.modules = modules_pkg  # type: ignore[attr-defined]
 
     objects_module = sys.modules.setdefault("topcoffea.modules.objects", types.ModuleType("topcoffea.modules.objects"))
+    modules_pkg.objects = objects_module  # type: ignore[attr-defined]
 
     def _always_clean(jets, leptons, drmin=0.4):  # pragma: no cover - exercised indirectly
         return ak.ones_like(jets.pt, dtype=bool)
 
     objects_module.isClean = _always_clean  # type: ignore[attr-defined]
 
-    sys.modules.setdefault("topcoffea.modules.selection", types.ModuleType("topcoffea.modules.selection"))
+    selection_module = sys.modules.setdefault("topcoffea.modules.selection", types.ModuleType("topcoffea.modules.selection"))
+    modules_pkg.selection = selection_module  # type: ignore[attr-defined]
 
     eft_helper_module = sys.modules.setdefault(
         "topcoffea.modules.eft_helper", types.ModuleType("topcoffea.modules.eft_helper")
     )
+    modules_pkg.eft_helper = eft_helper_module  # type: ignore[attr-defined]
     eft_helper_module.remap_coeffs = lambda *_args, **_kwargs: _args[2] if len(_args) > 2 else None  # type: ignore[attr-defined]
     eft_helper_module.calc_w2_coeffs = lambda coeffs, *_: coeffs  # type: ignore[attr-defined]
 
@@ -70,6 +73,8 @@ def _install_training_stubs() -> None:
     hist_eft_module.HistEFT = _DummyHistEFT
     sys.modules["topcoffea.modules.HistEFT"] = hist_eft_module
     sys.modules["topcoffea.modules.histEFT"] = hist_eft_module
+    modules_pkg.HistEFT = hist_eft_module  # type: ignore[attr-defined]
+    modules_pkg.histEFT = hist_eft_module  # type: ignore[attr-defined]
 
 
 @pytest.fixture()
@@ -127,7 +132,7 @@ def synthetic_events() -> ak.Array:
             "event": [1000, 1001, 1002],
         }
     )
-    events.metadata = {"dataset": "SampleMC"}
+    object.__setattr__(events, "metadata", {"dataset": "SampleMC"})
     return events
 
 

--- a/topeft/modules/topcoffea_imports.py
+++ b/topeft/modules/topcoffea_imports.py
@@ -1,0 +1,58 @@
+"""Helpers for resolving ``topcoffea`` namespace modules."""
+
+from __future__ import annotations
+
+import sys
+from importlib import import_module
+from types import ModuleType
+from typing import Callable
+
+import topcoffea
+
+__all__ = ["require_module", "require_script"]
+
+
+def _resolve_importer() -> Callable[[str], ModuleType]:
+    importer = getattr(topcoffea, "import_module", None)
+    if importer is not None:
+        return importer
+    return import_module
+
+
+def _load_namespace(namespace: str) -> ModuleType:
+    try:
+        return getattr(topcoffea, namespace)
+    except AttributeError:
+        importer = _resolve_importer()
+        importer(f"topcoffea.{namespace}")
+        return getattr(topcoffea, namespace)
+
+
+def _resolve_attr(namespace: str, dotted_name: str) -> ModuleType:
+    importer = _resolve_importer()
+    module_path = f"topcoffea.{namespace}.{dotted_name}"
+    module = importer(module_path)
+    namespace_module = _load_namespace(namespace)
+    current = namespace_module
+    parts = dotted_name.split(".")
+    for index, part in enumerate(parts, 1):
+        if not hasattr(current, part):
+            subpath = ".".join(parts[:index])
+            child = sys.modules.get(f"topcoffea.{namespace}.{subpath}")
+            if child is None:
+                child = importer(f"topcoffea.{namespace}.{subpath}")
+            setattr(current, part, child)
+        current = getattr(current, part)
+    return current
+
+
+def require_module(name: str) -> ModuleType:
+    """Return ``topcoffea.modules.<name>`` after ensuring it is imported."""
+
+    return _resolve_attr("modules", name)
+
+
+def require_script(name: str) -> ModuleType:
+    """Return ``topcoffea.scripts.<name>`` after ensuring it is imported."""
+
+    return _resolve_attr("scripts", name)


### PR DESCRIPTION
## Summary
- add a shared helper that resolves `topcoffea.modules` and `topcoffea.scripts` entries so every caller can rely on attribute access without resorting to `sys.path` hacks
- update all training, validation, and plotting scripts to call the helper (and refresh the lint guard) so `make_html`, object selection, and correction modules are imported consistently
- harden the unit tests that stub `topcoffea` by wiring the stubbed modules onto the namespace and by using `object.__setattr__` for metadata assignment

## Testing
- `pytest tests/test_topcoffea_import_style.py`
- `pytest tests/test_training_tuple_output.py`