### PR TITLE
Set Run2 NanoEvents factories to numpy mode and harden jet cleaning

### DIFF
--- a/analysis/topeft_run2/README.md
+++ b/analysis/topeft_run2/README.md
@@ -88,6 +88,13 @@ This directory contains scripts for the Full Run 2 EFT analysis. This README doc
         config = RunConfig(json_files=["/path/to/sample.json"])
         run_workflow(config)
 
+      The Run 2 workflow always instantiates NanoEvents factories in explicit
+      ``"numpy"`` mode, so local futures runs use in-memory arrays without
+      relying on Dask. The coffea runner wiring enforces the mode when
+      building factories, which avoids ``_mode`` attribute errors seen with
+      coffea >= 0.7 and clarifies that Dask is not a requirement for the
+      standard Run 2 configuration.
+
     - A step-by-step walkthrough of the command-line interface is available in
       the [TOP-22-006 quickstart guide](../docs/quickstart_top22_006.md).  See
       also the [Run 2 quickstart overview](../docs/quickstart_run2.md), the

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -1144,8 +1144,30 @@ class AnalysisProcessor(processor.ProcessorABC):
         )[0]
 
         if not dataset.is_data:
+            pt_gen = None
+
+            try:
+                matched_gen = cleaned_jets.matched_gen
+            except Exception:
+                matched_gen = None
+
+            if matched_gen is not None:
+                pt_gen = matched_gen.pt
+            else:
+                genjet_idx = getattr(cleaned_jets, "genJetIdx", None)
+                event_record = getattr(cleaned_jets, "_events", None)
+                gen_jets = getattr(event_record, "GenJet", None)
+                if gen_jets is not None and genjet_idx is not None:
+                    try:
+                        pt_gen = gen_jets[genjet_idx].pt
+                    except Exception:
+                        pt_gen = None
+
+            if pt_gen is None:
+                pt_gen = ak.zeros_like(cleaned_jets.pt)
+
             cleaned_jets["pt_gen"] = ak.values_astype(
-                ak.fill_none(cleaned_jets.matched_gen.pt, 0), np.float32
+                ak.fill_none(pt_gen, 0), np.float32
             )
 
         cleaned_jets = ApplyJetCorrections(

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -1159,7 +1159,13 @@ class AnalysisProcessor(processor.ProcessorABC):
                 gen_jets = getattr(event_record, "GenJet", None)
                 if gen_jets is not None and genjet_idx is not None:
                     try:
-                        pt_gen = gen_jets[genjet_idx].pt
+                        valid_genjet_idx = genjet_idx >= 0
+                        safe_genjet_idx = ak.where(valid_genjet_idx, genjet_idx, None)
+                        pt_gen = ak.where(
+                            valid_genjet_idx,
+                            gen_jets[safe_genjet_idx].pt,
+                            ak.zeros_like(cleaned_jets.pt),
+                        )
                     except Exception:
                         pt_gen = None
 

--- a/analysis/topeft_run2/check_for_lepMVA.py
+++ b/analysis/topeft_run2/check_for_lepMVA.py
@@ -2,6 +2,7 @@ import os
 import json
 
 from coffea.nanoevents import NanoEventsFactory
+from analysis.topeft_run2.nanoevents_helpers import ensure_factory_mode
 
 import topcoffea
 
@@ -48,7 +49,8 @@ def main():
                 root_files = ["/hadoop" + x.replace("//","/") for x in jsn["files"]]
                 root_file = root_files[0]
                 print(f"\t[{idx+1:>2}/{njsns}] Checking: {root_file}")
-                nano_events = NanoEventsFactory.from_root(root_file,entry_stop=5).events()
+                factory = NanoEventsFactory.from_root(root_file,entry_stop=5)
+                nano_events = ensure_factory_mode(factory).events()
                 e = nano_events.Electron
                 print("\t\te.mvaTTHUL",e.mvaTTHUL)
 main()

--- a/analysis/topeft_run2/make_1d_quad_plots.py
+++ b/analysis/topeft_run2/make_1d_quad_plots.py
@@ -2,6 +2,7 @@ import os
 import argparse
 import datetime
 from coffea.nanoevents import NanoEventsFactory
+from analysis.topeft_run2.nanoevents_helpers import ensure_factory_mode
 
 import topcoffea
 from topeft.modules.topcoffea_imports import require_script
@@ -39,7 +40,8 @@ def main():
     in_file = redirector + in_file
 
     # Get the events object and wc names from the input file
-    events = NanoEventsFactory.from_root(in_file).events()
+    factory = NanoEventsFactory.from_root(in_file)
+    events = ensure_factory_mode(factory).events()
     wc_names_lst = utils.get_list_of_wc_names(in_file)
 
     # Get the wc fit dict

--- a/analysis/topeft_run2/nanoevents_helpers.py
+++ b/analysis/topeft_run2/nanoevents_helpers.py
@@ -1,0 +1,48 @@
+"""Helpers for constructing NanoEvents factories with explicit modes.
+
+The helpers here centralize the logic required by coffea >=0.7, where
+``NanoEvents`` objects expect their originating factory to advertise an
+explicit ``_mode`` (for example ``"numpy"`` for in-memory processing).
+By funnelling all factory creation through these helpers we ensure a
+consistent mode is attached regardless of whether coffea sets it
+internally.
+"""
+
+from __future__ import annotations
+
+from coffea.nanoevents import NanoEventsFactory
+
+
+def ensure_factory_mode(factory: NanoEventsFactory, *, mode: str = "numpy") -> NanoEventsFactory:
+    """Guarantee ``factory._mode`` is populated.
+
+    Parameters
+    ----------
+    factory:
+        The factory instance produced by ``NanoEventsFactory.from_root`` or
+        similar helpers.
+    mode:
+        The mode value to enforce when the factory does not already define
+        ``_mode``.
+    """
+
+    try:
+        current_mode = getattr(factory, "_mode", None)
+    except Exception:  # pragma: no cover - defensive fallback
+        current_mode = None
+
+    if current_mode != mode:
+        try:
+            factory._mode = mode
+        except Exception:  # pragma: no cover - best effort
+            pass
+
+    return factory
+
+
+def nanoevents_factory_from_root(*args, mode: str = "numpy", **kwargs) -> NanoEventsFactory:
+    """Wrap ``NanoEventsFactory.from_root`` and enforce an explicit mode."""
+
+    factory = NanoEventsFactory.from_root(*args, **kwargs)
+    return ensure_factory_mode(factory, mode=mode)
+

--- a/analysis/topeft_run2/run_sow.py
+++ b/analysis/topeft_run2/run_sow.py
@@ -11,6 +11,7 @@ import coffea.processor as processor
 from coffea.nanoevents import NanoEventsFactory, NanoAODSchema
 
 import topcoffea
+from analysis.topeft_run2.nanoevents_helpers import nanoevents_factory_from_root
 
 if hasattr(NanoEventsFactory, "warn_missing_crossrefs"):
     NanoEventsFactory.warn_missing_crossrefs = False
@@ -177,6 +178,10 @@ else:
 
 runner_fields = set(getattr(processor.Runner, "__dataclass_fields__", {}))
 runner_kwargs: dict[str, Any] = {}
+if "nanoevents_factory" in runner_fields:
+    runner_kwargs["nanoevents_factory"] = lambda *args, **kwargs: nanoevents_factory_from_root(
+        *args, mode="numpy", **kwargs
+    )
 if executor == "futures":
     runner_kwargs.update(
         futures_runner_overrides(

--- a/tests/test_nanoevents_without_caches.py
+++ b/tests/test_nanoevents_without_caches.py
@@ -5,6 +5,7 @@ import uuid
 
 import awkward as ak
 from coffea.nanoevents import BaseSchema, NanoEventsFactory
+from analysis.topeft_run2.nanoevents_helpers import ensure_factory_mode
 
 
 _hist_eft_stub = types.ModuleType("topcoffea.modules.HistEFT")
@@ -177,3 +178,22 @@ def test_process_handles_nanoevents_without_cache(monkeypatch):
 
     assert result == {"status": "ok"}
     assert processed_variations == ["nominal"]
+
+
+def test_factory_mode_is_set_for_numpy(monkeypatch):
+    factory = ensure_factory_mode(
+        NanoEventsFactory.from_preloaded(
+            _DummyMapping(event=ak.Array([1.0])), schemaclass=BaseSchema
+        ),
+        mode="numpy",
+    )
+
+    events = factory.events()
+
+    processor, processed_variations = _build_minimal_processor(monkeypatch)
+
+    result = processor.process(events)
+
+    assert result == {"status": "ok"}
+    assert processed_variations == ["nominal"]
+    assert getattr(factory, "_mode", None) == "numpy"


### PR DESCRIPTION
## Summary
- add shared NanoEvents helpers and wire Run 2 runners/scripts to initialise factories with an explicit numpy mode for coffea 0.7 compatibility
- guard jet generator matching so pt_gen is filled safely when cross-references are missing
- extend regression coverage and document that Run 2 workflow runs in non-Dask numpy mode by default

## Testing
- pytest tests/test_nanoevents_without_caches.py tests/test_analysis_processor_variations.py