### PR TITLE
Provide lazy cache when building corrected jets

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -1188,6 +1188,12 @@ class AnalysisProcessor(processor.ProcessorABC):
                 ak.fill_none(pt_gen, 0), np.float32
             )
 
+        jet_lazy_cache = None
+        jet_events = getattr(cleaned_jets, "_events", None)
+        jet_caches = getattr(jet_events, "caches", None) if jet_events is not None else None
+        if jet_caches:
+            jet_lazy_cache = jet_caches[0]
+
         cleaned_jets = build_corrected_jets(
             ApplyJetCorrections(
                 dataset.year,
@@ -1196,6 +1202,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                 era=dataset.run_era,
             ),
             cleaned_jets,
+            lazy_cache=jet_lazy_cache,
         )
         cleaned_jets = ApplyJetSystematics(
             dataset.year, cleaned_jets, variation_state.object_variation

--- a/tests/test_corrected_jets_lazy_cache.py
+++ b/tests/test_corrected_jets_lazy_cache.py
@@ -1,0 +1,38 @@
+import types
+
+import awkward as ak
+
+from topeft.modules.corrections import ApplyJetSystematics, build_corrected_jets
+
+
+class _DummyJetFactory:
+    def __init__(self):
+        self.last_lazy_cache = None
+
+    def build(self, jets, lazy_cache=None):
+        self.last_lazy_cache = lazy_cache
+
+        corrected = ak.with_field(jets, jets.pt * 1.1, "pt")
+        corrected = ak.with_field(corrected, jets.mass * 1.1, "mass")
+
+        return corrected
+
+
+def test_corrected_jets_use_lazy_cache_and_feed_systematics():
+    jets = ak.Array([[{"pt": 50.0, "mass": 5.0}]])
+
+    dummy_cache = object()
+    dummy_events = types.SimpleNamespace(caches=[dummy_cache])
+    jets._events = dummy_events
+
+    jet_factory = _DummyJetFactory()
+
+    corrected = build_corrected_jets(jet_factory, jets, lazy_cache=dummy_cache)
+
+    assert jet_factory.last_lazy_cache is dummy_cache
+    assert ak.all(corrected.pt != jets.pt)
+    assert ak.all(ak.isclose(corrected.pt, jets.pt * 1.1))
+    assert ak.all(ak.isclose(corrected.mass, jets.mass * 1.1))
+
+    nominal = ApplyJetSystematics("2018", corrected, "nominal")
+    assert ak.all(ak.isclose(nominal.pt, corrected.pt))

--- a/topeft/modules/corrections.py
+++ b/topeft/modules/corrections.py
@@ -1489,10 +1489,20 @@ def ApplyJetCorrections(year, corr_type, isData, era, useclib=True, savelevels=F
     return CorrectedJetsFactory(name_map, jec_stack)
 
 
-def build_corrected_jets(jet_factory, jets):
-    """Materialise corrected jets using the cache-free factory interface."""
+def build_corrected_jets(jet_factory, jets, lazy_cache=None):
+    """Materialise corrected jets, providing an awkward lazy cache when available."""
 
-    corrected = jet_factory.build(jets)
+    if lazy_cache is None:
+        events = getattr(jets, "_events", None)
+        caches = getattr(events, "caches", None) if events is not None else None
+        if caches:
+            lazy_cache = caches[0]
+
+    try:
+        corrected = jet_factory.build(jets, lazy_cache=lazy_cache)
+    except TypeError:
+        corrected = jet_factory.build(jets)
+
     return ak.Array(corrected)
 
 


### PR DESCRIPTION
## Summary
- pass available NanoEvents lazy caches into `build_corrected_jets` so corrected jets can be built with the expected interface
- update the Run 2 analysis processor to forward the cache while building jet corrections
- add a unit test validating that corrected jets use the lazy cache and feed systematics downstream

## Testing
- pytest tests/test_corrected_jets_lazy_cache.py