### PR TITLE
Add heartbeat logging to data-driven helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ When `--do-np` is passed `run_analysis.py` produces the nonprompt-enhanced `_np.
   ```
 
   The direct invocation is handy when the metadata json is missing or when you have relocated the base pickle and want to override the output destination in one call.
+  Long-running deferred jobs now emit lightweight progress heartbeats while histograms are combined; tune the cadence with `--heartbeat-seconds` (set to `0` to log every histogram) or silence the messages with `--quiet` for batch use.
 To make use of distributed resources, the `work queue` executor can be used. To use the work queue executor, just change the executor option to  `-x work_queue` and run the run script as before. Next, you will need to request some workers to execute the tasks on the distributed resources. Please note that the workers must be submitted from the same environment that you are running the run script from (so this will usually mean you want to activate the env in another terminal, and run the `condor_submit_workers` command from there. Here is an example `condor_submit_workers` command (remembering to activate the env prior to running the command):
 ```
 conda activate coffea-env


### PR DESCRIPTION
## Summary
- add configurable heartbeat logging to run_data_driven.py along with CLI switches for tuning or silencing progress output
- document the new progress behavior for deferred nonprompt processing and extend tests to cover heartbeat and quiet modes

## Testing
- pytest tests/test_run_data_driven.py
- ./analysis/topeft_run2/fullR3_run.sh --cr -x futures --skip-topcoffea-data-check --nchunks 1 --nworkers 1 *(fails: run_analysis.py exits with ValueError from coffea executor setup)*