### PR TITLE
Improve jet layout logging diagnostics

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -1173,19 +1173,15 @@ class AnalysisProcessor(processor.ProcessorABC):
                 target = arr
                 selected_field = None
 
-                if ak.is_record(target):
+                fields = ak.fields(target)
+                if fields:
                     for candidate in ("jets", "Jet", "pt"):
-                        if candidate in target.fields:
+                        if candidate in fields:
                             selected_field = candidate
                             break
 
-                    if selected_field is None and target.fields:
-                        selected_field = target.fields[0]
-
                     if selected_field is None:
-                        raise TypeError(
-                            f"Cannot determine jet field for '{label}' from record fields={target.fields}"
-                        )
+                        selected_field = fields[0]
 
                     target = target[selected_field]
 

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -1198,8 +1198,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                 counts = ak.num(target, axis=-1)
             except Exception as exc:
                 raise TypeError(
-                    f"Unable to log jet layout for '{label}': "
-                    f"original_type={original_type!r}, arr_type={ak.type(arr)!r}, error={exc}"
+                    f"Unable to log jet layout for '{label}': original_type={original_type!r}, arr_type={ak.type(arr)!r}, error={exc}"
                 ) from exc
 
             self._debug(

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -1198,7 +1198,8 @@ class AnalysisProcessor(processor.ProcessorABC):
                 counts = ak.num(target, axis=-1)
             except Exception as exc:
                 raise TypeError(
-                    f"Unable to log jet layout for '{label}': {exc}"
+                    f"Unable to log jet layout for '{label}': "
+                    f"original_type={original_type!r}, arr_type={ak.type(arr)!r}, error={exc}"
                 ) from exc
 
             self._debug(

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -1198,15 +1198,17 @@ class AnalysisProcessor(processor.ProcessorABC):
                 counts = ak.num(target, axis=-1)
             except Exception as exc:
                 raise TypeError(
-                    f"Unable to log jet layout for '{label}': original_type={original_type!r}, arr_type={ak.type(arr)!r}, error={exc}"
+                    f"Unable to log jet layout for '{label}': "
+                    f"original_type={original_type!r}, arr_type={ak.type(arr)!r}, error={exc}"
                 ) from exc
 
             self._debug(
-                "\n\n\n\n\n%s layout: original_type=%s selected_field=%s target=%s counts=%s nonempty=%s (len=%d)\n\n\n\n\n",
+                "\n\n\n\n\n%s layout: original_type=%s selected_field=%s target=%s target_type=%s counts=%s nonempty=%s (len=%d)\n\n\n\n\n",
                 label,
                 original_type,
                 selected_field,
                 target,
+                ak.type(target),
                 counts,
                 counts > 0,
                 len(counts),


### PR DESCRIPTION
## Summary
- refine `_log_jet_layout` to pick jet-like fields from records, validate list-of-jet structure, and log original types alongside the selected array
- compute jet counts with an explicit axis and provide clearer errors for unexpected layouts

## Testing
- not run (not requested)