### PR TITLE
Ensure Condor plotter entry dir defaults and propagation

### DIFF
--- a/analysis/topeft_run2/condor_plotter_entry.sh
+++ b/analysis/topeft_run2/condor_plotter_entry.sh
@@ -7,12 +7,36 @@ main() {
     unset PYTHONPATH
 
     local entry_dir="${TOPEFT_ENTRY_DIR:-}"
+
+    if [[ -z "${entry_dir}" && $# -gt 0 && "$1" == TOPEFT_ENTRY_DIR=* ]]; then
+        entry_dir="${1#TOPEFT_ENTRY_DIR=}"
+        shift
+    fi
+
     if [[ -z "${entry_dir}" ]]; then
-        echo "[condor_plotter_entry] ERROR: TOPEFT_ENTRY_DIR is not set." >&2
+        local script_dir
+        script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+        if [[ -n "${PWD:-}" ]]; then
+            entry_dir="${PWD}"
+        fi
+
+        if [[ -z "${entry_dir}" && -n "${script_dir}" ]]; then
+            entry_dir="${script_dir}"
+        fi
+    fi
+
+    if [[ -z "${entry_dir}" ]]; then
+        echo "[condor_plotter_entry] ERROR: TOPEFT_ENTRY_DIR is not set and no fallback was found." >&2
         return 1
     fi
 
-    cd "${entry_dir}"
+    echo "[condor_plotter_entry] Using entry directory: ${entry_dir}" >&2
+
+    cd "${entry_dir}" || {
+        echo "[condor_plotter_entry] ERROR: Failed to cd into '${entry_dir}'." >&2
+        return 1
+    }
 
     activate_with_conda() {
         if command -v conda >/dev/null 2>&1; then

--- a/analysis/topeft_run2/condor_plotter_entry.sh
+++ b/analysis/topeft_run2/condor_plotter_entry.sh
@@ -8,8 +8,10 @@ main() {
 
     local entry_dir="${TOPEFT_ENTRY_DIR:-}"
 
-    if [[ -z "${entry_dir}" && $# -gt 0 && "$1" == TOPEFT_ENTRY_DIR=* ]]; then
-        entry_dir="${1#TOPEFT_ENTRY_DIR=}"
+    if [[ $# -gt 0 && "$1" == TOPEFT_ENTRY_DIR=* ]]; then
+        if [[ -z "${entry_dir}" ]]; then
+            entry_dir="${1#TOPEFT_ENTRY_DIR=}"
+        fi
         shift
     fi
 


### PR DESCRIPTION
## Summary
- add fallbacks in condor_plotter_entry.sh to derive and log the entry directory when TOPEFT_ENTRY_DIR is missing
- set TOPEFT_ENTRY_DIR explicitly in the Condor submit helper and pass it via both environment and wrapper arguments
- surface the resolved entry directory in dry-run output for easier verification

## Testing
- Not run (not requested)