### PR TITLE
Align AnalysisProcessor with coffea ProcessorABC

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -17,9 +17,9 @@ import re
 import logging
 
 import coffea
+import coffea.processor as processor
 import hist
 import topcoffea
-from coffea.processor import ProcessorABC
 from coffea.analysis_tools import PackedSelection
 from coffea.lumi_tools import LumiMask
 from typing import Dict, List, Optional, Tuple
@@ -242,7 +242,7 @@ _TAU_SF_WEIGHT_SPECS: Tuple[Tuple[str, str, str, str, str], ...] = (
 )
 
 
-class AnalysisProcessor(ProcessorABC):
+class AnalysisProcessor(processor.ProcessorABC):
 
     def __init__(
         self,

--- a/analysis/topeft_run2/workflow.py
+++ b/analysis/topeft_run2/workflow.py
@@ -927,6 +927,14 @@ class RunWorkflow:
                 executor_mode=self._config.executor,
             )
 
+            import coffea.processor as processor
+
+            if not isinstance(processor_instance, processor.ProcessorABC):
+                raise TypeError(
+                    "AnalysisProcessor is not an instance of coffea.processor.ProcessorABC. "
+                    f"Active coffea.processor module: {getattr(processor, '__file__', 'unknown')}"
+                )
+
             self._log_task_submission(task)
 
             attempt = 0

--- a/tests/test_flavor_split_histograms.py
+++ b/tests/test_flavor_split_histograms.py
@@ -555,3 +555,9 @@ def test_histogram_tuple_structure_includes_channel_metadata(processor):
     )
 
     assert expected_key in processor.accumulator
+
+
+def test_analysis_processor_matches_coffea_processorabc(processor):
+    import coffea.processor as processor_module
+
+    assert isinstance(processor, processor_module.ProcessorABC)


### PR DESCRIPTION
## Summary
- import coffea.processor consistently and subclass ProcessorABC from the same module used by the executors
- add a preflight ProcessorABC validation before runner execution to surface mismatched coffea installs
- add a regression test ensuring AnalysisProcessor instances satisfy the coffea ProcessorABC check

## Testing
- python -m pytest tests/test_flavor_split_histograms.py -k processorabc