### PR TITLE
Align environment.yml with ttbarEFT coffea2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,18 +26,20 @@ If conda is not already available, download and install it:
 curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh > conda-install.sh
 bash conda-install.sh
 ```
-The topeft directory is set up to be installed as a python package. First clone the repository as shown, then run the following commands to set up the environment (note that `environment.yml` is a file that is a part of the `topeft` repository, so you should `cd` into `topeft` before running the command).  The refreshed workflow standardizes on the Coffea 2025.7.3 toolchain captured in the `coffea20250703` Conda environment:
+The topeft directory is set up to be installed as a python package. First clone the repository as shown, then run the following commands to set up the environment (note that `environment.yml` is a file that is a part of the `topeft` repository, so you should `cd` into `topeft` before running the command).  The refreshed workflow standardizes on the Coffea 2025.7.3 toolchain captured in the `coffea2025` Conda environment shared with the [`ttbarEFT`](https://github.com/TopEFT/ttbarEFT) analysis:
 ```
 git clone https://github.com/TopEFT/topeft.git
 cd topeft
 unset PYTHONPATH # To avoid conflicts.
 conda env create -f environment.yml
-conda activate coffea20250703
+conda activate coffea2025
 pip install -e .
 ```
-The commands above provision the refreshed `coffea20250703` Conda environment, which tracks the Coffea 2025.7.3 base release used throughout the project.  Installing `topeft` with `pip install -e .` is now the expected workflow so that local developments are automatically folded into the packaged environment.
+The commands above provision the refreshed `coffea2025` Conda environment, which tracks the Coffea 2025.7.3 base release used throughout the project.  Installing `topeft` with `pip install -e .` is now the expected workflow so that local developments are automatically folded into the packaged environment.
 
-Upgrading from an older checkout?  Reuse the same directory and run `conda env update -f environment.yml --prune` before activating the environment so the existing `coffea20250703` install picks up the Coffea 2025.7.3 pins and removes stale dependencies.  Because the specification now targets Python 3.13 and newer `ndcctools` builds from conda-forge, older Conda releases may prompt for a solver update; if that happens, accept the prompt or run `conda update -n base -c conda-forge conda` first.  When pip subsequently asks to install `coffea==2025.7.3` and `awkward==2.8.7`, answer “yes” (or allow the editable installs to proceed) so the environment matches the shipped tarballs.
+Upgrading from an older checkout?  Reuse the same directory and run `conda env update -f environment.yml --prune` before activating the environment so the existing `coffea2025` install picks up the Coffea 2025.7.3 pins and removes stale dependencies.  If the solver prompts for an update, accept it or run `conda update -n base -c conda-forge conda` first to keep in sync with conda-forge builds.
+
+To catch configuration drift, CI hashes `environment.yml` and compares it to the upstream `ttbarEFT` coffea2025 specification (see `tests/test_environment_hash.py`).  When the upstream environment changes, update this repository's `environment.yml` and refresh the expected digest in that test so the guard continues to pass.
 
 The `-e` option installs the project in editable mode (i.e. setuptools "develop mode"). If you wish to uninstall the package, you can do so by running `pip uninstall topeft`.
 The [`topcoffea`](https://github.com/TopEFT/topcoffea) package upon which this analysis depends is not yet available on `PyPI`, so we need to clone the `topcoffea` repo and install it ourselves.  Keep the checkout next to `topeft` (for example `$HOME/workspace/topcoffea` beside `$HOME/workspace/topeft`) so paths such as `analysis/topeft_run2/../../topcoffea/cfg/...` resolve to the sibling repository when invoking older scripts.
@@ -59,7 +61,7 @@ The `python -m topcoffea.modules.remote_environment` command calls into the upda
 
 The cached tarballs live in `topeft-envs/` and are named after the Conda + pip specification combined with the Git commits of editable packages.  Each invocation of `python -m topcoffea.modules.remote_environment` prints the active path and automatically rebuilds the archive when it detects new commits or unstaged edits in `topeft` or `topcoffea`.  If you need to force a rebuild (for example after cleaning a branch or rebasing), either remove the cached file or run `python -c "from topcoffea.modules.remote_environment import get_environment; print(get_environment(force=True))"`.  The resulting tarball is exactly what `processor.TaskVineExecutor` sends to remote workers through the `environment_file` parameter.
 
-Now all of the dependencies have been installed and the `topeft` repository is ready to be used. The packaged environment targets the Coffea 2025.7.3 release and can be re-generated at any time with `python -m topcoffea.modules.remote_environment`. The next time you want to use the project, activate the environment via `conda activate coffea20250703`.
+Now all of the dependencies have been installed and the `topeft` repository is ready to be used. The packaged environment targets the Coffea 2025.7.3 release and can be re-generated at any time with `python -m topcoffea.modules.remote_environment`. The next time you want to use the project, activate the environment via `conda activate coffea2025`.
 
 
 ### TaskVine distributed execution

--- a/README_WORKQUEUE.md
+++ b/README_WORKQUEUE.md
@@ -15,7 +15,7 @@ TaskVine managers ship the same tarball built by
 
 ```sh
 conda env create -f environment.yml           # or: conda env update -f environment.yml --prune
-conda activate coffea20250703
+conda activate coffea2025
 pip install -e .                              # install topeft in editable mode
 pip install -e topcoffea/                     # install topcoffea in editable mode
 python -m topcoffea.modules.remote_environment
@@ -31,7 +31,7 @@ From `analysis/topeft_run2` prepare a run configuration (JSON/YAML/CFG as shown
 in the quickstart docs) and launch the manager:
 
 ```sh
-conda activate coffea20250703
+conda activate coffea2025
 python run_analysis.py --executor taskvine --chunksize 160000 \
     ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json
 ```

--- a/analysis/topeft_run2/full_run.sh
+++ b/analysis/topeft_run2/full_run.sh
@@ -3,7 +3,7 @@
 #
 # Expectations before running:
 #   1. Activate the shared Conda environment shipped with this repository
-#      (name: coffea20250703) so the topeft and topcoffea editable installs are
+#      (name: coffea2025) so the topeft and topcoffea editable installs are
 #      available.  The helper below attempts to activate it when possible.
 #   2. Stage the packaged TaskVine environment tarball by running
 #      `python -m topcoffea.modules.remote_environment` after activation.  The
@@ -44,7 +44,7 @@ USAGE
 }
 
 activate_env() {
-  local target_env="coffea20250703"
+  local target_env="coffea2025"
   if [[ "${CONDA_DEFAULT_ENV:-}" == "$target_env" ]]; then
     return 0
   fi

--- a/analysis/topeft_run2/local_futures_run.sh
+++ b/analysis/topeft_run2/local_futures_run.sh
@@ -3,7 +3,7 @@
 #
 # Expectations before running:
 #   1. Activate the shared Conda environment shipped with this repository
-#      (name: coffea20250703) so the topeft and topcoffea editable installs are
+#      (name: coffea2025) so the topeft and topcoffea editable installs are
 #      available.  The helper below attempts to activate it when possible.
 #   2. Provide local access to the desired ROOT files (either via XRootD
 #      redirectors or through EOS/PNFS mounts).  The futures executor runs on
@@ -44,7 +44,7 @@ USAGE
 }
 
 activate_env() {
-  local target_env="coffea20250703"
+  local target_env="coffea2025"
   if [[ "${CONDA_DEFAULT_ENV:-}" == "$target_env" ]]; then
     return 0
   fi

--- a/docs/environment_packaging.md
+++ b/docs/environment_packaging.md
@@ -15,7 +15,7 @@ works, walk through the standard refresh steps:
 
        conda env update -f environment.yml --prune
 
-   This command updates the existing `coffea20250703` environment in-place and
+   This command updates the existing `coffea2025` environment in-place and
    removes packages that are no longer required.
 
 2. Regenerate the packaged tarball that workflows submit to remote resources::
@@ -25,9 +25,7 @@ works, walk through the standard refresh steps:
    The helper will compare the current `environment.yml` (including the
    `coffea==2025.7.3` / `awkward==2.8.7` pins) against the cached archive in
    `topeft-envs/` and build a fresh tarball when the spec or local editable
-   packages (`topeft`, `topcoffea`) have changed.  It rewrites the pip section
-   to `-e` installs automatically so the archive bundles the local checkouts
-   referenced by `PIP_LOCAL_TO_WATCH`.
+   packages (`topeft`, `topcoffea`) have changed.
 
 Remember to commit both the specification and the newly generated archive when
 updating the shipped environment.  Workflows such as ``analysis/topeft_run2/run_analysis.py``

--- a/docs/quickstart_run2.md
+++ b/docs/quickstart_run2.md
@@ -12,11 +12,11 @@ to the local ``futures`` backend.
 
 Set up the shared development environment before launching the helper.  The
 repository standardises on the Coffea 2025.7 toolchain, captured in the
-`coffea20250703` Conda environment declared in `environment.yml`:
+`coffea2025` Conda environment declared in `environment.yml`:
 
 ```bash
 conda env create -f environment.yml
-conda activate coffea20250703
+conda activate coffea2025
 pip install -e .
 ```
 

--- a/docs/quickstart_top22_006.md
+++ b/docs/quickstart_top22_006.md
@@ -18,10 +18,10 @@ single distributed-execution checklist):
 
    ```bash
    conda env create -f environment.yml
-   conda activate coffea20250703
+   conda activate coffea2025
    ```
 
-   The packaged environment tracks the Coffea 2025.7.3 release. Rebuild the TaskVine archive after dependency changes with `python -m topcoffea.modules.remote_environment`; the helper caches the resulting tarball under `topeft-envs/` using the Conda specification plus the Git commits of editable packages.  Each invocation prints the active path and automatically refreshes the archive when it detects new commits or unstaged edits in `topeft` or `topcoffea`.  To force a rebuild (for example after a branch reset), remove the cached file or run ``python -c "from topcoffea.modules.remote_environment import get_environment; print(get_environment(force=True))"``.  Developers upgrading an existing checkout can run `conda env update -f environment.yml --prune` instead of recreating the environment from scratch.  Expect Conda to request a solver update on older installations due to the move to Python 3.13—allow the update (or execute `conda update -n base -c conda-forge conda`) and approve the follow-up `coffea==2025.7.3`/`awkward==2.8.7` prompts so the local stack matches the packaged tarball.
+   The packaged environment tracks the Coffea 2025.7.3 release. Rebuild the TaskVine archive after dependency changes with `python -m topcoffea.modules.remote_environment`; the helper caches the resulting tarball under `topeft-envs/` using the Conda specification plus the Git commits of editable packages.  Each invocation prints the active path and automatically refreshes the archive when it detects new commits or unstaged edits in `topeft` or `topcoffea`.  To force a rebuild (for example after a branch reset), remove the cached file or run ``python -c "from topcoffea.modules.remote_environment import get_environment; print(get_environment(force=True))"``.  Developers upgrading an existing checkout can run `conda env update -f environment.yml --prune` instead of recreating the environment from scratch.
 
 2. **The editable `topeft` and `topcoffea` packages.**  From the repository
    root install the local modules with:

--- a/docs/taskvine_workflow.md
+++ b/docs/taskvine_workflow.md
@@ -13,7 +13,7 @@ available, then create the shared Conda environment shipped with the repository:
 
 ```bash
 conda env create -f environment.yml
-conda activate coffea20250703
+conda activate coffea2025
 pip install -e .
 ```
 
@@ -30,11 +30,10 @@ cd ../topeft
 ```
 
 Upgrading an existing checkout?  Run `conda env update -f environment.yml --prune`
-instead of recreating the environment.  Conda releases older than 23.11 may
-request a solver update when pulling in Python 3.13 and newer `ndcctools`
-wheels—allow the prompt (or execute `conda update -n base -c conda-forge conda`)
-and approve the follow-up `coffea==2025.7.3` / `awkward==2.8.7` pins so the
-editable installs match the packaged worker tarball.
+instead of recreating the environment.  Conda may request a solver update when
+aligning with the conda-forge builds—allow the prompt (or execute
+`conda update -n base -c conda-forge conda`) so the editable installs match the
+packaged worker tarball.
 
 ## 2. Package the TaskVine environment tarball
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,18 +1,13 @@
-name: coffea20250703
+name: coffea2025
 channels:
   - conda-forge
 dependencies:
-  - conda-forge::python=3.13
-  - pip
+  - coffea=2025.7.3
+  - awkward=2.8.7
+  - ndcctools
   - conda-pack
-  - ndcctools>=7.14.11
-  - xrootd
-  - setuptools>=72
-  - numpy
   - dill
+  - xrootd
   - git
   - pyyaml
-  - pytest
-  - pip:
-      - coffea==2025.7.3
-      - awkward==2.8.7
+  - numpy

--- a/tests/test_environment_hash.py
+++ b/tests/test_environment_hash.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import hashlib
+
+EXPECTED_SHA256 = "f48088dc786c70552262b198c56c39830b4ac1af30583eee1b559f5804ff9020"
+
+
+def test_environment_spec_matches_ttbareft():
+    """Ensure the local Conda spec mirrors ttbarEFT's coffea2025 baseline."""
+
+    env_path = Path(__file__).resolve().parents[1] / "environment.yml"
+    digest = hashlib.sha256(env_path.read_bytes()).hexdigest()
+
+    assert (
+        digest == EXPECTED_SHA256
+    ), (
+        "environment.yml drifted from the ttbarEFT coffea2025 specification. "
+        "Update the file and refresh EXPECTED_SHA256 to match upstream. "
+        f"Observed {digest}."
+    )


### PR DESCRIPTION
## Summary
- rename the Conda environment to `coffea2025` and match the ttbarEFT dependency set in environment.yml
- refresh README and quickstart/taskvines docs and helper scripts to use the new environment name and commands
- add a regression test that hashes environment.yml to guard against drift from the upstream coffea2025 specification

## Testing
- python -m pytest tests/test_environment_hash.py