### PR TITLE
Add application region handling for 1l tau control regions

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -1194,6 +1194,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             selections.add("isAR_2lOS",    (~events.is2l_SR) & charge2l_0)
             if self.tau_h_analysis:
                 selections.add("isSR_1l",    ( events.is1l_SR))
+                selections.add("isAR_1l",    (~events.is1l_SR))
 
             selections.add("isSR_3l",  events.is3l_SR)
             selections.add("isAR_3l", ~events.is3l_SR)

--- a/topeft/channels/ch_lst.json
+++ b/topeft/channels/ch_lst.json
@@ -398,7 +398,8 @@
                 "m"
             ],
             "appl_lst": [
-                "isSR_1l"
+                "isSR_1l",
+                "isAR_1l"
             ],
             "jet_lst": [
                 "=2",
@@ -422,7 +423,8 @@
                 "m"
             ],
             "appl_lst": [
-                "isSR_1l"
+                "isSR_1l",
+                "isAR_1l"
             ],
             "jet_lst": [
                 "=2",


### PR DESCRIPTION
## Summary
- add the 1ℓ application-region flag for tau analyses alongside existing AR/SR selections
- include `isAR_1l` in the application lists for 1ℓτ control channels so AR histograms are produced
- ensure data-driven estimation receives the 1ℓτ application-region slices for nonprompt/flip histogram building

## Testing
- python -m compileall analysis/topeft_run2/analysis_processor.py topeft/modules/dataDrivenEstimation.py