### PR TITLE
Align environment spec with shared histogram stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ pip install -e .
 ```
 The commands above provision the refreshed `coffea2025` Conda environment, which tracks the Coffea 2025.7.3 base release used throughout the project.  Installing `topeft` with `pip install -e .` is now the expected workflow so that local developments are automatically folded into the packaged environment.
 
+The Conda specification now also pins `hist=2.9.*` and `boost-histogram>=1.4` to mirror the histogram stack required by the sibling `topcoffea` checkout.  Keep the NumPy and pandas constraints intact when updating the environment so that ABI compatibility stays aligned across both projects.
+
 To install both sibling repositories in one step, either request the new optional dependency group or run the helper script:
 
 ```

--- a/README_WORKQUEUE.md
+++ b/README_WORKQUEUE.md
@@ -25,6 +25,8 @@ The final command prints the path to the packaged environment.  Re-run it
 whenever you update dependencies or pull new commits so the archive remains in
 sync with your editable checkouts.
 
+The updated specification includes `hist=2.9.*` and `boost-histogram>=1.4` alongside the existing NumPy/pandas pins so the histogram stack matches `topcoffea`'s `pyproject.toml`.  Refresh the Conda environment and TaskVine tarball after pulling the new dependencies.
+
 ## Running the analysis with TaskVine
 
 From `analysis/topeft_run2` prepare a run configuration (JSON/YAML/CFG as shown

--- a/docs/environment_packaging.md
+++ b/docs/environment_packaging.md
@@ -23,7 +23,8 @@ works, walk through the standard refresh steps:
        python -m topcoffea.modules.remote_environment
 
    The helper will compare the current `environment.yml` (including the
-   `coffea==2025.7.3` / `awkward==2.8.7` pins) against the cached archive in
+   `coffea==2025.7.3` / `awkward==2.8.7` pins plus the aligned
+   `hist==2.9.*` / `boost-histogram>=1.4` pair) against the cached archive in
    `topeft-envs/` and build a fresh tarball when the spec or local editable
    packages (`topeft`, `topcoffea`) have changed.
 

--- a/docs/run_and_plot_quickstart.md
+++ b/docs/run_and_plot_quickstart.md
@@ -21,6 +21,8 @@ This guide walks through creating the shared environment, running `run_analysis.
    pip install -e .
    ```
 
+   The shared spec now carries `hist=2.9.*` and `boost-histogram>=1.4` alongside the existing NumPy/pandas pins so the histogram helpers match the `topcoffea` baseline.
+
 3. Clone and install the sibling [`topcoffea`](https://github.com/TopEFT/topcoffea) checkout **on the `ch_update_calcoffea` branch** so the processors and packaged environments agree on the dependency baseline:
 
    ```bash

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,8 @@ dependencies:
   - coffea=2025.7.3
   - awkward=2.8.7
   - pandas>=2.2,<2.3
+  - hist=2.9.*
+  - boost-histogram>=1.4
   - ndcctools
   - conda-pack
   - dill

--- a/tests/test_environment_hash.py
+++ b/tests/test_environment_hash.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import hashlib
 
-EXPECTED_SHA256 = "f48088dc786c70552262b198c56c39830b4ac1af30583eee1b559f5804ff9020"
+EXPECTED_SHA256 = "e1bfdc6116d857c6256f718b5f01433e6525e24bedd441a62e3793b644accf22"
 
 
 def test_environment_spec_matches_ttbareft():


### PR DESCRIPTION
## Summary
- add hist 2.9.* and boost-histogram>=1.4 to the Conda environment alongside the existing numpy/pandas pins to match the topcoffea stack
- refresh environment-creation docs to mention the unified histogram dependencies
- update the expected environment hash for the revised specification

## Testing
- not run (not requested)