### PR TITLE
Normalize off-Z split channel selections

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -1977,6 +1977,22 @@ class AnalysisProcessor(processor.ProcessorABC):
                 "3l_offZ_none",
                 (sfosz_3l_OffZ_mask & ~sfosz_3l_OffZ_any_mask),
             )
+            preselections.add(
+                "3l_offZ_split",
+                (
+                    preselections.any("3l_offZ_low")
+                    | preselections.any("3l_offZ_high")
+                    | preselections.any("3l_offZ_none")
+                ),
+            )
+            preselections.add(
+                "3l_offZ",
+                (
+                    preselections.any("3l_offZ_low")
+                    | preselections.any("3l_offZ_high")
+                    | preselections.any("3l_offZ_none")
+                ),
+            )
         else:
             preselections.add("3l_offZ", sfosz_3l_OffZ_mask)
 

--- a/analysis/topeft_run2/workflow.py
+++ b/analysis/topeft_run2/workflow.py
@@ -195,9 +195,12 @@ class ChannelPlanner:
                                 exclude_set.difference_update(include_set)
                             features = set(active_features)
                             features.update(group.features)
+                            chan_def_lst = self._normalize_channel_definition(
+                                region.to_legacy_list(), active_features
+                            )
                             return {
                                 "jet_selection": jet_key,
-                                "chan_def_lst": region.to_legacy_list(),
+                                "chan_def_lst": chan_def_lst,
                                 "lep_flav_lst": category.lepton_flavors,
                                 "appl_region": application,
                                 "features": tuple(sorted(features)),
@@ -299,6 +302,20 @@ class ChannelPlanner:
         self._cr_groups = tuple(cr_groups)
         self._active_features = tuple(sorted(active_features))
         return self._sr_groups, self._cr_groups, self._active_features
+
+    @staticmethod
+    def _normalize_channel_definition(
+        chan_def_lst: Sequence[str], active_features: Iterable[str]
+    ) -> List[str]:
+        """Return ``chan_def_lst`` adjusted for active metadata features."""
+
+        normalized = list(chan_def_lst)
+        if "offz_split" in set(active_features) and "3l_offZ" in normalized:
+            normalized = [
+                "3l_offZ_split" if entry == "3l_offZ" else entry
+                for entry in normalized
+            ]
+        return normalized
 
 
 def normalize_jet_category(jet_cat: Any) -> str:

--- a/tests/test_channel_features.py
+++ b/tests/test_channel_features.py
@@ -180,6 +180,21 @@ def test_build_channel_dict_includes_offz_features(channel_helper):
     assert "offz_split" in channel_dict["features"]
 
 
+def test_offz_split_rewrites_legacy_offz_subchannel(channel_helper):
+    channel_dict = build_dict(
+        channel_helper,
+        "3l_p_offZ_1b_2j",
+        "isSR_3l",
+        is_data=False,
+        skip_sr=False,
+        skip_cr=False,
+        scenario_names=["TOP_22_006"],
+    )
+
+    assert "3l_offZ_split" in channel_dict["chan_def_lst"]
+    assert "3l_offZ" not in channel_dict["chan_def_lst"]
+
+
 def test_build_channel_dict_includes_tau_features_for_control(channel_helper):
     channel_dict = build_dict(
         channel_helper,


### PR DESCRIPTION
## Summary
- normalize legacy trilepton off-Z channel definitions when the offz_split feature is active
- add selection aliases so off-Z split channels share a combined mask during histogram filling
- add regression coverage for off-Z split channel resolution in the planner and processor

## Testing
- pytest tests/test_channel_features.py tests/test_analysis_processor_variations.py::test_offz_split_channels_accept_legacy_offz