### PR TITLE
feat: tidy progress output and add per-task variation recap

### DIFF
--- a/analysis/topeft_run2/README.md
+++ b/analysis/topeft_run2/README.md
@@ -122,6 +122,13 @@ This directory contains scripts for the Full Run 2 EFT analysis. This README doc
           now emit at ``INFO`` so you can see them without enabling the extremely verbose
           DEBUG logs from dependencies; reserve ``--log-level DEBUG`` for deep dives into
           third-party internals.
+        - Progress bars and logging output no longer trample each other: the CLI uses a
+          ``tqdm``-aware logging handler so ``INFO`` lines remain readable even while coffea
+          updates its per-task progress display.
+        - Each histogram task now ends with a concise “variation recap” line that lists the
+          requested variation labels, the object/weight variations that actually executed,
+          and the histogram labels that were filled; search for ``Completed histogram task`` to
+          see the summary for a given sample/channel combination.
         - Example 5-event futures run with full diagnostics::
 
             python run_analysis.py ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \

--- a/analysis/topeft_run2/README.md
+++ b/analysis/topeft_run2/README.md
@@ -128,7 +128,9 @@ This directory contains scripts for the Full Run 2 EFT analysis. This README doc
         - Each histogram task now ends with a concise “variation recap” line that lists the
           requested variation labels, the object/weight variations that actually executed,
           and the histogram labels that were filled; search for ``Completed histogram task`` to
-          see the summary for a given sample/channel combination.
+          see the summary for a given sample/channel combination.  Internally the processor
+          stashes these recaps in a reserved accumulator key, which the workflow pops before
+          writing outputs so downstream consumers only see the usual histograms.
         - Example 5-event futures run with full diagnostics::
 
             python run_analysis.py ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -22,7 +22,7 @@ import hist
 import topcoffea
 from coffea.analysis_tools import PackedSelection
 from coffea.lumi_tools import LumiMask
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from topeft.modules.paths import topeft_path
 from topeft.modules.corrections import (
@@ -318,6 +318,7 @@ _TAU_SF_WEIGHT_SPECS: Tuple[Tuple[str, str, str, str, str], ...] = (
 
 
 class AnalysisProcessor(processor.ProcessorABC):
+    VARIATION_SUMMARY_KEY = "__topeft_variation_summary__"
 
     def __init__(
         self,
@@ -378,6 +379,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                 os.environ.get("TOPEFT_SUPPRESS_DEBUG_STDOUT")
             )
         self._suppress_debug_prints = bool(suppress_debug_prints)
+        self._executed_variations: List[Dict[str, Any]] = []
         self._golden_json_path = golden_json_path
         if self._sample.get("isData") and not self._golden_json_path:
             raise ValueError("golden_json_path must be provided for data samples")
@@ -524,6 +526,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         self._histogram_key_map = histogram_key_map
 
+        histogram[self.VARIATION_SUMMARY_KEY] = []
         self._accumulator = histogram
 
         # Set the energy threshold to cut on
@@ -597,6 +600,33 @@ class AnalysisProcessor(processor.ProcessorABC):
                 result[key] = value
             return result
         return {}
+
+    def _record_variation_execution(
+        self,
+        variation_state: VariationState,
+        *,
+        histogram_label: str,
+        executed_weight_variations: Sequence[str],
+    ) -> None:
+        """Capture a lightweight summary of the variation that just ran."""
+
+        variation = variation_state.request.variation
+        components: Tuple[Any, ...] = ()
+        if variation is not None:
+            raw_components = getattr(variation, "components", ()) or ()
+            components = tuple(str(component) for component in raw_components)
+
+        entry: Dict[str, Any] = {
+            "requested_name": variation_state.name,
+            "variation_type": variation_state.variation_type or "nominal",
+            "histogram_label": histogram_label,
+            "object_variation": variation_state.object_variation or "nominal",
+            "executed_weight_variations": tuple(executed_weight_variations),
+            "requested_weight_variations": tuple(variation_state.weight_variations),
+            "data_weight_label": variation_state.requested_data_weight_label,
+            "components": components,
+        }
+        self._executed_variations.append(entry)
 
     @property
     def accumulator(self):
@@ -2341,6 +2371,8 @@ class AnalysisProcessor(processor.ProcessorABC):
             if name not in wgt_var_lst:
                 wgt_var_lst.append(name)
 
+        executed_weight_variations: List[str] = []
+
         lep_chan = self._channel_dict["chan_def_lst"][0]
         jet_req = self._channel_dict["jet_selection"]
         lep_flav_iter = (
@@ -2362,6 +2394,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                 and wgt_fluct in data_weight_systematics_set
             ):
                 continue
+            executed_weight_variations.append(wgt_fluct)
 
             if wgt_fluct == "nominal":
                 hist_variation_label = hist_label
@@ -2467,6 +2500,12 @@ class AnalysisProcessor(processor.ProcessorABC):
                     continue
                 hout[histkey].fill(**axes_fill_info_dict)
 
+        self._record_variation_execution(
+            variation_state,
+            histogram_label=hist_label,
+            executed_weight_variations=executed_weight_variations,
+        )
+
     @property
     def channel(self):
         return self._channel
@@ -2535,6 +2574,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         dataset = self._build_dataset_context(events)
         base_objects = self._select_base_objects(events, dataset)
         variation_requests = self._build_variation_requests()
+        self._executed_variations.clear()
 
         object_systematics = self._available_systematics.get("object", ())
         weight_systematics = self._available_systematics.get("weight", ())
@@ -2597,6 +2637,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                 hout,
             )
 
+        hout[self.VARIATION_SUMMARY_KEY] = list(self._executed_variations)
         return hout
 
     def postprocess(self, accumulator):

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -318,6 +318,8 @@ _TAU_SF_WEIGHT_SPECS: Tuple[Tuple[str, str, str, str, str], ...] = (
 
 
 class AnalysisProcessor(processor.ProcessorABC):
+    # Internal accumulator slot for per-task variation recaps; RunWorkflow pops
+    # this key before serialized outputs are returned to users or saved.
     VARIATION_SUMMARY_KEY = "__topeft_variation_summary__"
 
     def __init__(

--- a/analysis/topeft_run2/logging_utils.py
+++ b/analysis/topeft_run2/logging_utils.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
+try:  # pragma: no cover - tqdm is bundled with coffea
+    from tqdm.contrib.logging import TqdmLoggingHandler
+except Exception:  # pragma: no cover - fallback when tqdm is unavailable
+    TqdmLoggingHandler = None  # type: ignore[assignment]
+
 from .run_analysis_helpers import VALID_LOG_LEVELS
 
 logger = logging.getLogger(__name__)
@@ -41,7 +46,10 @@ def configure_logging(level_name: str, *, formatter: Optional[str] = None) -> No
     # repeatedly; reuse existing root handlers whenever they are present.
     attach_handler = not root.handlers
     if attach_handler:
-        handler = logging.StreamHandler()
+        if TqdmLoggingHandler is not None:
+            handler: logging.Handler = TqdmLoggingHandler()
+        else:
+            handler = logging.StreamHandler()
         handler.setFormatter(
             logging.Formatter(
                 formatter or "%(asctime)s %(levelname)s %(name)s: %(message)s"

--- a/analysis/topeft_run2/logging_utils.py
+++ b/analysis/topeft_run2/logging_utils.py
@@ -46,6 +46,8 @@ def configure_logging(level_name: str, *, formatter: Optional[str] = None) -> No
     # repeatedly; reuse existing root handlers whenever they are present.
     attach_handler = not root.handlers
     if attach_handler:
+        # Prefer tqdm-aware logging so progress bars and INFO lines do not stomp
+        # on each other; fall back to a plain stream handler if tqdm is missing.
         if TqdmLoggingHandler is not None:
             handler: logging.Handler = TqdmLoggingHandler()
         else:


### PR DESCRIPTION
### Summary

This PR improves the interplay between `topeft` logging and coffea/tqdm progress bars and adds a per-histogram-task “variation recap” at `INFO` level. The goal is to keep logs readable (even when copied from the terminal or a CI log) while still exposing which variations were actually executed for each histogram task.

### Technical changes

- **Logging / progress separation**
  - `analysis/topeft_run2/logging_utils.py`
    - `configure_logging` now prefers `tqdm.contrib.logging.TqdmLoggingHandler` (falling back to a standard `StreamHandler` when `tqdm`’s logging integration is unavailable).
    - INFO/WARN log lines are now emitted via the tqdm-aware handler, so they appear cleanly above coffea’s progress bars instead of being interleaved mid-line with tqdm output.

- **Variation execution tracking**
  - `analysis/topeft_run2/analysis_processor.py`
    - Introduces a reserved accumulator key (e.g. `VARIATION_SUMMARY_KEY = "__topeft_variation_summary__"`) and per-processor `_executed_variations` tracking.
    - Adds a helper `_record_variation_execution(...)` that is called whenever a variation is actually processed.
    - At the start of `process`, `_executed_variations` is cleared. Before returning the accumulator, the collected variation summary is stored under `VARIATION_SUMMARY_KEY` so the workflow can consume it.

- **Per-task variation recap logging**
  - `analysis/topeft_run2/workflow.py`
    - Adds `_log_variation_recap(...)`, which:
      - Retrieves the variation summary from the accumulator via `VARIATION_SUMMARY_KEY`.
      - Emits a single `INFO` log after each histogram task completes, including:
        - `sample`, `channel`, `application`, `variable`
        - requested variations
        - executed object/weight variations
        - histogram labels
        - any skipped weight variations
      - Pops `VARIATION_SUMMARY_KEY` from the accumulator so downstream consumers see the original histogram structure.
    - Existing workflow logic remains unchanged aside from consuming this internal summary payload.

- **Documentation**
  - `analysis/topeft_run2/README.md`
    - Notes that logging now uses a tqdm-aware handler so log messages and coffea progress bars coexist more cleanly.
    - Documents the new per-histogram-task “variation recap” line and where to look for it in the logs.

### UX examples

With `--log-level INFO`, users now see:

- Clean log messages, e.g.
  - `INFO:Starting histogram task 11/387988: sample=UL17_tHq_b1_NDSkim channel=2lss_m_5j variable=invmass application=isAR_2lSS variations=1`
- A recap after each histogram task, for example:
  - `INFO:Completed histogram task 11/387988: sample=UL17_tHq_b1_NDSkim channel=2lss_m_5j variable=invmass application=isAR_2lSS requested_variations=[nominal] object_variations=[nominal] executed_weight_variations=[nominal] histogram_labels=[UL17_tHq_b1_NDSkim__2lss_m_5j__isAR_2lSS__invmass__nominal] skipped_weight_variations=[]`

Progress bars from coffea/tqdm still appear interactively, but they no longer corrupt the INFO lines when you copy logs from the terminal or from CI.

### Testing

- `python -m compileall analysis/topeft_run2`
- `python analysis/topeft_run2/run_analysis.py --help`
- Local smoke test (iterative executor, tiny slice):

  ```bash
  cd topeft

  python analysis/topeft_run2/run_analysis.py \
    input_samples/cfgs/mc_signal_samples_NDSkim.cfg,\
input_samples/cfgs/mc_background_samples_NDSkim.cfg,\
input_samples/cfgs/data_samples_NDSkim.cfg \
    --outname UL17_SRs_quickstart \
    --outpath histos/local_debug \
    --nworkers 1 \
    --summary-verbosity brief \
    --executor iterative \
    --skip-cr \
    --do-systs \
    --log-level INFO \
    -c 1 \
    -s 5
