### PR TITLE
Fix ptbl btag mask handling

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -633,14 +633,14 @@ class AnalysisProcessor(processor.ProcessorABC):
         ptbl_bjet = good_jets[(is_btag_med | is_btag_loose)]
         ptbl_bjet = ak.with_name(ptbl_bjet, "PtEtaPhiMCandidate")
         leading_b = ak.firsts(ptbl_bjet[ak.argsort(ptbl_bjet.pt, axis=-1, ascending=False)])
-        has_btag = ak.num(ptbl_bjet) > 0
+        has_btag = ak.num(ptbl_bjet.pt, axis=-1) > 0
 
         zero_vector = ak.zip(
             {
-                "pt": ak.zeros_like(ak.num(good_jets, axis=-1)) * np.float32(0.0),
-                "eta": ak.zeros_like(ak.num(good_jets, axis=-1)) * np.float32(0.0),
-                "phi": ak.zeros_like(ak.num(good_jets, axis=-1)) * np.float32(0.0),
-                "mass": ak.zeros_like(ak.num(good_jets, axis=-1)) * np.float32(0.0),
+                "pt": ak.zeros_like(has_btag, dtype=np.float32),
+                "eta": ak.zeros_like(has_btag, dtype=np.float32),
+                "phi": ak.zeros_like(has_btag, dtype=np.float32),
+                "mass": ak.zeros_like(has_btag, dtype=np.float32),
             },
             with_name="PtEtaPhiMCandidate",
         )
@@ -659,7 +659,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         pt_sum = np.hypot(px_b + px_l, py_b + py_l)
         pt_sum = ak.firsts(ak.singletons(pt_sum))
-        pt_sum = ak.values_astype(ak.fill_none(pt_sum, -1), np.float32)
+        pt_sum = ak.values_astype(ak.fill_none(pt_sum, np.float32(-1.0)), np.float32)
         return ak.where(has_btag, pt_sum, np.float32(-1.0))
 
     def _build_histogram_key(

--- a/tests/test_analysis_processor_variations.py
+++ b/tests/test_analysis_processor_variations.py
@@ -679,6 +679,31 @@ def test_ptbl_pairing_handles_missing_btags(monkeypatch):
     assert np.isfinite(np.asarray(ak.to_list(recorded_ptbl), dtype=float)).all()
 
 
+def test_compute_ptbl_handles_zero_and_positive_btags():
+    processor = _make_processor()
+
+    good_jets = ak.Array(
+        [
+            [{"pt": 45.0, "eta": 0.1, "phi": 0.2, "mass": 5.0}],
+            [{"pt": 55.0, "eta": -0.1, "phi": -0.3, "mass": 4.0}],
+        ]
+    )
+    is_btag_med = ak.Array([[False], [True]])
+    is_btag_loose = ak.Array([[False], [False]])
+    leptons = ak.Array(
+        [
+            [{"pt": 40.0, "eta": 0.0, "phi": 0.0, "mass": 0.1}],
+            [{"pt": 42.0, "eta": 0.2, "phi": 0.1, "mass": 0.1}],
+        ]
+    )
+
+    ptbl_values = processor._compute_ptbl(good_jets, is_btag_med, is_btag_loose, leptons)
+    ptbl_flat = ak.to_list(ak.flatten(ptbl_values, axis=None))
+
+    assert ptbl_flat[0] == pytest.approx(-1.0)
+    assert ptbl_flat[1] > 0
+
+
 def test_histogram_btag_masks_handle_multijet_events(monkeypatch):
     (
         processor,


### PR DESCRIPTION
## Summary
- compute `has_btag` from explicit per-event b-jet counts and align zero-btag fallback vectors
- keep pt sum defaults consistent for missing b-tag events
- add regression coverage for zero and positive b-tag ptbl calculations

## Testing
- pytest tests/test_analysis_processor_variations.py -k ptbl *(fails: environment expects topcoffea on ch_update_calcoffea branch)*