### PR TITLE
Remove local Awkward stack shim and document Run 2 requirement

### DIFF
--- a/analysis/topeft_run2/README.md
+++ b/analysis/topeft_run2/README.md
@@ -55,6 +55,7 @@ This directory contains scripts for the Full Run 2 EFT analysis. This README doc
 
 * `run_analysis.py`:
     - Provides the CLI entrypoint for the Run 2 Coffea workflow. The heavy lifting now lives in ``analysis.topeft_run2.workflow`` where the ``RunWorkflow`` class orchestrates channel planning, histogram scheduling, and executor setup.
+    - The Run 2 helpers assume Awkward Array ``>=2`` and rely on the library's native ``ak.stack`` implementation rather than a local compatibility shim.
     - YAML-driven presets live in ``analysis/topeft_run2/configs/``.  The ``fullR2_run.yml`` profile mirrors the historic ``fullR2_run.sh`` wrapper and includes both control-region (``default``) and signal-region (``sr``) option bundles.  Launch the control-region pass with::
 
         python run_analysis.py ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -64,12 +64,6 @@ get_te_param = GetParam(topeft_path("params/params.json"))
 
 np.seterr(divide="ignore", invalid="ignore", over="ignore")
 
-if not hasattr(ak, "stack"):
-    def _ak_stack(arrays, axis=0):
-        return ak.Array(np.stack([ak.to_numpy(arr) for arr in arrays], axis=axis))
-
-    ak.stack = _ak_stack  # type: ignore[attr-defined]
-
 
 # Takes strings as inputs, constructs a string for the full channel name
 # Try to construct a channel name like this: [n leptons]_[lepton flavors]_[p or m charge]_[on or off Z]_[n b jets]_[n jets]

--- a/tests/test_analysis_processor_variations.py
+++ b/tests/test_analysis_processor_variations.py
@@ -1,8 +1,9 @@
-import awkward as ak
-import numpy as np
 import importlib
 import sys
 import types
+import awkward as ak
+import numpy as np
+import pytest
 
 _hist_eft_stub = types.ModuleType("topcoffea.modules.HistEFT")
 
@@ -116,6 +117,19 @@ def _make_processor():
     processor._debug_logging = False
     processor._debug = lambda *args, **kwargs: None
     return processor
+
+
+@pytest.mark.skipif(
+    not hasattr(ap.ak, "stack"),
+    reason="Awkward build missing ak.stack; Run 2 workflow expects native support.",
+)
+def test_ak_stack_uses_awkward_native():
+    arrays = [ak.Array([1, 2]), ak.Array([3, 4])]
+    stacked_axis0 = ap.ak.stack(arrays, axis=0)
+    stacked_axis1 = ap.ak.stack(arrays, axis=1)
+
+    assert ak.to_list(stacked_axis0) == [[1, 2], [3, 4]]
+    assert ak.to_list(stacked_axis1) == [[1, 3], [2, 4]]
 
 
 def test_apply_object_variations_preserves_good_jet_count(monkeypatch):


### PR DESCRIPTION
## Summary
- remove the custom ak.stack shim in the Run 2 analysis processor to rely on Awkward's native support
- add a lightweight test that exercises ak.stack stacking when available
- document that the Run 2 workflow expects Awkward Array >=2 without a local stack shim

## Testing
- python -m pytest tests/test_analysis_processor_variations.py::test_ak_stack_uses_awkward_native