### PR TITLE
Guard topcoffea helper imports in workflow

### DIFF
--- a/analysis/topeft_run2/workflow.py
+++ b/analysis/topeft_run2/workflow.py
@@ -61,8 +61,25 @@ from topeft.modules.executor import (
 )
 from topeft.modules.runner_output import normalise_runner_output, tuple_dict_stats
 
-topcoffea_path = topcoffea.modules.paths.topcoffea_path
-topcoffea_utils = topcoffea.modules.utils
+
+def _import_topcoffea_submodule(submodule: str):
+    module_name = f"{topcoffea.__name__}.modules.{submodule}"
+    try:
+        return importlib.import_module(module_name)
+    except ModuleNotFoundError as exc:
+        raise ImportError(
+            (
+                "Unable to import required topcoffea helper module '%s'. "
+                "Ensure the sibling topcoffea checkout is available and on the "
+                "'ch_update_calcoffea' branch."
+            )
+            % module_name
+        ) from exc
+
+
+_topcoffea_paths = _import_topcoffea_submodule("paths")
+topcoffea_path = _topcoffea_paths.topcoffea_path
+topcoffea_utils = _import_topcoffea_submodule("utils")
 
 from .run_analysis_helpers import (
     DEFAULT_WEIGHT_VARIATIONS,

--- a/tests/test_workflow_topcoffea_imports.py
+++ b/tests/test_workflow_topcoffea_imports.py
@@ -1,0 +1,56 @@
+"""Exercise the workflow import shims for topcoffea helpers."""
+
+from __future__ import annotations
+
+import importlib
+import runpy
+import sys
+import warnings
+
+import pytest
+
+
+def _clear_modules(monkeypatch: pytest.MonkeyPatch, *module_names: str) -> None:
+    for name in module_names:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+
+def test_workflow_imports_topcoffea_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_modules(
+        monkeypatch,
+        "analysis.topeft_run2",
+        "analysis.topeft_run2.workflow",
+        "topcoffea.modules.paths",
+        "topcoffea.modules.utils",
+    )
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=RuntimeWarning)
+        module_globals = runpy.run_module(
+            "analysis.topeft_run2.workflow", run_name="analysis.topeft_run2.workflow"
+        )
+
+    assert callable(module_globals["topcoffea_path"])
+    assert module_globals["topcoffea_utils"] is not None
+
+
+def test_workflow_imports_missing_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_modules(
+        monkeypatch, "analysis.topeft_run2", "analysis.topeft_run2.workflow", "topcoffea.modules.paths"
+    )
+
+    real_import_module = importlib.import_module
+
+    def _raise_for_paths(name: str, *args, **kwargs):
+        if name.endswith(".modules.paths"):
+            raise ModuleNotFoundError("paths module unavailable")
+        return real_import_module(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib, "import_module", _raise_for_paths)
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=RuntimeWarning)
+        with pytest.raises(ImportError, match="ch_update_calcoffea"):
+            runpy.run_module(
+                "analysis.topeft_run2.workflow", run_name="analysis.topeft_run2.workflow"
+            )


### PR DESCRIPTION
## Summary
- explicitly import topcoffea helper modules used by the Run 2 workflow and provide a clear error when the paths helper is missing
- exercise the new import shim path to ensure optional topcoffea modules are handled even when not preloaded

## Testing
- python -m pytest tests/test_workflow_topcoffea_imports.py