### PR TITLE
Refine DY tau control region selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ A colleague unfamiliar with the repository followed the quickstart above to a su
 * Consult [Work Queue executor](#work-queue-executor) for distributed runs or read `README_WORKQUEUE.md` directly.
 * Datacard production and historical reproductions remain in [Reproducing the TOP-22-006 histograms and datacards](#to-reproduce-the-top-22-006-histograms-and-datacards).
 
+### DY τℓ+τh control region
+Enabling `--tau_h_analysis` now stages a Drell–Yan–enriched validation region with one light lepton and one hadronic tau. Events must feature an opposite-sign ℓ–τh pair near the visible Z mass (either via the existing `onZ_tau` mask or a 60–120 GeV window on m(ℓ,τh)), pass the standard single-lepton trigger path, and contain no medium b tags. The region is split by electron/muon flavor and by the usual 2–4 jet bins so it can appear alongside the other CR yields and plots.
+
 ## Repository contents
 The `topeft/topeft` directory is set up to be installed as a pip installable package.
 - `topeft/topeft`: A package containing modules and files that will be installed into the environment.

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -1082,6 +1082,12 @@ class AnalysisProcessor(processor.ProcessorABC):
                 preselections.add("0tau", (no_tau_mask))
                 preselections.add("onZ_tau", (tl_zpeak_mask))
                 preselections.add("offZ_tau", (~tl_zpeak_mask))
+                lt_os_mask = ak.fill_none((l0.charge * tau0.charge) < 0, False)
+                lt_vis_mass = ak.fill_none((l0 + tau0).mass, np.inf)
+                lt_vis_onZ_mask = ak.fill_none((lt_vis_mass > 60.0) & (lt_vis_mass < 120.0), False)
+                preselections.add("lt_os", lt_os_mask)
+                preselections.add("lt_vis_onZ", lt_vis_onZ_mask)
+                preselections.add("lt_onZ_loose", (tl_zpeak_mask | lt_vis_onZ_mask))
             if self.fwd_analysis:
                 preselections.add("2lss_fwd", (events.is2l & pass_trg & fwdjet_mask))
                 preselections.add("2l_fwd_p", (chargel0_p & fwdjet_mask))

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -225,7 +225,10 @@ if __name__ == "__main__":
     parser.add_argument(
         "--tau_h_analysis",
         action="store_true",
-        help="Add tau channels",
+        help=(
+            "Add hadronic tau channels, including the DY-like 1l+tau_h control region "
+            "with opposite-sign pairs around the visible Z mass."
+        ),
     )
     parser.add_argument(
         "--fwd-analysis",

--- a/topeft/channels/ch_lst.json
+++ b/topeft/channels/ch_lst.json
@@ -405,6 +405,30 @@
                 "=3",
                 "=4"
             ]
+        },
+        "dy_tautau_CR": {
+            "lep_chan_lst": [
+                [
+                    "1l_dy_tautau_CR",
+                    "1l",
+                    "1tau",
+                    "lt_os",
+                    "lt_onZ_loose",
+                    "bmask_exactly0m"
+                ]
+            ],
+            "lep_flav_lst": [
+                "e",
+                "m"
+            ],
+            "appl_lst": [
+                "isSR_1l"
+            ],
+            "jet_lst": [
+                "=2",
+                "=3",
+                "=4"
+            ]
         }
     },
     "OFFZ_SPLIT_CH_LST_SR": {

--- a/topeft/channels/ch_lst.json
+++ b/topeft/channels/ch_lst.json
@@ -406,7 +406,7 @@
                 "=4"
             ]
         },
-        "dy_tautau_CR": {
+        "1l_dy_tautau_CR": {
             "lep_chan_lst": [
                 [
                     "1l_dy_tautau_CR",

--- a/topeft/params/cr_sr_plots_metadata.yml
+++ b/topeft/params/cr_sr_plots_metadata.yml
@@ -102,6 +102,21 @@ CR_CHAN_DICT:
     - 1l_m_1tau_CR_2j
     - 1l_m_1tau_CR_3j
     - 1l_m_1tau_CR_4j
+  cr_dy_tautau:
+    - 1l_e_dy_tautau_CR_2j
+    - 1l_e_dy_tautau_CR_3j
+    - 1l_e_dy_tautau_CR_4j
+    - 1l_m_dy_tautau_CR_2j
+    - 1l_m_dy_tautau_CR_3j
+    - 1l_m_dy_tautau_CR_4j
+  cr_dy_tautau_e:
+    - 1l_e_dy_tautau_CR_2j
+    - 1l_e_dy_tautau_CR_3j
+    - 1l_e_dy_tautau_CR_4j
+  cr_dy_tautau_m:
+    - 1l_m_dy_tautau_CR_2j
+    - 1l_m_dy_tautau_CR_3j
+    - 1l_m_dy_tautau_CR_4j
 SR_CHAN_DICT:
   2lss_SR:
     - 2lss_4t_m_4j


### PR DESCRIPTION
## Summary
- register individual ℓ–τh opposite-sign and loose Z-window preselections for tau analysis flow
- configure the DY tau control-region channel to use standard preselection entries instead of a dedicated combined mask

## Testing
- jq empty topeft/channels/ch_lst.json