### PR TITLE
Gate full_run env activation and add dry-run test

### DIFF
--- a/analysis/topeft_run2/full_run.sh
+++ b/analysis/topeft_run2/full_run.sh
@@ -4,8 +4,9 @@
 #
 # Expectations before running:
 #   1. Activate the shared Conda environment shipped with this repository
-#      (name: coffea2025) so the topeft and topcoffea editable installs are
-#      available.  The helper below attempts to activate it when possible.
+#      (name: coffea2025) or another compatible setup so the topeft and
+#      topcoffea editable installs are available. This script assumes the
+#      environment is already active and does not attempt to activate it.
 #   2. For TaskVine runs, stage the packaged environment tarball by running
 #      `python -m topcoffea.modules.remote_environment` after activation.  The
 #      script reuses the returned path as the --environment-file argument.
@@ -48,17 +49,12 @@ Notes:
 USAGE
 }
 
-activate_env() {
+check_active_env() {
   local target_env="coffea2025"
-  if [[ "${CONDA_DEFAULT_ENV:-}" == "$target_env" ]]; then
-    return 0
-  fi
-  if command -v conda >/dev/null 2>&1; then
-    # shellcheck disable=SC1091
-    source "$(conda info --base)/etc/profile.d/conda.sh"
-    conda activate "$target_env" || true
-  else
-    echo "Warning: conda not available; ensure $target_env is already active." >&2
+  if [[ -n "${CONDA_DEFAULT_ENV:-}" && "${CONDA_DEFAULT_ENV}" != "$target_env" ]]; then
+    echo "Warning: CONDA_DEFAULT_ENV='${CONDA_DEFAULT_ENV}' (expected '${target_env}' or a compatible environment)." >&2
+  elif [[ -z "${CONDA_DEFAULT_ENV:-}" ]]; then
+    echo "Note: no active conda environment detected; ensure '${target_env}' or another compatible environment is already activated." >&2
   fi
 }
 
@@ -298,7 +294,7 @@ main() {
   repo_root=$(cd "$script_dir/../.." && pwd)
   cd "$script_dir"
 
-  activate_env
+  check_active_env
   local env_tarball=""
   if [[ "$executor" == "taskvine" && "$user_env_override" == false && "$dry_run" == false ]]; then
     env_tarball=$(stage_environment)

--- a/tests/test_full_run_wrapper.py
+++ b/tests/test_full_run_wrapper.py
@@ -45,3 +45,48 @@ def test_full_run_sh_dry_run(tmp_path):
     assert "UL17_SRs_drytest" in stdout
     assert str(outdir) in stdout
     assert "--skip-cr --do-systs" in stdout
+
+
+def test_full_run_sh_dry_run_without_conda(monkeypatch, tmp_path):
+    repo_root = Path(__file__).resolve().parent.parent
+    analysis_dir = repo_root / "analysis" / "topeft_run2"
+    script_path = analysis_dir / "full_run.sh"
+    outdir = tmp_path / "histos"
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    sample_path = "../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json"
+
+    env = {
+        "PATH": "/usr/bin",
+        "PYTHONPATH": "",
+    }
+
+    cmd = [
+        str(script_path),
+        "--sr",
+        "-y",
+        "UL17",
+        "--tag",
+        "drytest",
+        "--outdir",
+        str(outdir),
+        "--executor",
+        "futures",
+        "--samples",
+        sample_path,
+        "--dry-run",
+    ]
+
+    completed = subprocess.run(
+        cmd,
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=analysis_dir,
+        env=env,
+    )
+
+    assert "Note: no active conda environment detected" in completed.stderr
+    assert "Resolved years: UL17" in completed.stdout
+    assert "Executor: futures" in completed.stdout
+    assert "UL17_SRs_drytest" in completed.stdout


### PR DESCRIPTION
## Summary
- update the full_run.sh wrapper to stop auto-activating the coffea environment and warn when none is detected
- clarify the script header that users should activate the environment before running
- add a dry-run wrapper test that runs without a conda environment to ensure the script no longer fails early

## Testing
- pytest tests/test_full_run_wrapper.py