### PR TITLE
Add HTCondor ulimit safeguards to plotter entry script

### DIFF
--- a/analysis/topeft_run2/condor_plotter_entry.sh
+++ b/analysis/topeft_run2/condor_plotter_entry.sh
@@ -8,6 +8,14 @@ main() {
 
     local entry_dir="${TOPEFT_ENTRY_DIR:-}"
 
+    local -a condor_ulimit_sources=()
+    if [[ -n "${_CONDOR_JOB_IWD:-}" ]]; then
+        condor_ulimit_sources+=("_CONDOR_JOB_IWD")
+    fi
+    if [[ -n "${TOPEFT_CONDOR_ULIMIT:-}" && "${TOPEFT_CONDOR_ULIMIT}" != "0" ]]; then
+        condor_ulimit_sources+=("TOPEFT_CONDOR_ULIMIT")
+    fi
+
     if [[ -z "${entry_dir}" && -n "${_CONDOR_JOB_IWD:-}" ]]; then
         entry_dir="${_CONDOR_JOB_IWD}"
     fi
@@ -40,6 +48,49 @@ main() {
     elif [[ -n "${TOPEFT_CONDA_PREFIX:-}" && -f "${TOPEFT_CONDA_PREFIX}/bin/activate" ]]; then
         # shellcheck disable=SC1091
         source "${TOPEFT_CONDA_PREFIX}/bin/activate"
+    fi
+
+    if (( ${#condor_ulimit_sources[@]} > 0 )); then
+        echo "[condor_plotter_entry] Condor ulimit safeguards enabled (sources: ${condor_ulimit_sources[*]})." >&2
+        echo "[condor_plotter_entry] Limits before adjustment:" >&2
+        ulimit -a >&2
+
+        local core_msg=""
+        if core_msg=$(ulimit -S -c 0 2>&1); then
+            echo "[condor_plotter_entry] Set core file size (soft) to 0." >&2
+        else
+            echo "[condor_plotter_entry] Could not adjust core file size (${core_msg}). Current: $(ulimit -c)." >&2
+        fi
+
+        adjust_memory_limit() {
+            local flag="$1" desc="$2"
+            local soft hard
+            soft=$(ulimit -S "${flag}")
+            hard=$(ulimit -H "${flag}")
+
+            if [[ "${hard}" == "unlimited" ]]; then
+                echo "[condor_plotter_entry] ${desc}: leaving unchanged (hard limit is unlimited)." >&2
+                return
+            fi
+
+            if [[ "${soft}" =~ ^[0-9]+$ && "${hard}" =~ ^[0-9]+$ && ${soft} -le ${hard} ]]; then
+                echo "[condor_plotter_entry] ${desc}: soft limit already ${soft} (hard ${hard})." >&2
+                return
+            fi
+
+            local set_msg=""
+            if set_msg=$(ulimit -S "${flag}" "${hard}" 2>&1); then
+                echo "[condor_plotter_entry] ${desc}: set soft limit to hard cap ${hard}." >&2
+            else
+                echo "[condor_plotter_entry] ${desc}: unable to set limit (${set_msg}). Current soft ${soft}, hard ${hard}." >&2
+            fi
+        }
+
+        adjust_memory_limit -v "Virtual memory"
+        adjust_memory_limit -m "Resident set size"
+
+        echo "[condor_plotter_entry] Limits before run_plotter.sh:" >&2
+        ulimit -a >&2
     fi
 
     ./run_plotter.sh "$@"

--- a/analysis/topeft_run2/submit_plotter_condor.sh
+++ b/analysis/topeft_run2/submit_plotter_condor.sh
@@ -25,6 +25,9 @@ Condor options (provide these anywhere before an optional "--" delimiter):
   --request-cpus N Request this many CPU cores (must be a positive integer)
   --request-memory SIZE
                    Request this amount of memory (HTCondor size expression)
+  --condor-ulimit  Export TOPEFT_CONDOR_ULIMIT=1 so the entry wrapper applies
+                   conservative ulimit settings (e.g., disabling core files)
+                   inside HTCondor jobs.
   --conda-prefix DIR
                    Location of the clib-env Conda environment on the worker
                    nodes. When provided, TOPEFT_CONDA_PREFIX is exported to
@@ -62,6 +65,7 @@ main() {
     local dry_run=0
     local request_cpus=""
     local request_memory=""
+    local condor_ulimit=0
     local -a plotter_args=()
     local parsing_condor=1
 
@@ -126,6 +130,11 @@ main() {
                     fi
                     request_memory="$2"
                     shift 2
+                    continue
+                    ;;
+                --condor-ulimit)
+                    condor_ulimit=1
+                    shift
                     continue
                     ;;
                 --dry-run)
@@ -273,6 +282,10 @@ PY
 
     if [[ -n "${conda_prefix}" ]]; then
         environment_entries+=("TOPEFT_CONDA_PREFIX=${conda_prefix}")
+    fi
+
+    if (( condor_ulimit )); then
+        environment_entries+=("TOPEFT_CONDOR_ULIMIT=1")
     fi
 
     local environment_string=""


### PR DESCRIPTION
## Summary
- detect Condor ulimit context via `_CONDOR_JOB_IWD` or the `TOPEFT_CONDOR_ULIMIT` toggle before running the plotter entry script
- log and apply conservative resource limits for Condor jobs, preventing core dumps and capping memory when possible
- add a `--condor-ulimit` helper flag that exports the toggle and document it in the Condor submission help text

## Testing
- not run (not requested)