### PR TITLE
Align Run 2 jet/MET corrections with cache-free API

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -64,6 +64,12 @@ get_te_param = GetParam(topeft_path("params/params.json"))
 
 np.seterr(divide="ignore", invalid="ignore", over="ignore")
 
+if not hasattr(ak, "stack"):
+    def _ak_stack(arrays, axis=0):
+        return ak.Array(np.stack([ak.to_numpy(arr) for arr in arrays], axis=axis))
+
+    ak.stack = _ak_stack  # type: ignore[attr-defined]
+
 
 # Takes strings as inputs, constructs a string for the full channel name
 # Try to construct a channel name like this: [n leptons]_[lepton flavors]_[p or m charge]_[on or off Z]_[n b jets]_[n jets]
@@ -1177,7 +1183,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             )
 
         cleaned_jets = ApplyJetCorrections(
-            dataset.year, corr_type="jets", isData=dataset.is_data, era=dataset.run_era
+            dataset.year, corr_type="jet", isData=dataset.is_data, era=dataset.run_era
         ).build(cleaned_jets)
         cleaned_jets = ApplyJetSystematics(
             dataset.year, cleaned_jets, variation_state.object_variation

--- a/docs/quickstart_run2.md
+++ b/docs/quickstart_run2.md
@@ -48,6 +48,17 @@ guide](environment_packaging.md) for rebuild strategies.  Legacy Work Queue
 instructions remain available in [`README_WORKQUEUE.md`](../README_WORKQUEUE.md)
 when you need to reproduce the historical backend.
 
+### Cache-free jet/MET corrections
+
+Run 2 processing now assumes the cache-free jet and MET correction interfaces
+shipped with the `ch_update_calcoffea` branch of `topcoffea`.  The helper and
+full workflow no longer rely on NanoEvents caches when building corrected jets
+or propagating jet variations into MET; the updated APIs materialise the
+corrections directly.  Make sure your environment uses the matching
+`topcoffea` checkout (or a release containing the same cache-free helpers) so
+the processor can run end-to-end without attaching a `lazy_cache` to the
+NanoEvents object.
+
 The quickest way to run the helper is via the dedicated module entry point::
 
     python -m topeft.quickstart input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \

--- a/tests/test_analysis_processor_jetmet_cacheless.py
+++ b/tests/test_analysis_processor_jetmet_cacheless.py
@@ -1,0 +1,260 @@
+import importlib
+import sys
+import types
+
+import awkward as ak
+import numpy as np
+
+from coffea.nanoevents import BaseSchema, NanoEventsFactory
+
+_hist_eft_stub = types.ModuleType("topcoffea.modules.HistEFT")
+
+
+class _DummyHistEFT:
+    def __init__(self, *_, **__):
+        pass
+
+    def fill(self, **__):
+        pass
+
+
+_hist_eft_stub.HistEFT = _DummyHistEFT
+importlib.import_module("topcoffea")
+modules_pkg = importlib.import_module("topcoffea.modules")
+modules_pkg.HistEFT = _hist_eft_stub  # type: ignore[attr-defined]
+sys.modules["topcoffea.modules.HistEFT"] = _hist_eft_stub
+sys.modules["topcoffea.modules.histEFT"] = _hist_eft_stub
+
+import analysis.topeft_run2.analysis_processor as ap
+
+
+class _DummyMapping(dict):
+    """Mapping wrapper that mimics NanoEventsFactory metadata."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.metadata = {
+            "uuid": "cacheless-jetmet-test",
+            "num_rows": len(next(iter(kwargs.values()))) if kwargs else 0,
+            "object_path": "Events",
+        }
+
+
+def _build_processor():
+    processor = ap.AnalysisProcessor.__new__(ap.AnalysisProcessor)
+    processor._debug_logging = False
+    processor._debug = lambda *_, **__: None
+    processor._available_systematics = {
+        "object": (),
+        "weight": (),
+        "theory": (),
+        "data_weight": (),
+    }
+    processor._available_systematics_sets = {
+        key: set(values) for key, values in processor._available_systematics.items()
+    }
+    processor._accumulator = {"status": "ok"}
+    processor._var_def = set()
+    processor.tau_h_analysis = False
+    processor.fwd_analysis = False
+    processor.offZ_3l_split = False
+    processor._channel_features = frozenset()
+
+    def _noop_event_selection(*args, **kwargs):
+        return None
+
+    ap.te_es.add1lMaskAndSFs = _noop_event_selection
+    ap.te_es.add2lMaskAndSFs = _noop_event_selection
+    ap.te_es.add3lMaskAndSFs = _noop_event_selection
+    ap.te_es.add4lMaskAndSFs = _noop_event_selection
+    ap.te_es.addLepCatMasks = _noop_event_selection
+
+    base_objects = ap.BaseObjectState(
+        met=ak.Array(
+            [
+                [
+                    {
+                        "pt": np.float32(50.0),
+                        "phi": np.float32(0.0),
+                        "sumEt": np.float32(55.0),
+                        "MetUnclustEnUpDeltaX": np.float32(0.0),
+                        "MetUnclustEnUpDeltaY": np.float32(0.0),
+                    }
+                ]
+            ]
+        ),
+        electrons=ak.Array([[[]]]),
+        muons=ak.Array([[[]]]),
+        taus=ak.Array([[[]]]),
+        jets=ak.Array(
+            [
+                [
+                    {
+                        "pt": np.float32(45.0),
+                        "eta": np.float32(0.2),
+                        "phi": np.float32(0.1),
+                        "mass": np.float32(9.0),
+                        "rawFactor": np.float32(0.1),
+                        "jetId": 6,
+                        "area": np.float32(0.5),
+                    }
+                ]
+            ]
+        ),
+        loose_leptons=ak.Array([[[]]]),
+        fakeable_leptons=ak.Array(
+            [
+                [
+                    {
+                        "pt": np.float32(0.0),
+                        "eta": np.float32(0.0),
+                        "phi": np.float32(0.0),
+                        "mass": np.float32(0.0),
+                        "jetIdx": -1,
+                    }
+                ]
+            ]
+        ),
+        fakeable_sorted=ak.Array(
+            [
+                [
+                    {
+                        "pt": np.float32(0.0),
+                        "conept": np.float32(0.0),
+                        "jetIdx": -1,
+                    }
+                ]
+            ]
+        ),
+        jets_rho=ak.Array([[np.float32(0.5)]]),
+        lepton_selection=object(),
+        cleaning_taus=None,
+        n_loose_taus=None,
+        tau0=None,
+    )
+
+    dataset = ap.DatasetContext(
+        dataset="sample",
+        trigger_dataset="sample",
+        hist_axis_name="sample",
+        is_data=False,
+        is_eft=False,
+        year="2018",
+        xsec=1.0,
+        sow=1.0,
+        run_era=None,
+        is_run2=True,
+        is_run3=False,
+        sample_type="mc",
+        is_lo_sample=False,
+        lumi_mask=ak.Array([True]),
+        lumi=1.0,
+        eft_coeffs=None,
+        eft_w2_coeffs=None,
+    )
+
+    def _build_dataset_context(self, events):
+        return dataset
+
+    def _select_base_objects(self, events, _dataset):
+        return base_objects
+
+    def _build_variation_requests(self):
+        return [ap.VariationRequest(variation=None, histogram_label="nominal")]
+
+    def _initialize_variation_state(
+        self, request, _base_objects, _dataset, *_args, **_kwargs
+    ):
+        return ap.VariationState(
+            request=request,
+            name="nominal",
+            base=None,
+            variation_type=None,
+            metadata={},
+            object_variation="nominal",
+            weight_variations=[],
+            requested_data_weight_label=None,
+            sow_variation_key_map={},
+            sow_variations={},
+            objects=ap.VariationObjects.from_base(base_objects),
+            lepton_selection=base_objects.lepton_selection,
+            jets_rho=base_objects.jets_rho,
+        )
+
+    processed_variations = []
+
+    def _register_weights_for_variation(
+        self, events, _dataset, variation_state, *_args, **_kwargs
+    ):
+        processed_variations.append(variation_state.name)
+        return {"weight": ak.ones_like(events.event, dtype=np.float32)}
+
+    def _fill_histograms_for_variation(
+        self, _events, _dataset, _variation_state, weights, *_args, **_kwargs
+    ):
+        weights["filled"] = True
+
+    processor._build_dataset_context = _build_dataset_context.__get__(
+        processor, ap.AnalysisProcessor
+    )
+    processor._select_base_objects = _select_base_objects.__get__(
+        processor, ap.AnalysisProcessor
+    )
+    processor._build_variation_requests = _build_variation_requests.__get__(
+        processor, ap.AnalysisProcessor
+    )
+    processor._initialize_variation_state = _initialize_variation_state.__get__(
+        processor, ap.AnalysisProcessor
+    )
+    processor._register_weights_for_variation = _register_weights_for_variation.__get__(
+        processor, ap.AnalysisProcessor
+    )
+    processor._fill_histograms_for_variation = _fill_histograms_for_variation.__get__(
+        processor, ap.AnalysisProcessor
+    )
+
+    return processor, processed_variations
+
+
+def test_analysis_processor_runs_without_caches_for_jetmet():
+    jets = ak.Array(
+        [
+            [
+                {
+                    "pt": np.float32(45.0),
+                    "eta": np.float32(0.2),
+                    "phi": np.float32(0.1),
+                    "mass": np.float32(9.0),
+                    "rawFactor": np.float32(0.1),
+                    "jetId": 6,
+                    "area": np.float32(0.5),
+                }
+            ]
+        ]
+    )
+    met = ak.Array(
+        [
+            [
+                {
+                    "pt": np.float32(50.0),
+                    "phi": np.float32(0.0),
+                    "sumEt": np.float32(55.0),
+                    "MetUnclustEnUpDeltaX": np.float32(0.0),
+                    "MetUnclustEnUpDeltaY": np.float32(0.0),
+                }
+            ]
+        ]
+    )
+
+    events = NanoEventsFactory.from_preloaded(
+        _DummyMapping(event=ak.Array([1]), Jet=jets, MET=met), schemaclass=BaseSchema
+    ).events()
+
+    assert not hasattr(events, "caches")
+
+    processor, processed_variations = _build_processor()
+    result = processor.process(events)
+
+    assert result == {"status": "ok"}
+    assert processed_variations == ["nominal"]
+    assert ak.to_list(events["njets"]) == [1]

--- a/topeft/modules/corrections.py
+++ b/topeft/modules/corrections.py
@@ -12,7 +12,7 @@ import gzip
 import pickle
 import correctionlib
 import json
-from coffea.jetmet_tools import CorrectedMETFactory
+from topcoffea.modules.CorrectedMETFactory import CorrectedMETFactory
 from coffea.btag_tools import BTagScaleFactor
 from coffea.lookup_tools import txt_converters, rochester_lookup
 


### PR DESCRIPTION
## Summary
- Update Run 2 processor jet/MET correction calls to the cache-free topcoffea interfaces and provide an awkward stack fallback for newer coffea environments
- Switch the MET correction factory import to the topcoffea cache-free implementation
- Add a regression test covering jet/MET corrections without NanoEvents caches and document the cache-free workflow in the Run 2 quickstart

## Testing
- pytest tests/test_analysis_processor_jetmet_cacheless.py -q