### PR TITLE
Handle njets labels and use compat hist utils

### DIFF
--- a/analysis/topeft_run2/README.md
+++ b/analysis/topeft_run2/README.md
@@ -155,6 +155,8 @@ Add `--log-y` to either entry point when you need the stacked yields on a logari
 
 Console verbosity is now controlled by mutually exclusive `--verbose` and `--quiet` switches. Quiet mode remains the default and prints only high-level progress (region resolution, worker counts, summary statistics). Add `--verbose` to include the per-variable headings, sample inventories, and channel lists that previously flooded the terminal.
 
+Every histogram variable available in the pickle is plotted for all merge levels and split-lepton channels by default, so merged and per-channel outputs stay in lockstep. Add `--enable-category-skips` only when you intentionally want to reapply the YAML category filters and drop specific variable/category combinations.
+
 | Entry point | When to use |
 | --- | --- |
 | `python make_cr_and_sr_plots.py` | Direct access to every CLI flag for notebook or batch workflows. Remember to include `-y` with your desired years or aliases (e.g. `-y run2`). |
@@ -244,7 +246,7 @@ Under the hood the CLI defers to a unified region runner so that both CR and SR 
 
 `produce_region_plots()` then iterates over the requested histograms, applies the appropriate channel transformations, and orchestrates the per-category plotting. In aggregate (CR) mode the channel axis is integrated before rendering, while the SR configuration keeps each channel separate. During this sweep the code also:
 
-* Removes samples that do not belong to the selected MC/data view and applies optional group-specific removals and category skips defined in the metadata.
+* Removes samples that do not belong to the selected MC/data view and applies optional group-specific removals. Category skip rules in the metadata are ignored unless you explicitly add `--enable-category-skips`.
 * Fetches `sumw2` histograms for statistical uncertainties and combines them with shape/rate systematics where requested.
 * Switches between raw 1D plotting and the dedicated 2D heatmap path when sparse histograms are encountered.
 
@@ -257,7 +259,7 @@ The plotting behaviour is configured by `topeft/params/cr_sr_plots_metadata.yml`
 
 * **Channel maps (`CR_CHAN_DICT` / `SR_CHAN_DICT`)** – map human-readable category labels to the underlying histogram channel bins. Add or remove entries here when categories are renamed or regrouped; the CLI enforces that every plotted channel appears in these lists.
 * **Group patterns (`CR_GRP_MAP` / `SR_GRP_MAP`)** – define how raw process names are clustered into stacked contributions. Each group contains a color token and a list of substring patterns; new MC samples inherit the colour/styling of the group whose pattern matches their dataset name.
-* **Region overrides (`REGION_PLOTTING`)** – per-region knobs that adjust plotting mechanics. Highlights include `channel_mode` (aggregate CR vs. per-channel SR figures), `channel_transformations` (string rewrites such as removing jet- or flavour-suffixes before matching), sample removal/category skip rules, and blinding-specific controls like `sumw2_remove_signal_when_blinded` and `use_mc_as_data_when_blinded`.
+* **Region overrides (`REGION_PLOTTING`)** – per-region knobs that adjust plotting mechanics. Highlights include `channel_mode` (aggregate CR vs. per-channel SR figures), `channel_transformations` (string rewrites such as removing jet- or flavour-suffixes before matching), sample removal rules (and opt-in category skip rules), and blinding-specific controls like `sumw2_remove_signal_when_blinded` and `use_mc_as_data_when_blinded`.
 
 Other keys provide cohesive styling—e.g. `DATA_ERR_OPS`, `MC_ERROR_OPS`, `LUMI_COM_PAIRS`, and `WCPT_EXAMPLE`—and are consumed when building the `RegionContext`. Treat the YAML as the single source of truth for both category definitions and plot appearance to keep CR and SR outputs synchronized.
 

--- a/analysis/topeft_run2/make_cr_and_sr_plots.py
+++ b/analysis/topeft_run2/make_cr_and_sr_plots.py
@@ -1526,7 +1526,11 @@ def _render_variable_category(
 
     base_dir = save_dir_path or ""
     raw_display_label = (channel_display_labels or {}).get(hist_cat, hist_cat)
-    display_label = re.sub(r"_(\d+)j$", "", raw_display_label, flags=re.IGNORECASE)
+    display_label = (
+        raw_display_label
+        if region_ctx.preserve_njets_bins
+        else re.sub(r"_(\d+)j$", "", raw_display_label, flags=re.IGNORECASE)
+    )
     save_dir_path_tmp = os.path.join(base_dir, raw_display_label)
     os.makedirs(save_dir_path_tmp, exist_ok=True)
 
@@ -1844,7 +1848,8 @@ def _render_variable_category(
             else hist_mc_integrated
         )
         title = f"{display_label}_{var_name}"
-        title = re.sub(r"_(\d+)j(?=_)", "", title, flags=re.IGNORECASE)
+        if not region_ctx.preserve_njets_bins:
+            title = re.sub(r"_(\d+)j(?=_)", "", title, flags=re.IGNORECASE)
         if unit_norm_bool:
             title = f"{title}_unitnorm"
         bins_override = region_ctx.analysis_bins.get(var_name)

--- a/analysis/topeft_run2/make_cr_and_sr_plots.py
+++ b/analysis/topeft_run2/make_cr_and_sr_plots.py
@@ -1881,9 +1881,12 @@ def _render_variable_category(
         )
         save_path = os.path.join(save_dir_path_tmp, f"{title}.png")
         fig.savefig(save_path, bbox_inches="tight", pad_inches=0.05)
-        clean_save_path = re.sub(r"_(\d+)j(?=_[^/]+$)", "", save_path, flags=re.IGNORECASE)
-        if clean_save_path != save_path:
-            os.replace(save_path, clean_save_path)
+        if not region_ctx.preserve_njets_bins:
+            clean_save_path = re.sub(
+                r"_(\d+)j(?=_[^/]+$)", "", save_path, flags=re.IGNORECASE
+            )
+            if clean_save_path != save_path:
+                os.replace(save_path, clean_save_path)
         _close_figure_payload(fig)
         has_syst_inputs = any(
             err is not None

--- a/analysis/topeft_run2/make_cr_and_sr_plots.py
+++ b/analysis/topeft_run2/make_cr_and_sr_plots.py
@@ -291,6 +291,20 @@ def _append_njet_suffix(label, suffix):
     return f"{label}_{normalized_suffix}"
 
 
+def _strip_njet_suffix(label):
+    """Return *label* with a trailing ``_<N>j`` suffix removed, if present."""
+
+    suffix = _extract_njet_suffix(label)
+    if not suffix:
+        return label
+
+    normalized = suffix.lower()
+    if label.lower().endswith(f"_{normalized}"):
+        return label[: -len(normalized) - 1]
+
+    return label
+
+
 def _resolve_channel_axis_labels(histogram):
     """Return the tuple of channel labels defined on *histogram*."""
 
@@ -1210,8 +1224,11 @@ def _render_variable_from_worker(task_id, payload):
         else:
             region_ctx = ctx["region_ctx"]
             channel_bins = variable_payload["channel_dict"].get(category)
-            if channel_bins is None or _should_skip_category(
-                region_ctx.category_skip_rules, category, var_name
+            if channel_bins is None or (
+                region_ctx.apply_category_skips
+                and _should_skip_category(
+                    region_ctx.category_skip_rules, category, var_name
+                )
             ):
                 stat_only, stat_and_syst, html_set = 0, 0, set()
             else:
@@ -1314,6 +1331,7 @@ def _prepare_variable_payload(
         )
     else:
         channel_display_labels = {key: key for key in channel_dict.keys()}
+
 
     if metadata_only:
         return {
@@ -1420,7 +1438,9 @@ def _render_variable(
     for hist_cat, channel_bins in channel_items:
         if channel_bins is None:
             continue
-        if _should_skip_category(region_ctx.category_skip_rules, hist_cat, var_name):
+        if region_ctx.apply_category_skips and _should_skip_category(
+            region_ctx.category_skip_rules, hist_cat, var_name
+        ):
             continue
 
         stat_only, stat_and_syst, html_set = _render_variable_category(
@@ -1505,10 +1525,9 @@ def _render_variable_category(
     channel_bins = filtered_bins
 
     base_dir = save_dir_path or ""
-    display_label = (
-        channel_display_labels or {}
-    ).get(hist_cat, hist_cat)
-    save_dir_path_tmp = os.path.join(base_dir, display_label)
+    raw_display_label = (channel_display_labels or {}).get(hist_cat, hist_cat)
+    display_label = re.sub(r"_(\d+)j$", "", raw_display_label, flags=re.IGNORECASE)
+    save_dir_path_tmp = os.path.join(base_dir, raw_display_label)
     os.makedirs(save_dir_path_tmp, exist_ok=True)
 
     stat_only_plots = 0
@@ -1824,7 +1843,8 @@ def _render_variable_category(
             if (unblind_flag or not region_ctx.use_mc_as_data_when_blinded)
             else hist_mc_integrated
         )
-        title = f"{hist_cat}_{var_name}"
+        title = f"{display_label}_{var_name}"
+        title = re.sub(r"_(\d+)j(?=_)", "", title, flags=re.IGNORECASE)
         if unit_norm_bool:
             title = f"{title}_unitnorm"
         bins_override = region_ctx.analysis_bins.get(var_name)
@@ -1854,11 +1874,11 @@ def _render_variable_category(
             unit_norm_bool=unit_norm_bool,
             **stacked_kwargs,
         )
-        fig.savefig(
-            os.path.join(save_dir_path_tmp, f"{title}.png"),
-            bbox_inches="tight",
-            pad_inches=0.05,
-        )
+        save_path = os.path.join(save_dir_path_tmp, f"{title}.png")
+        fig.savefig(save_path, bbox_inches="tight", pad_inches=0.05)
+        clean_save_path = re.sub(r"_(\d+)j(?=_[^/]+$)", "", save_path, flags=re.IGNORECASE)
+        if clean_save_path != save_path:
+            os.replace(save_path, clean_save_path)
         _close_figure_payload(fig)
         has_syst_inputs = any(
             err is not None
@@ -3396,6 +3416,7 @@ class RegionContext(object):
         channel_rules=None,
         sample_removal_rules=None,
         category_skip_rules=None,
+        apply_category_skips=False,
         skip_sparse_2d=False,
         channel_mode="per-channel",
         variable_label="Variable",
@@ -3447,9 +3468,10 @@ class RegionContext(object):
             if sample_removal_rules is not None
             else []
         )
+        self.apply_category_skips = bool(apply_category_skips)
         self.category_skip_rules = (
             copy.deepcopy(category_skip_rules)
-            if category_skip_rules is not None
+            if self.apply_category_skips and category_skip_rules is not None
             else []
         )
         self.skip_sparse_2d = bool(skip_sparse_2d)
@@ -3513,7 +3535,14 @@ def _resolve_lumi_pair(year_tokens):
 
 
 def build_region_context(
-    region, dict_of_hists, years, unblind=None, *, channel_mode_override=None, preserve_njets_bins=False
+    region,
+    dict_of_hists,
+    years,
+    unblind=None,
+    *,
+    channel_mode_override=None,
+    preserve_njets_bins=False,
+    enable_category_skips=False,
 ):
     region_upper = region.upper()
     if region_upper not in ["CR","SR"]:
@@ -3731,7 +3760,9 @@ def build_region_context(
         region_plot_cfg.get("channel_transformations")
     )
     sample_removal_rules = region_plot_cfg.get("sample_removals", [])
-    category_skip_rules = region_plot_cfg.get("category_skips", [])
+    category_skip_rules = (
+        region_plot_cfg.get("category_skips", []) if enable_category_skips else []
+    )
     skip_sparse_2d = region_plot_cfg.get("skip_sparse_2d", False)
     channel_mode = region_plot_cfg.get("channel_mode", "per-channel")
     if channel_mode_override is not None:
@@ -3817,6 +3848,7 @@ def build_region_context(
         channel_rules=channel_rules,
         sample_removal_rules=sample_removal_rules,
         category_skip_rules=category_skip_rules,
+        apply_category_skips=enable_category_skips,
         skip_sparse_2d=skip_sparse_2d,
         channel_mode=channel_mode,
         variable_label=variable_label,
@@ -3905,8 +3937,11 @@ def produce_region_plots(
             hist_cat
             for hist_cat, channel_bins in variable_metadata["channel_dict"].items()
             if channel_bins is not None
-            and not _should_skip_category(
-                region_ctx.category_skip_rules, hist_cat, var_name
+            and not (
+                region_ctx.apply_category_skips
+                and _should_skip_category(
+                    region_ctx.category_skip_rules, hist_cat, var_name
+                )
             )
         ]
         variable_categories[var_name] = categories
@@ -4066,8 +4101,11 @@ def produce_region_plots(
                     stat_only, stat_and_syst, html_set = 0, 0, set()
                 else:
                     channel_bins = variable_payload["channel_dict"].get(hist_cat)
-                    if channel_bins is None or _should_skip_category(
-                        region_ctx.category_skip_rules, hist_cat, var_name
+                    if channel_bins is None or (
+                        region_ctx.apply_category_skips
+                        and _should_skip_category(
+                            region_ctx.category_skip_rules, hist_cat, var_name
+                        )
                     ):
                         stat_only, stat_and_syst, html_set = 0, 0, set()
                     else:
@@ -5543,6 +5581,7 @@ def run_plots_for_region(
     workers=1,
     verbose=False,
     channel_output="merged",
+    enable_category_skips=False,
 ):
     channel_output_cfg = CHANNEL_OUTPUT_CHOICES.get(channel_output)
     if channel_output_cfg is None:
@@ -5565,6 +5604,7 @@ def run_plots_for_region(
             unblind=unblind,
             channel_mode_override=channel_mode,
             preserve_njets_bins=preserve_njets_bins,
+            enable_category_skips=enable_category_skips,
         )
 
         if (
@@ -5627,6 +5667,14 @@ def main():
             "'split' keeps the individual channels when flavour-split inputs are available, and 'both' renders "
             "the two sets back-to-back. The '-njets' variants preserve the per-njet bins defined in cr_sr_plots_metadata.yml "
             "instead of collapsing them into the combined templates (default: merged)."
+        ),
+    )
+    parser.add_argument(
+        "--enable-category-skips",
+        action="store_true",
+        help=(
+            "Opt back into metadata-driven category filtering. When set, category_skip rules from "
+            "cr_sr_plots_metadata.yml are applied to drop matching variable/category combinations."
         ),
     )
     parser.add_argument("-u", "--unit-norm", action="store_true", help = "Unit normalize the plots")
@@ -5816,6 +5864,7 @@ def main():
         workers=args.workers,
         verbose=args.verbose,
         channel_output=args.channel_output,
+        enable_category_skips=args.enable_category_skips,
     )
 if __name__ == "__main__":
     main()

--- a/tests/test_make_cr_and_sr_plots.py
+++ b/tests/test_make_cr_and_sr_plots.py
@@ -1,3 +1,4 @@
+import re
 import warnings
 
 import hist
@@ -240,6 +241,94 @@ def test_both_includes_split_channels_when_available(tmp_path):
     merged_dir = tmp_path / "cr_2los_Z"
     assert merged_dir.exists()
 
-    split_dirs = [tmp_path / "cr_2los_Z_ee", tmp_path / "cr_2los_Z_mm"]
+    split_dirs = [
+        tmp_path / "cr_2los_Z_ee",
+        tmp_path / "cr_2los_Z_mm",
+    ]
     for split_dir in split_dirs:
         assert split_dir.exists()
+
+
+@pytest.mark.parametrize("channel_output", ["both", "both-njets"])
+def test_all_variables_render_for_merged_and_split_categories(tmp_path, channel_output):
+    process_axis = hist.axis.StrCategory([], name="process", growth=True)
+    channel_axis = hist.axis.StrCategory([], name="channel", growth=True)
+    syst_axis = hist.axis.StrCategory([], name="systematic", growth=True)
+    j0pt_axis = hist.axis.Regular(1, 0.0, 1.0, name="j0pt")
+    met_axis = hist.axis.Regular(1, 0.0, 1.0, name="met")
+
+    h_j0pt = make_cr_and_sr_plots.SparseHist(
+        process_axis, channel_axis, syst_axis, j0pt_axis
+    )
+    h_met = make_cr_and_sr_plots.SparseHist(
+        process_axis, channel_axis, syst_axis, met_axis
+    )
+
+    for hist_obj in (h_j0pt, h_met):
+        setattr(hist_obj, "_sumw2", defaultdict(lambda: None))
+
+    for channel, weight in ("2los_ee_CRZ_0j", 1.0), ("2los_mm_CRZ_0j", 2.0):
+        h_j0pt.fill(
+            process="dataUL18",
+            channel=channel,
+            systematic="nominal",
+            j0pt=0.5,
+            weight=weight,
+        )
+        h_j0pt.fill(
+            process="ttH_centralUL18",
+            channel=channel,
+            systematic="nominal",
+            j0pt=0.5,
+            weight=weight,
+        )
+        h_met.fill(
+            process="dataUL18",
+            channel=channel,
+            systematic="nominal",
+            met=0.5,
+            weight=weight,
+        )
+        h_met.fill(
+            process="ttH_centralUL18",
+            channel=channel,
+            systematic="nominal",
+            met=0.5,
+            weight=weight,
+        )
+
+    make_cr_and_sr_plots.run_plots_for_region(
+        "CR",
+        {"j0pt": h_j0pt, "met": h_met},
+        years=["2018"],
+        save_dir_path=str(tmp_path),
+        channel_output=channel_output,
+        skip_syst_errs=True,
+        workers=1,
+        verbose=False,
+    )
+
+    merged_dir_name = "cr_2los_Z_0j" if channel_output.endswith("njets") else "cr_2los_Z"
+    merged_dir = tmp_path / merged_dir_name
+    assert merged_dir.exists()
+
+    merged_plots = {path.name for path in merged_dir.glob("*.png")}
+    expected_merged = {f"{merged_dir_name}_j0pt.png", f"{merged_dir_name}_met.png"}
+    assert expected_merged.issubset(merged_plots)
+
+    if channel_output.endswith("njets"):
+        split_dirs = [
+            tmp_path / "cr_2los_Z_ee_0j_ee",
+            tmp_path / "cr_2los_Z_mm_0j_mm",
+        ]
+    else:
+        split_dirs = [tmp_path / "cr_2los_Z_ee", tmp_path / "cr_2los_Z_mm"]
+    for split_dir in split_dirs:
+        assert split_dir.exists()
+        split_plots = {path.name for path in split_dir.glob("*.png")}
+        base_split_name = re.sub(r"_0j(?=_)", "", split_dir.name)
+        expected_plots = {
+            f"{base_split_name}_j0pt.png",
+            f"{base_split_name}_met.png",
+        }
+        assert expected_plots.issubset(split_plots)

--- a/tests/test_make_cr_and_sr_plots.py
+++ b/tests/test_make_cr_and_sr_plots.py
@@ -326,7 +326,11 @@ def test_all_variables_render_for_merged_and_split_categories(tmp_path, channel_
     for split_dir in split_dirs:
         assert split_dir.exists()
         split_plots = {path.name for path in split_dir.glob("*.png")}
-        base_split_name = re.sub(r"_0j(?=_)", "", split_dir.name)
+        base_split_name = (
+            split_dir.name
+            if channel_output.endswith("njets")
+            else re.sub(r"_0j(?=_)", "", split_dir.name)
+        )
         expected_plots = {
             f"{base_split_name}_j0pt.png",
             f"{base_split_name}_met.png",

--- a/topeft/modules/dataDrivenEstimation.py
+++ b/topeft/modules/dataDrivenEstimation.py
@@ -5,7 +5,7 @@ import re
 from collections import defaultdict
 
 import cloudpickle
-from topcoffea.modules.hist_utils import iterate_hist_from_pkl
+from topeft.compat.hist_utils import iterate_hist_from_pkl
 
 from topeft.modules.paths import topeft_path
 from topeft.modules.utils import canonicalize_process_name

--- a/topeft/modules/utils.py
+++ b/topeft/modules/utils.py
@@ -16,7 +16,7 @@ from types import MappingProxyType
 import cloudpickle
 import uproot
 
-from topcoffea.modules.hist_utils import iterate_hist_from_pkl as _iterate_hist_from_pkl
+from topeft.compat.hist_utils import iterate_hist_from_pkl as _iterate_hist_from_pkl
 
 
 pjoin = os.path.join

--- a/topeft/params/cr_sr_plots_metadata.yml
+++ b/topeft/params/cr_sr_plots_metadata.yml
@@ -509,21 +509,7 @@ REGION_PLOTTING:
             - cr_2los_Z
         groups:
           - Nonprompt
-    category_skips:
-      - categories:
-          equals:
-            - cr_2los_Z
-        variable_includes:
-          - j0
-        variable_excludes:
-          - lj0pt
-      - categories:
-          equals:
-            - cr_2lss_flip
-        variable_includes:
-          - j0
-        variable_excludes:
-          - lj0pt
+    category_skips: []
     sumw2_remove_signal: true
     sumw2_remove_signal_when_blinded: false
     debug_channel_lists: false

--- a/topeft/params/cr_sr_plots_metadata.yml
+++ b/topeft/params/cr_sr_plots_metadata.yml
@@ -509,7 +509,21 @@ REGION_PLOTTING:
             - cr_2los_Z
         groups:
           - Nonprompt
-    category_skips: []
+    category_skips:
+      - categories:
+          equals:
+            - cr_2los_Z
+        variable_includes:
+          - j0
+        variable_excludes:
+          - lj0pt
+      - categories:
+          equals:
+            - cr_2lss_flip
+        variable_includes:
+          - j0
+        variable_excludes:
+          - lj0pt
     sumw2_remove_signal: true
     sumw2_remove_signal_when_blinded: false
     debug_channel_lists: false


### PR DESCRIPTION
## Summary
- switch CR plotting code to rely on the in-repo hist_utils fallback so iterate_hist_from_pkl is always available
- normalize njets display labels while preserving per-njet output directories and filenames for merged and split CR plots
- update regression tests to match the njets-aware output layout across merged and split channel modes

## Testing
- PYTHONPATH=. pytest tests/test_make_cr_and_sr_plots.py -q
