### PR TITLE
Stream data-driven histogram processing

### DIFF
--- a/analysis/topeft_run2/README.md
+++ b/analysis/topeft_run2/README.md
@@ -86,6 +86,7 @@ This directory contains scripts for the Full Run 2 EFT analysis. This README doc
     - Finalizes deferred nonprompt/flips histograms using either the metadata emitted by `run_analysis.py --np-postprocess=defer` or manually specified pickle paths.
     - Example usage: `python run_data_driven.py --metadata-json histos/plotsTopEFT_np.pkl.gz.metadata.json --apply-renormfact-envelope`
     - When invoked with metadata the CLI automatically discovers the base pickle, resolved years, and desired `_np.pkl.gz` destination so you can regenerate the datacard-ready file long after the original processing campaign finished. Provide `--input-pkl` and (optionally) `--output-pkl` explicitly when you only kept the histogram pickles.
+    - Pointing `--input-pkl` at a `.pkl`/`.pkl.gz` file now streams the histograms one key at a time, so memory usage no longer scales with the full dictionary size. This mirrors the inline `run_analysis.py --np-postprocess=defer` workflow: the base pickle can live on disk until you are ready to postprocess it, even when the histogram set is several gigabytes.
 
 > **Sourcing helpers:** `run_plotter.sh`, `submit_plotter_condor.sh`, `fullR3_run.sh`, `fullR3_run_diboson.sh`, and `condor_plotter_entry.sh` now funnel their work through a `main()` function. They return non-zero statuses instead of exiting outright when validation fails, so sourcing them in an interactive shell will surface the error without tearing down your session. Executing the scripts directly still exits with the same return codes as before.
 

--- a/analysis/topeft_run2/update_json_sow.py
+++ b/analysis/topeft_run2/update_json_sow.py
@@ -2,7 +2,8 @@ import os
 import argparse
 
 from topcoffea.modules.paths import topcoffea_path
-from topcoffea.modules.utils import regex_match, load_sample_json_file, get_files, get_hist_from_pkl
+from topcoffea.modules.utils import regex_match, load_sample_json_file, get_files
+from topeft.modules.utils import get_hist_from_pkl
 from topcoffea.modules.update_json import update_json
 from topeft.modules.yield_tools import YieldTools
 

--- a/tests/test_data_driven_streaming.py
+++ b/tests/test_data_driven_streaming.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import gzip
+
+import cloudpickle
+import hist
+import numpy as np
+import pytest
+
+from analysis.topeft_run2 import run_data_driven
+from topcoffea.modules.sparseHist import SparseHist
+from topeft.modules import dataDrivenEstimation
+from topeft.modules.dataDrivenEstimation import DataDrivenProducer
+from topeft.modules.utils import get_hist_from_pkl
+
+
+@pytest.fixture
+def sparse_hist_axes():
+    return (
+        hist.axis.StrCategory([], name="process", growth=True),
+        hist.axis.StrCategory([], name="appl", growth=True),
+        hist.axis.StrCategory([], name="systematic", growth=True),
+        hist.axis.Regular(1, 0.0, 1.0, name="pt"),
+    )
+
+
+def _fill_histogram(entries, axes):
+    histogram = SparseHist(*axes)
+    for entry in entries:
+        histogram.fill(
+            process=entry["process"],
+            appl=entry["appl"],
+            systematic=entry.get("systematic", "nominal"),
+            pt=entry.get("pt", 0.5),
+            weight=entry["weight"],
+        )
+    return histogram
+
+
+def _build_hist_dict(axes):
+    entries = [
+        {"process": "dataUL16", "appl": "isAR_3l", "weight": 10.0},
+        {"process": "TTTo2L2Nu_centralUL16", "appl": "isAR_3l", "weight": 3.0},
+        {"process": "dataUL16", "appl": "isAR_2lSS_OS", "weight": 4.0},
+        {"process": "TTTo2L2Nu_centralUL16", "appl": "isSR_3l", "weight": 1.0},
+    ]
+    main_hist = _fill_histogram(entries, axes)
+
+    sumw2_entries = [dict(entry, weight=entry["weight"] ** 2) for entry in entries]
+    sumw2_hist = _fill_histogram(sumw2_entries, axes)
+
+    return {"nominal": main_hist, "nominal_sumw2": sumw2_hist}
+
+
+def test_data_driven_producer_streams_histograms(monkeypatch, tmp_path):
+    input_path = tmp_path / "input.pkl.gz"
+    input_path.write_bytes(b"placeholder")
+
+    calls = {}
+
+    def fake_iterate(path, *, allow_empty, materialize=False):
+        calls["args"] = (path, allow_empty, materialize)
+        return iter(())
+
+    monkeypatch.setattr(dataDrivenEstimation, "iterate_hist_from_pkl", fake_iterate)
+
+    producer = DataDrivenProducer(str(input_path), "")
+    assert producer.getDataDrivenHistogram() == {}
+    assert calls["args"] == (str(input_path), True, False)
+
+
+def test_run_data_driven_matches_inline_output(tmp_path, sparse_hist_axes):
+    expected_histograms = DataDrivenProducer(_build_hist_dict(sparse_hist_axes), "").getDataDrivenHistogram()
+
+    input_histograms = _build_hist_dict(sparse_hist_axes)
+    input_path = tmp_path / "input.pkl.gz"
+    with gzip.open(input_path, "wb") as stream:
+        cloudpickle.dump(input_histograms, stream)
+
+    output_path = tmp_path / "output_np.pkl.gz"
+    run_data_driven._finalize_histograms(
+        str(input_path),
+        str(output_path),
+        only_flips=False,
+        apply_envelope=False,
+    )
+
+    streamed_histograms = get_hist_from_pkl(str(output_path))
+
+    assert set(streamed_histograms) == set(expected_histograms)
+    for key, expected_hist in expected_histograms.items():
+        streamed_hist = streamed_histograms[key]
+        np.testing.assert_allclose(
+            np.asarray(streamed_hist.values(flow=True)),
+            np.asarray(expected_hist.values(flow=True)),
+        )
+        assert list(streamed_hist.axes["process"]) == list(expected_hist.axes["process"])

--- a/topeft/modules/utils.py
+++ b/topeft/modules/utils.py
@@ -16,6 +16,8 @@ from types import MappingProxyType
 import cloudpickle
 import uproot
 
+from topcoffea.modules.hist_utils import iterate_hist_from_pkl as _iterate_hist_from_pkl
+
 
 pjoin = os.path.join
 
@@ -468,17 +470,15 @@ def dump_to_pkl(out_name,out_file):
     print("Done.\n")
 
 
-def get_hist_dict_non_empty(h):
-    print(h.keys())
-    return {k: v for k, v in h.items()}# if not v.empty()}
+def iterate_hist_from_pkl(*args, **kwargs):
+    """Proxy to ``topcoffea.modules.hist_utils.iterate_hist_from_pkl``."""
+
+    return _iterate_hist_from_pkl(*args, **kwargs)
 
 
 # Get the dictionary of hists from the pkl file (e.g. that a processor outputs)
 def get_hist_from_pkl(path_to_pkl, allow_empty=True):
-    h = pickle.load(gzip.open(path_to_pkl))
-    if not allow_empty:
-        h = get_hist_dict_non_empty(h)
-    return h
+    return iterate_hist_from_pkl(path_to_pkl, allow_empty=allow_empty, materialize=True)
 
 
 ############## Dictionary manipulations and tools ##############


### PR DESCRIPTION
## Summary
- update the shared histogram loader to delegate to the iterator-aware helper shipped in topcoffea and refresh the scripts that relied on the old implementation
- teach `DataDrivenProducer` to stream pickle inputs when a path is provided and document the new behaviour in the Run 2 README
- add regression tests that exercise the streaming path and confirm the deferred helper still reproduces the inline `_np.pkl.gz` results

## Testing
- `PYTHONPATH=/workspace/topeft:/workspace/topcoffea pytest tests/test_data_driven_streaming.py tests/test_run_data_driven.py tests/test_canonical_process_names.py`