### PR TITLE
Handle forward jet counts defensively

### DIFF
--- a/docs/quickstart_run2.md
+++ b/docs/quickstart_run2.md
@@ -182,7 +182,8 @@ through the scenario list:
   off-Z trilepton split.
 * ``tau_analysis`` – Extends the baseline with the tau-enriched regions.
 * ``fwd_analysis`` – Adds the forward-jet selections on top of the shared
-  control suite.
+  control suite.  Forward-jet counts are recomputed as integer per-event
+  tallies before histogramming to avoid Awkward broadcasting pitfalls.
 
 Pass ``--scenario`` one or more times to request the combinations you need.  For
 example, ``--scenario TOP_22_006 --scenario tau_analysis`` layers the tau


### PR DESCRIPTION
## Summary
- Recompute forward-jet counts as per-event integers during histogram preparation, defaulting to zero when forward jet info is missing
- Add regression coverage for forward-jet histogram masks and document the run2 workflow behavior

## Testing
- pytest tests/test_analysis_processor_variations.py