### PR TITLE
Align runner call signature with coffea 2025

### DIFF
--- a/analysis/topeft_run2/run_sow.py
+++ b/analysis/topeft_run2/run_sow.py
@@ -198,7 +198,12 @@ runner = processor.Runner(
 attempt = 0
 while True:
     try:
-        output = runner(flist, treename, processor_instance)
+        output = runner(
+            flist,
+            processor_instance,
+            treename,
+            # coffea Runner.__call__ expects (fileset, processor_instance, treename)
+        )
     except Exception as exc:
         if executor != "futures" or attempt >= futures_retries:
             raise

--- a/analysis/topeft_run2/workflow.py
+++ b/analysis/topeft_run2/workflow.py
@@ -955,8 +955,9 @@ class RunWorkflow:
                 try:
                     out = runner(
                         {task.sample: sample_flist},
-                        self._config.treename,
                         processor_instance,
+                        self._config.treename,
+                        # coffea Runner.__call__ expects (fileset, processor_instance, treename)
                     )
                 except Exception as exc:
                     if attempt >= max_retries:


### PR DESCRIPTION
## Summary
- update runner invocations in workflow and sow script to pass processor instances before treename per coffea Runner.__call__ signature
- document the expected runner signature inline to guard against regressions

## Testing
- Not run (not requested)