### PR TITLE
Handle HistEFT import fallbacks and guard messaging

### DIFF
--- a/docs/run_analysis_configuration.md
+++ b/docs/run_analysis_configuration.md
@@ -180,6 +180,11 @@ switching executors once the run is ready to scale beyond the local machine.
 * ``FileNotFoundError`` from :class:`SampleLoader` usually means that relative
   paths were provided.  Always invoke ``run_analysis.py`` from the repository
   root or supply absolute paths.
+* If histogram handling fails with an ``ImportError`` noting that
+  ``topcoffea.modules.histEFT``/``topcoffea.modules.HistEFT`` is missing, confirm
+  that your sibling ``topcoffea`` checkout is on the ``ch_update_calcoffea``
+  branch (or matching tag) and reinstall it with ``pip install -e ../topcoffea``
+  before retrying the run.
 
 With these pieces in place you can mix and match quickstart presets and YAML
 profiles while keeping the run history compact and shareable.  When you need to

--- a/tests/test_runner_output_imports.py
+++ b/tests/test_runner_output_imports.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+import pytest
+
+
+def _module(name: str) -> types.ModuleType:
+    module = types.ModuleType(name)
+    module.__file__ = f"<mocked {name}>"
+    module.__path__ = []  # type: ignore[attr-defined]
+    return module
+
+
+def _reload_runner_output(monkeypatch, module_map: dict[str, types.ModuleType]):
+    for key, value in module_map.items():
+        monkeypatch.setitem(sys.modules, key, value)
+    sys.modules.pop("topeft.modules.runner_output", None)
+    return importlib.import_module("topeft.modules.runner_output")
+
+
+def test_runner_output_imports_lowercase_hist_eft(monkeypatch):
+    topcoffea_pkg = _module("topcoffea")
+    modules_pkg = _module("topcoffea.modules")
+    hist_eft_module = _module("topcoffea.modules.histEFT")
+
+    class _DummyHistEFT:
+        pass
+
+    hist_eft_module.HistEFT = _DummyHistEFT
+    modules_pkg.histEFT = hist_eft_module  # type: ignore[attr-defined]
+
+    runner_output = _reload_runner_output(
+        monkeypatch,
+        {
+            "topcoffea": topcoffea_pkg,
+            "topcoffea.modules": modules_pkg,
+            "topcoffea.modules.histEFT": hist_eft_module,
+        },
+    )
+
+    assert runner_output.HistEFT is _DummyHistEFT
+
+
+def test_runner_output_imports_raise_helpful_error(monkeypatch):
+    topcoffea_pkg = _module("topcoffea")
+    modules_pkg = _module("topcoffea.modules")
+
+    runner_output = _reload_runner_output(
+        monkeypatch,
+        {
+            "topcoffea": topcoffea_pkg,
+            "topcoffea.modules": modules_pkg,
+        },
+    )
+
+    assert runner_output.HistEFT is None
+    assert runner_output._HISTEFT_IMPORT_ERROR is not None
+    with pytest.raises(ImportError, match="does not provide a HistEFT class"):
+        runner_output._summarise_histogram(object())


### PR DESCRIPTION
## Summary
- Add a resilient HistEFT loader that tries both topcoffea module layouts and records a user-friendly error if neither is available
- Cover the new import shims with tests that mock topcoffea environments missing the uppercase alias
- Extend the troubleshooting checklist to point users at the expected topcoffea branch when the HistEFT import guard triggers

## Testing
- pytest tests/test_runner_output_imports.py tests/test_runner_output_serialisation.py