### PR TITLE
Add local futures helper script and smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,24 @@ For a narrated walkthrough that ties environment preparation, tarball packaging,
 
    For HTCondor-backed pools, `condor_submit_workers` and other submission helpers ship with TaskVine; point them at the same manager string and pass `--python-env` when the helper supports it. Refer to the [remote environment maintenance guide](docs/environment_packaging.md) for details on rebuilding the tarball whenever dependencies change.
 
-Work Queue has been retired from the workflow helpers. A condensed record of the historic instructions is preserved in [README_WORKQUEUE.md](README_WORKQUEUE.md) for teams pinned to older releases.
+   When you prefer to debug locally without spinning up a TaskVine manager,
+   switch to `analysis/topeft_run2/local_futures_run.sh`. The wrapper mirrors the
+   region/year handling of `full_run.sh` while forcing the Coffea futures
+   executor, exposing knobs like `--workers`, `--futures-prefetch`, and
+   `--futures-retries`, and emitting the same
+   `(variable, channel, application, sample, systematic)` histogram pickles.
+   Override the default sample list with `--samples` (for example pointing at
+   `input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json`) when
+   you want a quick single-node smoke test:
+
+   ```bash
+   cd analysis/topeft_run2
+   ./local_futures_run.sh --sr -y UL17 --samples \
+       ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \
+       --outdir histos/local_debug --tag quickstart
+   ```
+
+   Work Queue has been retired from the workflow helpers. A condensed record of the historic instructions is preserved in [README_WORKQUEUE.md](README_WORKQUEUE.md) for teams pinned to older releases.
 
 ### To run an example job
 

--- a/analysis/topeft_run2/local_futures_run.sh
+++ b/analysis/topeft_run2/local_futures_run.sh
@@ -1,0 +1,414 @@
+#!/usr/bin/env bash
+# Wrapper for launching run_analysis.py with the Coffea futures executor.
+#
+# Expectations before running:
+#   1. Activate the shared Conda environment shipped with this repository
+#      (name: coffea20250703) so the topeft and topcoffea editable installs are
+#      available.  The helper below attempts to activate it when possible.
+#   2. Provide local access to the desired ROOT files (either via XRootD
+#      redirectors or through EOS/PNFS mounts).  The futures executor runs on
+#      the submitting host, so the files must be readable from the same node.
+#
+# The run_analysis workflow emits histogram pickles keyed by
+# (variable, channel, application, sample, systematic) 5-tuples; downstream
+# tools assume this schema when combining outputs.
+
+set -euo pipefail
+
+PrintUsage() {
+  cat <<'USAGE'
+Usage: local_futures_run.sh [-y YEAR [YEAR ...]] [-t TAG] [--cr | --sr] \
+                            [--outdir PATH] [--workers N] \
+                            [--futures-prefetch N] [--futures-retries N] \
+                            [--samples PATH [PATH ...]] \
+                            [extra run_analysis args]
+
+Examples:
+  local_futures_run.sh --cr -y run2 --outdir histos/run2_debug
+  local_futures_run.sh --sr -y UL17 --workers 8 --futures-prefetch 2 \
+      --prefix root://xrootd.site/ --outdir histos/local_debug
+
+Notes:
+  * YEARS accept explicit values (2022, 2022EE, UL17, etc.) or bundles
+    (run2 -> UL16 UL16APV UL17 UL18, run3 -> 2022 2022EE).  Unknown entries
+    are rejected so mis-typed eras fail fast.
+  * Required input cfg/json files live under input_samples/cfgs/ and are
+    selected automatically per year.  Use --samples when you want to override
+    the list (for example pointing at the UL17 quickstart JSON).  Add extra CLI
+    arguments (for example --options configs/fullR2_run.yml:sr) after the
+    recognized flags to pass through additional run_analysis toggles.
+  * The default output name is <YEARS>_(CRs|SRs)_<TAG>, saved to the specified
+    output directory with the 5-tuple histogram schema used throughout this
+    branch.
+USAGE
+}
+
+activate_env() {
+  local target_env="coffea20250703"
+  if [[ "${CONDA_DEFAULT_ENV:-}" == "$target_env" ]]; then
+    return 0
+  fi
+  if command -v conda >/dev/null 2>&1; then
+    # shellcheck disable=SC1091
+    source "$(conda info --base)/etc/profile.d/conda.sh"
+    conda activate "$target_env" || true
+  else
+    echo "Warning: conda not available; ensure $target_env is already active." >&2
+  fi
+}
+
+main() {
+  if [[ $# -eq 0 ]]; then
+    PrintUsage
+    return 0
+  fi
+
+  local default_year="UL17"
+  local default_tag
+  default_tag=$(git rev-parse --short HEAD 2>/dev/null || date +%y%m%d)
+
+  local flag_cr=false
+  local flag_sr=false
+  local -a extra_args=()
+  local -a years=()
+  local -a expanded_years=()
+  local -a resolved_years=()
+  local user_chunk_override=false
+  local user_executor_override=false
+  local outdir="histos"
+  local tag=""
+  local futures_prefetch=1
+  local futures_retries=0
+  local futures_retry_wait=5.0
+  local workers=4
+  local -a user_samples=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -y|--year)
+        shift
+        if [[ $# -eq 0 || "$1" == -* ]]; then
+          echo "Error: -y|--year requires at least one argument" >&2
+          return 1
+        fi
+        while [[ $# -gt 0 ]]; do
+          case "$1" in
+            -*)
+              break
+              ;;
+            *)
+              years+=("$1")
+              shift
+              ;;
+          esac
+        done
+        ;;
+      -t|--tag)
+        tag="$2"
+        shift 2
+        ;;
+      --outdir)
+        outdir="$2"
+        shift 2
+        ;;
+      --workers)
+        workers="$2"
+        shift 2
+        ;;
+      --samples)
+        shift
+        if [[ $# -eq 0 || "$1" == -* ]]; then
+          echo "Error: --samples requires at least one argument" >&2
+          return 1
+        fi
+        while [[ $# -gt 0 ]]; do
+          case "$1" in
+            -*)
+              break
+              ;;
+            *)
+              user_samples+=("$1")
+              shift
+              ;;
+          esac
+        done
+        ;;
+      --futures-prefetch)
+        futures_prefetch="$2"
+        shift 2
+        ;;
+      --futures-retries)
+        futures_retries="$2"
+        shift 2
+        ;;
+      --futures-retry-wait)
+        futures_retry_wait="$2"
+        shift 2
+        ;;
+      --cr)
+        flag_cr=true
+        shift
+        ;;
+      --sr)
+        flag_sr=true
+        shift
+        ;;
+      -s|--chunksize|--chunksize=*)
+        user_chunk_override=true
+        extra_args+=("$1")
+        shift
+        ;;
+      -x|--executor|--executor=*)
+        user_executor_override=true
+        extra_args+=("$1")
+        shift
+        ;;
+      -h|--help)
+        PrintUsage
+        return 0
+        ;;
+      --)
+        shift
+        extra_args+=("$@")
+        break
+        ;;
+      *)
+        extra_args+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  if [[ "$flag_cr" == false && "$flag_sr" == false ]] || [[ "$flag_cr" == true && "$flag_sr" == true ]]; then
+    echo "Error: specify exactly one of --cr or --sr" >&2
+    echo
+    PrintUsage
+    return 1
+  fi
+
+  if [[ ${#years[@]} -eq 0 ]]; then
+    echo "Warning: YEAR not provided, using default YEAR=$default_year"
+    years=("$default_year")
+  fi
+
+  local year
+  for year in "${years[@]}"; do
+    case "${year,,}" in
+      run2)
+        expanded_years+=(UL16 UL16APV UL17 UL18)
+        ;;
+      run3)
+        expanded_years+=(2022 2022EE)
+        ;;
+      *)
+        expanded_years+=("$year")
+        ;;
+    esac
+  done
+
+  declare -A seen_year=()
+  for year in "${expanded_years[@]}"; do
+    if [[ -z "${seen_year[$year]:-}" ]]; then
+      resolved_years+=("$year")
+      seen_year[$year]=1
+    fi
+  done
+
+  if [[ ${#resolved_years[@]} -eq 0 ]]; then
+    echo "Error: no valid years resolved from the provided arguments." >&2
+    return 1
+  fi
+
+  if [[ -z "$tag" ]]; then
+    echo "Warning: TAG not provided, using default TAG=$default_tag"
+    tag="$default_tag"
+  fi
+
+  local year_label
+  year_label=$(IFS=-; echo "${resolved_years[*]}")
+
+  local out_name
+  if [[ "$flag_cr" == true ]]; then
+    out_name="${year_label}_CRs_${tag}"
+  else
+    out_name="${year_label}_SRs_${tag}"
+  fi
+
+  local script_dir
+  script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+  local repo_root
+  repo_root=$(cd "$script_dir/../.." && pwd)
+  cd "$script_dir"
+
+  activate_env
+
+  local cfgs_path="$repo_root/input_samples/cfgs"
+  local -a cfgs_list=()
+  local -A run2_year_map=(
+    [2016]=2016
+    [2016apv]=2016APV
+    [2017]=2017
+    [2018]=2018
+    [ul16]=UL16
+    [ul16apv]=UL16APV
+    [ul17]=UL17
+    [ul18]=UL18
+  )
+
+  local -a run2_cfgs_sr=(
+    "$cfgs_path/mc_signal_samples_NDSkim.cfg"
+    "$cfgs_path/mc_background_samples_NDSkim.cfg"
+    "$cfgs_path/data_samples_NDSkim.cfg"
+  )
+  local -a run2_cfgs_cr=(
+    "$cfgs_path/mc_signal_samples_NDSkim.cfg"
+    "$cfgs_path/mc_background_samples_NDSkim.cfg"
+    "$cfgs_path/mc_background_samples_cr_NDSkim.cfg"
+    "$cfgs_path/data_samples_NDSkim.cfg"
+  )
+  local -a run3_cfgs_2022_sr=(
+    "$cfgs_path/2022_mc_signal_samples.cfg"
+    "$cfgs_path/2022_mc_background_samples.cfg"
+    "$cfgs_path/2022_data_samples.cfg"
+  )
+  local -a run3_cfgs_2022_cr=(
+    "$cfgs_path/2022_mc_background_samples.cfg"
+    "$cfgs_path/2022_data_samples.cfg"
+  )
+  local -a run3_cfgs_2022ee_sr=(
+    "$cfgs_path/2022_mc_signal_samples.cfg"
+    "$cfgs_path/2022_mc_background_samples.cfg"
+    "$cfgs_path/2022EE_data_samples.cfg"
+  )
+  local -a run3_cfgs_2022ee_cr=(
+    "$cfgs_path/2022_mc_background_samples.cfg"
+    "$cfgs_path/2022EE_data_samples.cfg"
+  )
+
+  declare -A seen_cfgs=()
+  add_cfg() {
+    local cfg_file="$1"
+    if [[ ! -f "$cfg_file" ]]; then
+      echo "Error: required cfg/json file not found: $cfg_file" >&2
+      return 1
+    fi
+    if [[ -n "${seen_cfgs[$cfg_file]:-}" ]]; then
+      return 0
+    fi
+    cfgs_list+=("$cfg_file")
+    seen_cfgs[$cfg_file]=1
+    return 0
+  }
+
+  local year_key
+  local run2_bundle_added=false
+  for year in "${resolved_years[@]}"; do
+    year_key=${year,,}
+    if [[ -n "${run2_year_map[$year_key]:-}" ]]; then
+      if [[ "$run2_bundle_added" == false ]]; then
+        if [[ "$flag_cr" == true ]]; then
+          for cfg in "${run2_cfgs_cr[@]}"; do
+            add_cfg "$cfg" || return 1
+          done
+        else
+          for cfg in "${run2_cfgs_sr[@]}"; do
+            add_cfg "$cfg" || return 1
+          done
+        fi
+        run2_bundle_added=true
+      fi
+      continue
+    fi
+
+    case "$year" in
+      2022)
+        if [[ "$flag_cr" == true ]]; then
+          for cfg in "${run3_cfgs_2022_cr[@]}"; do
+            add_cfg "$cfg" || return 1
+          done
+        else
+          for cfg in "${run3_cfgs_2022_sr[@]}"; do
+            add_cfg "$cfg" || return 1
+          done
+        fi
+        ;;
+      2022EE)
+        if [[ "$flag_cr" == true ]]; then
+          for cfg in "${run3_cfgs_2022ee_cr[@]}"; do
+            add_cfg "$cfg" || return 1
+          done
+        else
+          for cfg in "${run3_cfgs_2022ee_sr[@]}"; do
+            add_cfg "$cfg" || return 1
+          done
+        fi
+        ;;
+      *)
+        echo "Error: unrecognized YEAR '$year'" >&2
+        return 1
+        ;;
+    esac
+  done
+
+  local -a input_specs=()
+  if [[ ${#user_samples[@]} -gt 0 ]]; then
+    for sample_path in "${user_samples[@]}"; do
+      if [[ ! -e "$sample_path" ]]; then
+        echo "Error: sample override not found: $sample_path" >&2
+        return 1
+      fi
+      input_specs+=("$sample_path")
+    done
+  else
+    input_specs=("${cfgs_list[@]}")
+  fi
+
+  if [[ ${#input_specs[@]} -eq 0 ]]; then
+    echo "Error: no cfg/json inputs resolved" >&2
+    return 1
+  fi
+
+  local cfgs
+  cfgs=$(IFS=,; echo "${input_specs[*]}")
+
+  echo "Resolved years: ${resolved_years[*]}"
+  echo "Resolved cfg inputs: $cfgs"
+  echo "Using Coffea futures executor with $workers workers"
+  echo "Futures prefetch: $futures_prefetch | retries: $futures_retries"
+
+  local -a options=(
+    --outname "$out_name"
+    --outpath "$outdir"
+    --nworkers "$workers"
+    --summary-verbosity brief
+  )
+  if [[ "$user_chunk_override" == false ]]; then
+    options+=(--chunksize 50000)
+  fi
+  if [[ "$user_executor_override" == false ]]; then
+    options+=(--executor futures)
+  fi
+  options+=(--futures-prefetch "$futures_prefetch")
+  options+=(--futures-retries "$futures_retries")
+  options+=(--futures-retry-wait "$futures_retry_wait")
+  if [[ "$flag_cr" == true ]]; then
+    options+=(--skip-sr)
+  else
+    options+=(--skip-cr --do-systs)
+  fi
+
+  local -a run_cmd=(python run_analysis.py "$cfgs")
+  run_cmd+=("${options[@]}")
+  run_cmd+=("${extra_args[@]}")
+
+  printf "\nRunning the following command:\n%s\n\n" "${run_cmd[*]}"
+  time "${run_cmd[@]}"
+}
+
+main "$@"
+exit_code=$?
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  exit "$exit_code"
+else
+  return "$exit_code"
+fi

--- a/docs/quickstart_run2.md
+++ b/docs/quickstart_run2.md
@@ -69,6 +69,32 @@ The output pickle is stored in the directory provided through ``--output`` with
 an ``outname`` of ``quickstart`` (so you can expect something like
 ``quickstart-output/quickstart.pkl.gz``).
 
+## Local futures shell wrapper
+
+For single-node debugging that mirrors the Run 2 production configuration, use
+``analysis/topeft_run2/local_futures_run.sh``. The wrapper mirrors
+``full_run.sh`` but skips the TaskVine environment staging/manager logic and
+forces the Coffea futures executor. Key features include:
+
+* ``--workers``, ``--futures-prefetch`` and ``--futures-retries`` switches for
+  tuning the executor without editing YAML.
+* Automatic year bundle expansion and control/signal-region toggles that keep
+  the ``(variable, channel, application, sample, systematic)`` histogram schema
+  identical to the distributed workflow.
+* A ``--samples`` override so you can point directly at the tiny UL17 JSON when
+  you only need a smoke test.
+
+Example invocation::
+
+    cd analysis/topeft_run2
+    ./local_futures_run.sh --sr -y UL17 \
+        --samples ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \
+        --outdir histos/local_debug --tag quickstart
+
+The command runs entirely on the submitting node, so make sure the referenced
+samples are locally accessible (or use ``--prefix``/XRootD) and that the active
+environment provides the Coffea 2025.7 executor stack.
+
 ## Understanding the quickstart inputs
 
 ### Samples JSON

--- a/tests/test_local_futures_wrapper.py
+++ b/tests/test_local_futures_wrapper.py
@@ -1,0 +1,49 @@
+"""Smoke-test the local futures shell wrapper."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="topcoffea histEFT type hints require Python 3.10+",
+)
+def test_local_futures_run_sh(tmp_path):
+    repo_root = Path(__file__).resolve().parent.parent
+    analysis_dir = repo_root / "analysis" / "topeft_run2"
+    script_path = analysis_dir / "local_futures_run.sh"
+    outdir = tmp_path / "histos"
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    sample_path = "../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json"
+
+    cmd = [
+        str(script_path),
+        "--sr",
+        "-y",
+        "UL17",
+        "--tag",
+        "localtest",
+        "--outdir",
+        str(outdir),
+        "--workers",
+        "1",
+        "--futures-prefetch",
+        "0",
+        "--samples",
+        sample_path,
+        "--nchunks",
+        "1",
+        "--chunksize",
+        "4000",
+    ]
+
+    subprocess.run(cmd, check=True, cwd=analysis_dir)
+
+    expected_pickle = outdir / "UL17_SRs_localtest.pkl.gz"
+    assert expected_pickle.exists()


### PR DESCRIPTION
## Summary
- add `analysis/topeft_run2/local_futures_run.sh`, a single-node helper that mirrors `full_run.sh` without the TaskVine setup while exposing futures-specific options including `--samples`
- document the local wrapper in both `README.md` and `docs/quickstart_run2.md`
- add `tests/test_local_futures_wrapper.py` to keep a UL17 smoke test (skipped on Python < 3.10) in CI

## Testing
- `pytest tests/test_local_futures_wrapper.py -k local --maxfail=1`