### PR TITLE
Add topcoffea branch guard and document pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,15 @@ The [`topcoffea`](https://github.com/TopEFT/topcoffea) package upon which this a
 cd /your/favorite/directory
 git clone https://github.com/TopEFT/topcoffea.git
 cd topcoffea
+git switch ch_update_calcoffea
 pip install -e .
 cd ../topeft
 python -m topcoffea.modules.remote_environment
 python -c "import topcoffea"
 ```
-Keeping both repositories installed in editable mode ensures the remote-packaging helper inspects the current checkouts (and fails fast if there are unstaged edits).  The `python -m topcoffea.modules.remote_environment` command calls into the updated `remote_environment.get_environment()` logic, which assembles a fresh TaskVine-ready tarball under `topeft-envs/`, captures the pinned Conda + pip stack, and returns the archive path that the workflow passes through the `environment_file` executor argument.  The helper will rebuild the cache whenever the specification or editable sources change, so re-running it before distributed submissions keeps the workers in sync.  The final `python -c "import topcoffea"` line mirrors the CI smoke test and confirms the namespace import succeeds for downstream tooling.
+Keeping both repositories installed in editable mode ensures the remote-packaging helper inspects the current checkouts (and fails fast if there are unstaged edits).  **Always switch the sibling checkout to `ch_update_calcoffea` (or the matching release tag) before running `pip install -e ../topcoffea` _and_ when invoking `python -m topcoffea.modules.remote_environment`.**  Packaging the tarball from the same branch keeps the Conda + pip stack aligned with the processors.  Analysts relying on a detached tag can set `TOPCOFFEA_BRANCH=<tag>` before running `topeft` so the guard recognises the pinned reference.  All CLI entry points now validate that the resolved branch matches the expected `ch_update_calcoffea` baseline (using `.git/HEAD` when available or the `TOPCOFFEA_BRANCH` override), raising a clear error if the sibling checkout drifts.
+
+The `python -m topcoffea.modules.remote_environment` command calls into the updated `remote_environment.get_environment()` logic, which assembles a fresh TaskVine-ready tarball under `topeft-envs/`, captures the pinned Conda + pip stack, and returns the archive path that the workflow passes through the `environment_file` executor argument.  The helper will rebuild the cache whenever the specification or editable sources change, so re-running it before distributed submissions keeps the workers in sync.  The final `python -c "import topcoffea"` line mirrors the CI smoke test and confirms the namespace import succeeds for downstream tooling.
 
 #### Packaged TaskVine environment cache
 

--- a/analysis/topeft_run2/README.md
+++ b/analysis/topeft_run2/README.md
@@ -122,7 +122,7 @@ This directory contains scripts for the Full Run 2 EFT analysis. This README doc
 * `make_cr_and_sr_plots.py`:
     - This script makes plots for all CRs categories and can also make SR plots.
     - The script takes as input the 5-tuple histogram pickle produced by the current topcoffea runners (e.g. TaskVine output that has both data and background MC).
-    - Ensure `python -c "import topcoffea"` succeeds in the active environment (install the sibling checkout via `pip install -e ../topcoffea` when developing locally) before running the plotter so `topcoffea.modules` imports resolve.
+    - Ensure `python -c "import topcoffea"` succeeds in the active environment. Install the sibling checkout via `pip install -e ../topcoffea` **after running** `git -C ../topcoffea switch ch_update_calcoffea` (or checking out the matching release tag) when developing locally so the processors, packaged environments, and guard all agree on the dependency baseline.
     - Example usage (smoke test with TaskVine-style output): `python make_cr_and_sr_plots.py -f /path/to/taskvine/output/plotsTopEFT.pkl.gz -o /tmp/cr_sr_smoke -n plots -y 2018 --skip-syst`
     - See `examples/run_make_cr_and_sr_plots_smoke.sh` for a ready-to-run wrapper that expects an existing runner output pickle.
 

--- a/analysis/topeft_run2/examples/run_make_cr_and_sr_plots_smoke.sh
+++ b/analysis/topeft_run2/examples/run_make_cr_and_sr_plots_smoke.sh
@@ -8,8 +8,10 @@ cd "${PROJECT_ROOT}"
 if ! python -c "import topcoffea" >/dev/null 2>&1; then
   cat >&2 <<'EOF'
 Missing topcoffea dependency.
-Install the sibling checkout with `pip install -e ../topcoffea` (or any other
-source that provides `import topcoffea`) before running this smoke test.
+Install the sibling checkout with `pip install -e ../topcoffea` after running
+`git -C ../topcoffea switch ch_update_calcoffea` (or checking out the matching
+tag) before running this smoke test so the processors and packaged environments
+stay in sync.
 EOF
   exit 1
 fi

--- a/docs/quickstart_run2.md
+++ b/docs/quickstart_run2.md
@@ -29,10 +29,17 @@ checklist):
 ```bash
 git clone https://github.com/TopEFT/topcoffea.git
 cd topcoffea
+git switch ch_update_calcoffea
 pip install -e .
 cd ../topeft
 python -m topcoffea.modules.remote_environment
 ```
+
+Always invoke `python -m topcoffea.modules.remote_environment` from the same
+branch (or tag) you just installed so the packaged tarball matches the source.
+All CLI entry points validate the active branch via `.git/HEAD` (or the
+`TOPCOFFEA_BRANCH` override for detached tags) and raise immediately when the
+checkout diverges from `ch_update_calcoffea`.
 
 The helper emits the cache path under `topeft-envs/`.  Pass the same value to
 ``vine_submit_workers --python-env`` when scaling beyond the default local

--- a/docs/quickstart_top22_006.md
+++ b/docs/quickstart_top22_006.md
@@ -36,8 +36,15 @@ single distributed-execution checklist):
    ```bash
    git clone https://github.com/TopEFT/topcoffea.git
    cd topcoffea
+   git switch ch_update_calcoffea
    pip install -e .
    ```
+
+   Run `python -m topcoffea.modules.remote_environment` from the same branch (or
+   release tag) so the packaged tarball matches your processors.  The branch
+   guard embedded in the CLI entry points inspects `.git/HEAD` (or the
+   `TOPCOFFEA_BRANCH` override for detached tags) and aborts early when the
+   sibling checkout drifts from `ch_update_calcoffea`.
 
 3. **Access to the Run 2 metadata bundles.**  The YAML preset points to
    configuration files already tracked in this repository under

--- a/docs/taskvine_workflow.md
+++ b/docs/taskvine_workflow.md
@@ -24,6 +24,7 @@ next to `topeft` and install it in editable mode:
 cd ..
 git clone https://github.com/TopEFT/topcoffea.git
 cd topcoffea
+git switch ch_update_calcoffea
 pip install -e .
 cd ../topeft
 ```
@@ -40,7 +41,11 @@ editable installs match the packaged worker tarball.
 The workflow relies on the refreshed
 `topcoffea.modules.remote_environment.get_environment()` helper to assemble a
 TaskVine-ready archive under `topeft-envs/`.  Run the packaging step after
-installing the editable modules or updating dependencies:
+installing the editable modules or updating dependencies.  Always invoke the
+helper from the same branch (or tag) you just installed so the tarball mirrors
+the source checkout—every CLI entry point now validates the active branch via
+`.git/HEAD` (or the `TOPCOFFEA_BRANCH` override for detached tags) and aborts
+early when the sibling repository drifts from `ch_update_calcoffea`:
 
 ```bash
 python -m topcoffea.modules.remote_environment

--- a/tests/test_dependency_checks.py
+++ b/tests/test_dependency_checks.py
@@ -1,0 +1,55 @@
+import sys
+import types
+
+import pytest
+
+from topeft._dependency_checks import ensure_topcoffea_branch
+
+
+def _install_topcoffea_stub(monkeypatch, tmp_path, *, head_contents=None):
+    repo_root = tmp_path / "topcoffea-src"
+    pkg_dir = repo_root / "topcoffea"
+    pkg_dir.mkdir(parents=True)
+    init_file = pkg_dir / "__init__.py"
+    init_file.write_text("# stub")
+
+    module = types.ModuleType("topcoffea")
+    module.__file__ = str(init_file)
+    module.modules = types.SimpleNamespace()
+
+    monkeypatch.setitem(sys.modules, "topcoffea", module)
+
+    if head_contents is not None:
+        git_dir = repo_root / ".git"
+        git_dir.mkdir(parents=True)
+        (git_dir / "HEAD").write_text(head_contents)
+
+
+def test_branch_guard_accepts_expected_branch(monkeypatch, tmp_path):
+    _install_topcoffea_stub(
+        monkeypatch,
+        tmp_path,
+        head_contents="ref: refs/heads/ch_update_calcoffea\n",
+    )
+
+    ensure_topcoffea_branch()
+
+
+def test_branch_guard_rejects_mismatched_branch(monkeypatch, tmp_path):
+    _install_topcoffea_stub(
+        monkeypatch,
+        tmp_path,
+        head_contents="ref: refs/heads/main\n",
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        ensure_topcoffea_branch()
+
+    assert "ch_update_calcoffea" in str(excinfo.value)
+
+
+def test_branch_guard_accepts_env_override(monkeypatch, tmp_path):
+    _install_topcoffea_stub(monkeypatch, tmp_path, head_contents=None)
+    monkeypatch.setenv("TOPCOFFEA_BRANCH", "ch_update_calcoffea")
+
+    ensure_topcoffea_branch()

--- a/topeft/_dependency_checks.py
+++ b/topeft/_dependency_checks.py
@@ -1,0 +1,91 @@
+"""Dependency guards for ensuring aligned topcoffea checkouts."""
+
+from __future__ import annotations
+
+"""Dependency guards to keep sibling topcoffea checkouts aligned."""
+
+import os
+from pathlib import Path
+from typing import Optional, Sequence
+
+EXPECTED_TOPCOFFEA_REFS: tuple[str, ...] = tuple(
+    ref.strip()
+    for ref in os.environ.get("TOPEFT_TOPCOFFEA_EXPECTED", "ch_update_calcoffea").split(",")
+    if ref.strip()
+)
+
+
+def _topcoffea_repo_root(topcoffea_pkg: object) -> Optional[Path]:
+    module_file = getattr(topcoffea_pkg, "__file__", None)
+    if not module_file:
+        return None
+    module_path = Path(module_file).resolve()
+    try:
+        return module_path.parent.parent
+    except AttributeError:  # pragma: no cover - defensive
+        return None
+
+
+def _branch_from_head(repo_root: Path) -> Optional[str]:
+    head_path = repo_root / ".git" / "HEAD"
+    try:
+        contents = head_path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return None
+    except OSError:
+        return None
+
+    if contents.startswith("ref:"):
+        ref_name = contents.split("ref:", 1)[1].strip()
+        return Path(ref_name).name
+    return None
+
+
+def _normalise_expected(expected: Optional[Sequence[str]]) -> tuple[str, ...]:
+    refs = tuple(ref.strip() for ref in (expected or EXPECTED_TOPCOFFEA_REFS) if ref.strip())
+    return refs or ("ch_update_calcoffea",)
+
+
+def ensure_topcoffea_branch(expected_refs: Optional[Sequence[str]] = None) -> None:
+    """Raise ``RuntimeError`` when the topcoffea checkout is off the baseline."""
+
+    if os.environ.get("TOPEFT_SKIP_TOPCOFFEA_BRANCH_CHECK"):
+        return
+
+    try:
+        import topcoffea  # type: ignore[import-not-found]
+    except Exception as exc:  # pragma: no cover - environment issue
+        raise RuntimeError(
+            "topcoffea is not installed. Clone https://github.com/TopEFT/topcoffea, "
+            "switch to the ch_update_calcoffea branch, and install it with 'pip install -e .'"
+        ) from exc
+
+    repo_root = _topcoffea_repo_root(topcoffea)
+    if repo_root is None:
+        return
+
+    branch = os.environ.get("TOPCOFFEA_BRANCH")
+    if not branch:
+        branch = _branch_from_head(repo_root)
+
+    if not branch:
+        # No git metadata available; assume tests or a vendored copy.
+        return
+
+    expected = _normalise_expected(expected_refs)
+    if branch in expected:
+        return
+
+    message = (
+        "topcoffea checkout at {repo} is on '{branch}' but the workflow expects one of "
+        "{expected}. Run 'git -C {repo} switch ch_update_calcoffea' (or checkout the "
+        "matching tag) before running topeft, or export TOPCOFFEA_BRANCH to override.".format(
+            repo=repo_root,
+            branch=branch,
+            expected=", ".join(expected),
+        )
+    )
+    raise RuntimeError(message)
+
+
+__all__ = ["ensure_topcoffea_branch"]

--- a/topeft/modules/executor.py
+++ b/topeft/modules/executor.py
@@ -16,6 +16,10 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, Optional, Sequence, Tuple
 import warnings
 
+from .._dependency_checks import ensure_topcoffea_branch
+
+ensure_topcoffea_branch()
+
 
 def parse_port_range(port: str) -> Tuple[int, int]:
     """Normalise a ``PORT`` or ``PORT_MIN-PORT_MAX`` string to a tuple."""


### PR DESCRIPTION
## Summary
- document the requirement to switch the sibling topcoffea checkout to `ch_update_calcoffea` before installation and when packaging the remote environment across the README, Run 2 docs, quickstarts, and helper scripts
- add a dependency guard that inspects the active topcoffea branch (with a `TOPCOFFEA_BRANCH` override) so workflows fail fast when the checkout drifts from the supported baseline, plus regression tests covering success, mismatch, and override scenarios

## Testing
- `pytest tests/test_dependency_checks.py`
- `pytest tests/test_executor_environment.py`