### PR TITLE
Handle missing sumw2 in to_hist

### DIFF
--- a/tests/test_datacard_tools.py
+++ b/tests/test_datacard_tools.py
@@ -1,0 +1,12 @@
+import numpy as np
+
+from topeft.modules.datacard_tools import to_hist
+
+
+def test_to_hist_handles_missing_sumw2_entries():
+    arr = [np.array([0.0, 3.0, 4.0]), None]
+
+    hist_obj = to_hist(arr, name="test_hist", zero_wgts=True)
+
+    np.testing.assert_allclose(hist_obj.values(), np.array([3.0, 4.0]))
+    np.testing.assert_array_equal(hist_obj.variances(), np.zeros(2))

--- a/tests/test_datacard_tools.py
+++ b/tests/test_datacard_tools.py
@@ -18,3 +18,10 @@ def test_to_hist_raises_without_zero_wgts_when_sumw2_missing():
 
     with pytest.raises(ValueError, match="sumw2"):
         to_hist(arr, name="test_hist", zero_wgts=False)
+
+
+def test_to_hist_raises_when_sumw_missing_even_if_sumw2_present():
+    arr = [None, np.array([0.0, 3.0, 4.0])]
+
+    with pytest.raises(ValueError, match="sumw"):
+        to_hist(arr, name="test_hist", zero_wgts=True)

--- a/tests/test_datacard_tools.py
+++ b/tests/test_datacard_tools.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from topeft.modules.datacard_tools import to_hist
 
@@ -10,3 +11,10 @@ def test_to_hist_handles_missing_sumw2_entries():
 
     np.testing.assert_allclose(hist_obj.values(), np.array([3.0, 4.0]))
     np.testing.assert_array_equal(hist_obj.variances(), np.zeros(2))
+
+
+def test_to_hist_raises_without_zero_wgts_when_sumw2_missing():
+    arr = [np.array([0.0, 3.0, 4.0]), None]
+
+    with pytest.raises(ValueError, match="sumw2"):
+        to_hist(arr, name="test_hist", zero_wgts=False)

--- a/topeft/modules/datacard_tools.py
+++ b/topeft/modules/datacard_tools.py
@@ -36,14 +36,22 @@ def to_hist(arr,name,zero_wgts=False):
     #   sub-array arr and when we modify clipped, it will propagate back to arr as well!
     clipped = [None, None]
     reference = None
+    missing_sumw2 = False
     for i in range(2):  # first entry is sum(weight), second entry is sum(weight^2)
         if arr[i] is not None:
             clipped[i] = np.array(arr[i][1:])  # Strip off the underoverflow bin
             if reference is None:
                 reference = clipped[i]
+        elif i == 1:
+            missing_sumw2 = True
 
     if reference is None:
         raise ValueError("Input histogram array contains no data")
+
+    if missing_sumw2 and not zero_wgts:
+        raise ValueError(
+            "Input histogram array is missing sumw2 data but zero_wgts is False"
+        )
 
     for i in range(2):
         if clipped[i] is None:

--- a/topeft/modules/datacard_tools.py
+++ b/topeft/modules/datacard_tools.py
@@ -36,17 +36,23 @@ def to_hist(arr,name,zero_wgts=False):
     #   sub-array arr and when we modify clipped, it will propagate back to arr as well!
     clipped = [None, None]
     reference = None
+    missing_sumw = False
     missing_sumw2 = False
     for i in range(2):  # first entry is sum(weight), second entry is sum(weight^2)
         if arr[i] is not None:
             clipped[i] = np.array(arr[i][1:])  # Strip off the underoverflow bin
             if reference is None:
                 reference = clipped[i]
-        elif i == 1:
+        elif i == 0:
+            missing_sumw = True
+        else:
             missing_sumw2 = True
 
     if reference is None:
         raise ValueError("Input histogram array contains no data")
+
+    if missing_sumw:
+        raise ValueError("Input histogram array is missing sumw data")
 
     if missing_sumw2 and not zero_wgts:
         raise ValueError(


### PR DESCRIPTION
## Summary
- update `to_hist` to seed placeholder arrays so missing entries no longer cause index errors, and guard downstream histogram creation
- add a regression test covering `to_hist` with a missing sumw2 array and enforcing zero variances when `zero_wgts` is requested

## Testing
- `pytest tests/test_datacard_tools.py`