### PR TITLE
Document direct nonprompt postprocessing options

### DIFF
--- a/analysis/topeft_run2/run_data_driven.py
+++ b/analysis/topeft_run2/run_data_driven.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-"""Standalone helper to build data driven histograms from saved metadata."""
+"""Standalone helper to build data driven histograms from saved metadata.
+
+Quickstart examples:
+  - Metadata sidecar: python run_data_driven.py --metadata-json histos/plotsTopEFT_np.pkl.gz.metadata.json \
+      --apply-renormfact-envelope
+  - Direct pickle paths: python run_data_driven.py --input-pkl histos/plotsTopEFT.pkl.gz \
+      --output-pkl histos/plotsTopEFT_np.pkl.gz --apply-renormfact-envelope
+"""
 
 from __future__ import annotations
 
@@ -17,9 +24,14 @@ from topeft.modules.get_renormfact_envelope import get_renormfact_envelope
 def _build_argument_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
-            "Finalize deferred nonprompt/flips histograms using the metadata emitted "
-            "by run_analysis.py."
-        )
+            "Finalize deferred nonprompt/flips histograms using the metadata emitted by run_analysis.py.\n\n"
+            "Quickstart:\n"
+            "  - Metadata sidecar: python run_data_driven.py --metadata-json histos/plotsTopEFT_np.pkl.gz.metadata.json\\\n"
+            "      --apply-renormfact-envelope\n"
+            "  - Direct pickle paths: python run_data_driven.py --input-pkl histos/plotsTopEFT.pkl.gz\\\n"
+            "      --output-pkl histos/plotsTopEFT_np.pkl.gz --apply-renormfact-envelope"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
         "--metadata-json",


### PR DESCRIPTION
## Summary
- clarify inline versus deferred nonprompt handling in the main README and provide metadata-free usage examples
- expand the analysis README with explicit run_data_driven.py commands, expected inputs/outputs, and troubleshooting guidance
- add quickstart guidance to run_data_driven.py so the CLI advertises the metadata-free workflow

## Testing
- `python run_analysis.py ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json -x futures` *(fails: ImportError: cannot import name 'iterate_hist_from_pkl' from 'topcoffea.modules.hist_utils')*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ef2591f0c832380cd12ed8d51c4e1)