### PR TITLE
Add conda shim fallback for remote environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ analysis/*/wq-executor-tmp-*
 analysis/*/wq-*.summary
 analysis/*/envs
 analysis/*/histos
+conda_spec.yml
+topeft-envs/
 
 # Project files
 .ropeproject

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,63 @@
+[build-system]
+requires = [
+    "setuptools>=69",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "topeft"
+version = "0.0.0"
+description = "Analysis code for top quark EFT analyses"
+readme = "README.md"
+requires-python = ">=3.9"
+authors = [
+    { name = "CMS TopEFT Group" },
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Operating System :: OS Independent",
+]
+dependencies = [
+    "coffea==2025.7.3",
+    "awkward>=2.8.7",
+    "dill",
+    "pyyaml",
+    "numpy",
+]
+
+[project.urls]
+Homepage = "https://github.com/TopEFT/topeft"
+Repository = "https://github.com/TopEFT/topeft"
+Issues = "https://github.com/TopEFT/topeft/issues"
+
+[project.optional-dependencies]
+topcoffea = [
+    "topcoffea @ file:../topcoffea",
+]
+
+[project.scripts]
+conda = "topeft.conda_shim:main"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+include = [
+    "topeft*",
+]
+
+[tool.setuptools.package-data]
+topeft = [
+    "channels/*",
+    "params/*",
+    "data/fliprates/*.pkl.gz",
+    "data/triggerSF/*.pkl.gz",
+    "data/btagSF/UL/*.pkl.gz",
+    "data/btagSF/UL/*.csv",
+    "modules/*.json",
+    "params/metadata.yml",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ include-package-data = true
 [tool.setuptools.packages.find]
 include = [
     "topeft*",
+    "analysis*",
 ]
 
 [tool.setuptools.package-data]

--- a/scripts/dev_install.sh
+++ b/scripts/dev_install.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install topcoffea and topeft together from sibling checkouts.
+pip install -e ../topcoffea -e .

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,4 @@
-import setuptools
+from setuptools import setup
 
-setuptools.setup(
-    name='topeft',
-    version='0.0.0',
-    description='Analysis code for top quark EFT analyses',
-    packages=setuptools.find_packages(),
-    # Include data files (Note: "include_package_data=True" does not seem to work)
-    package_data={
-        "topeft" : [
-            "channels/*",
-            "params/*",
-            "data/fliprates/*.pkl.gz",
-            "data/triggerSF/*.pkl.gz",
-            "data/btagSF/UL/*.pkl.gz",
-            "data/btagSF/UL/*.csv",
-            "modules/*.json",
-            "params/metadata.yml"
-        ],
-    }
-)
-
+if __name__ == "__main__":
+    setup()

--- a/topeft/conda_shim.py
+++ b/topeft/conda_shim.py
@@ -1,0 +1,46 @@
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _resolve_target():
+    requested = os.environ.get("CONDA_EXE")
+    if requested:
+        return requested
+
+    found = shutil.which("conda")
+    if found:
+        return found
+    return None
+
+
+def _which_micromamba():
+    return shutil.which("micromamba")
+
+
+def _is_self(target: str) -> bool:
+    try:
+        return Path(target).resolve() == Path(sys.argv[0]).resolve()
+    except FileNotFoundError:
+        return False
+
+
+def main() -> int:
+    target = _resolve_target()
+    if target and not _is_self(target):
+        return subprocess.call([target, *sys.argv[1:]])
+
+    micromamba = _which_micromamba()
+    if micromamba:
+        return subprocess.call([micromamba, *sys.argv[1:]])
+
+    sys.stderr.write(
+        "No conda-compatible executable found. Install conda or micromamba to run this command.\n"
+    )
+    return 127
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/topeft/conda_shim.py
+++ b/topeft/conda_shim.py
@@ -1,3 +1,4 @@
+import importlib.util
 import os
 import shutil
 import subprocess
@@ -27,10 +28,26 @@ def _is_self(target: str) -> bool:
         return False
 
 
+def _call_conda_module(argv):
+    if importlib.util.find_spec("conda") is None:
+        return None
+
+    return subprocess.call([sys.executable, "-m", "conda", *argv])
+
+
 def main() -> int:
     target = _resolve_target()
-    if target and not _is_self(target):
-        return subprocess.call([target, *sys.argv[1:]])
+    if target:
+        if not _is_self(target):
+            return subprocess.call([target, *sys.argv[1:]])
+
+        sibling_real = Path(sys.argv[0]).with_name("conda_real")
+        if sibling_real.exists():
+            return subprocess.call([str(sibling_real), *sys.argv[1:]])
+
+        module_result = _call_conda_module(sys.argv[1:])
+        if module_result is not None:
+            return module_result
 
     micromamba = _which_micromamba()
     if micromamba:


### PR DESCRIPTION
## Summary
- add a conda console-script shim that forwards to the real conda or micromamba so TaskVine environment packaging works without a full conda install
- expose the shim via pyproject metadata and document the micromamba fallback for minimal runners
- ignore generated environment artifacts created during remote environment packaging

## Testing
- `pip install -e .`
- `python -m topcoffea.modules.remote_environment`