### PR TITLE
Ensure forward jet counts use numeric masks

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -1839,19 +1839,25 @@ class AnalysisProcessor(processor.ProcessorABC):
         elif goodJets is not None and "isFwd" in ak.fields(goodJets):
             fwd_mask = ak.fill_none(goodJets.isFwd, False)
         else:
-            fwd_mask = ak.zeros_like(events["event"], dtype=bool)
+            fwd_mask = None
 
-        nfwdj = ak.num(fwd_mask[fwd_mask], axis=-1)
-        nfwdj = ak.fill_none(nfwdj, 0)
-        nfwdj_layout = ak.to_layout(nfwdj, allow_record=False)
-        nfwdj = ak.values_astype(ak.Array(nfwdj_layout), np.int64)
-        if nfwdj_layout.purelist_depth != 1:
-            raise TypeError(
-                f"nfwdj must be a flat per-event array, not {nfwdj_layout.purelist_depth}D"
-            )
+        if fwd_mask is not None:
+            nfwdj = ak.num(fwd_mask[fwd_mask], axis=-1)
+            nfwdj = ak.fill_none(nfwdj, 0)
+            nfwdj_layout = ak.to_layout(nfwdj, allow_record=False)
+            nfwdj = ak.values_astype(ak.Array(nfwdj_layout), np.int64)
+            if nfwdj_layout.purelist_depth != 1:
+                raise TypeError(
+                    f"nfwdj must be a flat per-event array, not {nfwdj_layout.purelist_depth}D"
+                )
+
+            fwdjet_mask = nfwdj > 0
+        else:
+            nfwdj = ak.zeros_like(events["event"], dtype=np.int64)
+            nfwdj_layout = ak.to_layout(nfwdj, allow_record=False)
+            fwdjet_mask = ak.zeros_like(events["event"], dtype=bool)
 
         variation_state.nfwdj = nfwdj
-        fwdjet_mask = nfwdj > 0
 
         chargel0_p = ak.fill_none((l0.charge) > 0, False)
         chargel0_m = ak.fill_none((l0.charge) < 0, False)

--- a/docs/analysis_processing.md
+++ b/docs/analysis_processing.md
@@ -64,6 +64,11 @@ aspects are worth keeping in mind when extending it:
   systematic)`` tuple so downstream data-driven estimation helpers (for
   example :class:`topeft.modules.dataDrivenEstimation.DataDrivenProducer`)
   receive the application tag without relying on categorical axes.
+* **Forward-jet bookkeeping** – forward-jet selections recompute the per-event
+  counts from their masks with ``ak.num`` and immediately cast them to numeric
+  arrays (filling missing entries with zeros) before histogramming so that
+  ``fwdjet_mask`` remains a flat boolean array even when events lack forward
+  jets.
 
 Because the constructor performs strict validation (checking for ``None``
 arguments, verifying tuple lengths, etc.), deviations are caught early.  The


### PR DESCRIPTION
## Summary
- recompute forward-jet counts from forward masks with numeric layouts before histogramming
- add regression coverage for multijet forward-mask events
- document that run 2 workflows enforce numeric forward-jet counts prior to histogram filling

## Testing
- pytest tests/test_analysis_processor_variations.py::test_forward_jet_counts_are_recomputed tests/test_analysis_processor_variations.py::test_forward_histograms_handle_multijet_masks