### PR TITLE
Wire scenario metadata YAMLs into workflow and ChannelPlanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,17 +246,25 @@ variations are evaluated.  Key sections include:
 
 When you need a custom configuration, copy the metadata file to a new name (for
 example `analysis/topeft_run2/configs/metadata_myteam.yml`) so your edits stay
-isolated.  Both the quickstart helper and `run_analysis.py` accept the clone via
-`--metadata`, removing the need to swap files in `topeft/params/metadata.yml`.
-When you are driving the workflow through a YAML profile, set a top-level
-`metadata: configs/metadata_myteam.yml` entry so the override lives alongside
-the rest of your configuration knobs.
-For example, the following command launches the full workflow with a bespoke
-metadata bundle kept alongside your analysis configs:
+isolated.  Quickstart helpers can still consume the clone directly via their own
+`--metadata` flag, but `run_analysis.py` now resolves metadata solely through
+the scenario registry or YAML options files.  Add a `metadata:` entry to the
+profile you launch with `--options` so the override lives alongside the rest of
+your configuration knobs.  A minimal example profile looks like:
+
+```yaml
+# analysis/topeft_run2/configs/fullR2_run_myteam.yml
+metadata: configs/metadata_myteam.yml
+jsonFiles:
+  - ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json
+scenarios:
+  - TOP_22_006
+```
+
+Run the custom configuration with:
 
 ```bash
-python run_analysis.py ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \
-    --metadata configs/metadata_myteam.yml --executor taskvine --nworkers 1 --chunksize 128000
+python run_analysis.py --options analysis/topeft_run2/configs/fullR2_run_myteam.yml
 ```
 
 The [metadata configuration guide](docs/run_analysis_configuration.md#metadata-configuration)
@@ -360,5 +368,4 @@ The [v0.5 tag](https://github.com/TopEFT/topcoffea/releases/tag/v0.5) was used t
     ```
 
 5. Proceed to the [Steps for reproducing the "official" TOP-22-006 workspace](https://github.com/TopEFT/EFTFit#steps-for-reproducing-the-official-top-22-006-workspace) steps listed in the EFTFit Readme. Remember that in addition to the files cards and templates, you will also need the `selectedWCs.txt` file. 
-
 

--- a/analysis/topeft_run2/README.md
+++ b/analysis/topeft_run2/README.md
@@ -64,12 +64,7 @@ This directory contains scripts for the Full Run 2 EFT analysis. This README doc
 
       Switch to the signal-region preset by appending ``:sr`` to the YAML path (``--options configs/fullR2_run.yml:sr``).  When ``--options`` is present the YAML file becomes the single source of truth—embed any extra overrides (for example executor choices or log verbosity) directly in the configuration or drop ``--options`` for an ad-hoc CLI run.
     - Metadata scenarios from ``topeft/params/metadata.yml`` can be selected via ``--scenario`` when running without YAML (defaults to ``TOP_22_006``).  Additional bundles include ``tau_analysis`` for the tau-enriched categories and ``fwd_analysis`` for the forward-jet study.  Repeat the argument to combine scenarios on CLI-only runs or edit your YAML presets to keep the combinations version-controlled.
-    - Custom metadata bundles can be passed directly with ``--metadata`` so you no longer need to overwrite ``topeft/params/metadata.yml``.  For example::
-
-          python run_analysis.py ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \
-              --metadata configs/metadata_dev.yml --executor futures --nworkers 1
-
-    - The same override is available in YAML presets via the top-level ``metadata`` key.  Setting ``metadata: configs/metadata_dev.yml`` inside your ``--options`` file keeps the bundle version-controlled alongside other run settings.
+    - When you need to test a custom metadata bundle, clone ``topeft/params/metadata.yml`` and reference it from the profile you launch with ``--options`` via the top-level ``metadata`` key.  This keeps overrides version-controlled while letting scenario-only runs continue to draw from the registry-backed defaults.
 
     - When running with the futures executor you can now tune the local workflow directly from the CLI (or the matching YAML keys).  The most common toggles are::
 

--- a/analysis/topeft_run2/scenario_registry.py
+++ b/analysis/topeft_run2/scenario_registry.py
@@ -1,0 +1,51 @@
+"""Registry mapping scenario names to metadata YAML files.
+
+This module centralises where the Run 2 CLI should look for the metadata
+describing each supported scenario.  Keeping the mapping in one location makes
+it straightforward to audit which YAML bundles are considered production ready
+while preventing ad-hoc path strings from spreading throughout the workflow.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable
+
+# Paths are stored relative to the topeft repository root.  The CLI converts
+# them into absolute paths via ``topeft.modules.paths.topeft_path`` before
+# passing them to the workflow.
+_SCENARIO_REGISTRY: Dict[str, str] = {
+    "TOP_22_006": "analysis/metadata/metadata_TOP_22_006.yaml",
+    "tau_analysis": "analysis/metadata/metadata_tau_analysis.yaml",
+    "fwd_analysis": "analysis/metadata/metadata_fwd_analysis.yaml",
+    # NOTE: intentionally not exposing "all_analysis" yet.
+}
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def known_scenarios() -> Iterable[str]:
+    """Return the scenario names wired into the registry."""
+
+    return _SCENARIO_REGISTRY.keys()
+
+
+def resolve_scenario_path(name: str) -> str:
+    """Return the metadata YAML path for ``name``.
+
+    Raises:
+        ValueError: if ``name`` is not registered.  The exception message lists
+            the available scenarios to help steer the user.
+    """
+
+    try:
+        rel_path = _SCENARIO_REGISTRY[name]
+        return str((_REPO_ROOT / rel_path).resolve())
+    except KeyError as exc:  # pragma: no cover - simple guard
+        available = ", ".join(sorted(known_scenarios()))
+        raise ValueError(
+            f"Unknown scenario '{name}'. Known scenarios: {available}"
+        ) from exc
+
+
+__all__ = ["known_scenarios", "resolve_scenario_path"]

--- a/analysis/topeft_run2/workflow.py
+++ b/analysis/topeft_run2/workflow.py
@@ -293,10 +293,9 @@ class ChannelPlanner:
                 if not self._skip_sr and group not in sr_groups:
                     sr_groups.append(group)
 
-        scenario_names = list(self._scenario_names)
-        for scenario_name in scenario_names:
-            for group_name in channel_helper.scenario_groups(scenario_name):
-                _register_group(group_name)
+        group_names = channel_helper.selected_group_names(self._scenario_names)
+        for group_name in group_names:
+            _register_group(group_name)
 
         if not sr_groups and not cr_groups and not seen_groups:
             raise ValueError("No channel groups selected. Please specify at least one scenario")
@@ -1336,10 +1335,13 @@ def run_workflow(config: RunConfig) -> None:
 
     import yaml
     from topeft.modules.channel_metadata import ChannelMetadataHelper
-    from topeft.modules.paths import topeft_path
 
-    default_metadata_path = topeft_path("params/metadata.yml")
-    metadata_source = config.metadata_path or default_metadata_path
+    metadata_source = config.metadata_path
+    if not metadata_source:
+        raise ValueError(
+            "RunConfig.metadata_path is not set. The scenario registry or options profile "
+            "must select a metadata bundle before launching run_workflow."
+        )
     candidate_path = Path(metadata_source).expanduser()
     if not candidate_path.is_absolute():
         candidate_path = Path.cwd() / candidate_path

--- a/docs/quickstart_run2.md
+++ b/docs/quickstart_run2.md
@@ -165,14 +165,11 @@ To test custom metadata, copy ``topeft/params/metadata.yml`` to a new location,
 edit the clone, and pass it to the helper via ``--metadata``.  Keeping the clone
 under version control (for example ``analysis/topeft_run2/configs/metadata_dev.yml``)
 makes it easy to promote the same configuration to the full workflow once the
-quickstart validation looks good.  The same path can be handed to
-``analysis/topeft_run2/run_analysis.py`` via ``--metadata`` when you are ready to
-run the full job:
-
-```bash
-python run_analysis.py ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \
-    --metadata configs/metadata_dev.yml --executor taskvine
-```
+quickstart validation looks good.  When you are ready to run
+``analysis/topeft_run2/run_analysis.py``, reference the same clone from a YAML
+profile launched with ``--options`` by adding ``metadata: configs/metadata_dev.yml``
+near the top of the file.  This keeps custom metadata tied to the profile while
+allowing the CLI to keep relying on the scenario registry for standard runs.
 
 ### Metadata scenarios
 

--- a/docs/quickstart_top22_006.md
+++ b/docs/quickstart_top22_006.md
@@ -138,12 +138,11 @@ scenarios declared in ``topeft/params/metadata.yml``.
    run.
 
    When you need to test changes to the metadata catalogue, clone
-   ``topeft/params/metadata.yml`` and pass the new path with ``--metadata``.  For
-   example, to reuse the JSON inputs above with a custom metadata bundle in
-   ``configs/metadata_dev.yml`` run::
-
-       python run_analysis.py ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \
-           --metadata configs/metadata_dev.yml --executor taskvine --nworkers 1
+   ``topeft/params/metadata.yml`` and reference the new path from the YAML
+   profile you launch with ``--options``.  Add ``metadata: configs/metadata_dev.yml``
+   (or similar) near the top of your options file so the override is captured in
+   version control, then run ``python run_analysis.py --options <your_yaml>`` to
+   exercise the edits.
 
 ## Next steps {#top22-quickstart-next-steps}
 

--- a/docs/run2_scenarios.md
+++ b/docs/run2_scenarios.md
@@ -14,6 +14,23 @@ Each section starts from a clean checkout of the repository with the editable
 recommended environment setup).  The commands shown below assume that you are in
 ``analysis/topeft_run2`` unless otherwise noted.
 
+The CLI always resolves `--scenario` via
+[`analysis/topeft_run2/scenario_registry.py`](../analysis/topeft_run2/scenario_registry.py),
+so passing a friendly name (or relying on the default `TOP_22_006`) automatically
+selects the corresponding metadata YAML.  A minimal pretend run looks like:
+
+```bash
+python run_analysis.py \
+    ../../input_samples/cfgs/mc_signal_samples_NDSkim.cfg \
+    --scenario TOP_22_006 \
+    --pretend --executor iterative --nworkers 1
+```
+
+!!! warning
+    When ``--options`` is supplied the YAML profile becomes the source of truth
+    for scenarios and metadata paths.  Do not repeat ``--scenario`` on the CLI in
+    that case—define the scenario list directly inside the profile instead.
+
 For details on how the scenarios map onto metadata-driven channel and histogram
 definitions, refer back to the [metadata configuration guide](run_analysis_configuration.md#metadata-configuration).
 

--- a/docs/run_analysis_configuration.md
+++ b/docs/run_analysis_configuration.md
@@ -39,10 +39,10 @@ place.  A common workflow is:
 1. Copy ``topeft/params/metadata.yml`` to ``analysis/topeft_run2/configs/metadata_<tag>.yml`` (or another tracked location).
 2. Update the cloned YAML with any new regions, variables, or systematics.
 3. Point ``python -m topeft.quickstart`` at the clone with ``--metadata`` to test
-   the changes quickly.  For ``run_analysis.py`` runs, reference the clone via the
-   CLI (``--metadata configs/metadata_<tag>.yml``) or add ``metadata:
-   configs/metadata_<tag>.yml`` to your ``--options`` YAML so the workflow stays
-   reproducible without touching the baseline file.
+   the changes quickly.  For ``run_analysis.py`` runs, set ``metadata:
+   configs/metadata_<tag>.yml`` (or similar) inside the YAML profile you launch
+   with ``--options`` so the override stays version-controlled while the CLI
+   continues to rely on the scenario registry for standard runs.
 
 The quickstart and scenario guides link back to this section so that anyone
 tweaking the Run 2 configuration knows where each dial is sourced.

--- a/reports/topeft-scenario-cli-docs-step2c-20251201-1030.md
+++ b/reports/topeft-scenario-cli-docs-step2c-20251201-1030.md
@@ -1,0 +1,14 @@
+# Run analysis docs cleanup (format_update_scenarios_step2)
+
+## Summary
+- Updated the top-level `README.md`, `analysis/topeft_run2/README.md`, `docs/quickstart_top22_006.md`, `docs/quickstart_run2.md`, and `docs/run_analysis_configuration.md` so user-facing instructions explain that `run_analysis.py` selects metadata via the scenario registry or options profiles rather than a `--metadata` CLI flag.
+- Replaced CLI examples that previously used `--metadata` with YAML-first workflows (showing where to set the `metadata:` key) and highlighted that quickstart helpers remain the only place where `--metadata` is accepted directly.
+- Confirmed the only remaining `--metadata` mentions under `docs/` reference the quickstart helper intentionally.
+
+## Verification
+- `rg --no-heading --line-number -- '--metadata' docs analysis`  → quickstart-specific mentions only (`docs/run_analysis_configuration.md:41`, `docs/quickstart_run2.md:165`).
+- `PYTHONNOUSERSITE=1 PYTHONPATH="" /users/apiccine/work/miniconda3/envs/coffea2025/bin/python analysis/topeft_run2/run_analysis.py input_samples/cfgs/mc_signal_samples_NDSkim.cfg --scenario TOP_22_006 --executor iterative --pretend`
+  - Confirms the CLI still resolves the scenario/metadata pair and completes pretend runs after docs changes. (The default TaskVine run without `--executor iterative` still errors in this environment because no cached remote environment tarball is present.)
+
+## Follow-ups
+- None; future doc updates should continue emphasizing the scenario registry plus YAML overrides for custom metadata.

--- a/reports/topeft-scenario-cli-step2b-20251201-1018.md
+++ b/reports/topeft-scenario-cli-step2b-20251201-1018.md
@@ -1,0 +1,16 @@
+# Scenario CLI UX refinements (format_update_scenarios_step2)
+
+## Summary
+- Added `resolve_scenario_choice` so callers receive both the resolved metadata path and the available scenario names, giving the CLI enough context to emit friendly errors.
+- Removed the CLI `--metadata` flag, enforced mutual exclusivity between `--scenario` and `--options`, and bubbled configuration metadata through `_apply_scenario_metadata_defaults` so the caller always sees the effective scenario/metadata pair.
+- Logged a single INFO line after logging is configured that reports `Using scenario '<name>' with metadata '<path>'`, with an options-profile suffix when the metadata path was explicitly provided by YAML.
+- Documented the new behavior in `docs/run_analysis_cli_reference.md` and `docs/run2_scenarios.md`, including guidance on the scenario registry and the `--options` precedence rules.
+
+## Testing
+- `PYTHONNOUSERSITE=1 PYTHONPATH="" /users/apiccine/work/miniconda3/envs/coffea2025/bin/python analysis/topeft_run2/run_analysis.py input_samples/cfgs/mc_signal_samples_NDSkim.cfg --outname UL17_SRs_quickstart_test --outpath histos/local_debug --nworkers 1 --summary-verbosity brief --executor iterative --skip-cr --do-systs --log-level INFO -c 1 -s 5 --scenario TOP_22_006 --pretend`
+- `PYTHONNOUSERSITE=1 PYTHONPATH="" /users/apiccine/work/miniconda3/envs/coffea2025/bin/python analysis/topeft_run2/run_analysis.py input_samples/cfgs/mc_signal_samples_NDSkim.cfg --scenario does_not_exist --pretend`
+- `PYTHONNOUSERSITE=1 PYTHONPATH="" /users/apiccine/work/miniconda3/envs/coffea2025/bin/python analysis/topeft_run2/run_analysis.py --options /tmp/options_scenario_test.yaml --pretend`
+- `PYTHONNOUSERSITE=1 PYTHONPATH="" /users/apiccine/work/miniconda3/envs/coffea2025/bin/python analysis/topeft_run2/run_analysis.py --options /tmp/options_scenario_test.yaml --scenario TOP_22_006 --pretend`
+
+## Follow-ups
+- Consider migrating older docs that still reference `--metadata` on `run_analysis.py` so they point readers at the scenario registry or YAML overrides.

--- a/reports/topeft-scenario-cli-wiring-20251201-0922.md
+++ b/reports/topeft-scenario-cli-wiring-20251201-0922.md
@@ -1,0 +1,15 @@
+# Scenario registry and CLI wiring
+
+## Summary
+- Added `analysis/topeft_run2/scenario_registry.py` to map `TOP_22_006`, `tau_analysis`, and `fwd_analysis` to their respective `analysis/metadata/metadata_*.yaml` files and expose helpers for the CLI.
+- Updated `run_analysis.py` to enforce one scenario per run, infer metadata paths via the registry when `--metadata` is omitted, and log the resolved scenario/metadata pairing alongside the new `--metadata` help text.
+- Ensured `ChannelMetadataHelper` can operate without a `channels.scenarios` block by falling back to all known groups in per-scenario YAMLs, keeping planner behaviour intact.
+- Kept the workflow loading logic pointed at `config.metadata_path`, so scenario-driven paths flow through untouched.
+
+## Testing
+- `PYTHONNOUSERSITE=1 PYTHONPATH="" /users/apiccine/work/miniconda3/envs/coffea2025/bin/python analysis/topeft_run2/run_analysis.py input_samples/cfgs/mc_signal_samples_NDSkim.cfg --outname UL17_SRs_quickstart_test --outpath histos/local_debug --nworkers 1 --summary-verbosity brief --executor iterative --skip-cr --do-systs --log-level INFO -c 1 -s 5 --pretend`
+  - Confirms scenario/metadata logging, registry resolution, and planning succeed (pretend mode used to avoid long-running execution in this environment).
+
+## Follow-ups
+- Support multi-scenario executions (or the future `all_analysis` meta-scenario) once a combined metadata file is ready and planners can merge groups.
+- Expand automated tests around the scenario registry and ChannelMetadataHelper fallback to guard against regressions.

--- a/reports/topeft-scenario-workflow-step3-20251201-1109.md
+++ b/reports/topeft-scenario-workflow-step3-20251201-1109.md
@@ -1,0 +1,15 @@
+# Step 3 – scenario metadata wiring
+
+## Summary
+- `run_workflow` now requires `RunConfig.metadata_path` to be set by the CLI/options resolver and loads only that YAML, removing the legacy fallback to `params/metadata.yml`.
+- `ChannelMetadataHelper` exposes `selected_group_names`, which returns the requested scenario groups when a legacy `channels.scenarios` block exists and otherwise yields every group defined in the per-scenario YAML.
+- `ChannelPlanner` retrieves the active groups via this helper and splits SR/CR purely by group names, keeping feature aggregation while staying agnostic to the legacy scenario map.
+
+## Technical details
+- The helper still stores scenario definitions when present for backwards compatibility; selecting a scenario validates referenced groups and preserves insertion order.
+- When metadata contains no `channels.scenarios`, the helper simply iterates the `channels.groups` keys, so per-scenario YAMLs automatically describe the active regions without additional wiring.
+- SR vs CR splitting still hinges on the `_CR` suffix; `ChannelPlanner` records feature flags from every registered group and feeds them into channel dictionaries unchanged.
+
+## Testing
+- `PYTHONNOUSERSITE=1 PYTHONPATH="" /users/apiccine/work/miniconda3/envs/coffea2025/bin/python analysis/topeft_run2/run_analysis.py input_samples/cfgs/mc_signal_samples_NDSkim.cfg --outname UL17_SRs_quickstart_test --outpath histos/local_debug --nworkers 1 --summary-verbosity brief --executor iterative --skip-cr --do-systs --log-level INFO -c 1 -s 5 --scenario TOP_22_006 --pretend`
+  - PASS: logs include the scenario/metadata pairing and the pretend run completes without missing-scenario errors.


### PR DESCRIPTION
## Summary

This PR completes the “step 3” wiring so that the Run-2 workflow actually consumes the new per-scenario metadata YAMLs introduced in step 1 and routed via the scenario registry in step 2.

Concretely:

- `run_workflow` now **requires** `RunConfig.metadata_path` (set by the CLI/options resolver) and loads only that YAML, removing the legacy fallback to `topeft/params/metadata.yml`.
- `ChannelMetadataHelper` has been extended with a `selected_group_names` helper that:
  - Uses `channels.scenarios` when present (legacy combined metadata file).
  - Falls back to “all groups in `channels.groups`” for per-scenario YAMLs that no longer declare scenarios.
- `ChannelPlanner` now retrieves active groups via `ChannelMetadataHelper.selected_group_names` and splits SR vs CR purely using the `_CR` suffix, while still unioning group `features` (e.g. `offz_split`, `requires_tau`, `requires_forward`) into its internal feature set.

The goal is to make the runtime planning fully scenario-driven without changing the physics content of the metadata itself.

## Implementation details

- **Workflow wiring**
  - `analysis/topeft_run2/workflow.py::run_workflow` now:
    - Reads `RunConfig.metadata_path` (populated by the scenario registry / `--options` profile).
    - Loads that YAML once into a `metadata` dict and uses it as the single source of truth.
    - Passes `metadata["channels"]` into `ChannelMetadataHelper`, and `metadata["variables"]` / `metadata["systematics"]` into the histogram/systematics planners as before.
  - The old implicit fallback to `topeft/params/metadata.yml` has been removed, so misconfigured runs now fail at the config layer instead of silently using the wrong metadata.

- **Channel metadata helper**
  - `topeft/modules/channel_metadata.py`:
    - Still builds `ChannelGroup` objects from `channels.groups` and (optionally) keeps track of legacy `channels.scenarios`.
    - Adds `selected_group_names(...)` to return the effective group list:
      - If a `channels.scenarios` block exists and a scenario is selected, it validates that all referenced groups are defined and returns them in order.
      - If no scenarios are present (the per-scenario YAML case), it simply returns all group names defined under `channels.groups`.
    - Existing helpers (`group`, `group_names`, etc.) remain available for backwards compatibility.

- **ChannelPlanner integration**
  - `analysis/topeft_run2/run_analysis_helpers.py` (or wherever `ChannelPlanner` lives) now:
    - Calls `channel_metadata.selected_group_names(...)` to obtain the groups for the current run.
    - Splits SR vs CR via the `_CR` suffix and applies `skip_sr` / `skip_cr` filters exactly as before.
    - Iterates over the registered groups to collect and union their feature flags, preserving behaviour for `offz_split`, `requires_tau`, `requires_forward`, etc.

No changes are made to the physics definitions of channels, variables, or systematics; only the wiring and selection logic are updated.

## Testing

- Pretend run for the baseline scenario:
  ```bash
  PYTHONNOUSERSITE=1 PYTHONPATH="" /users/apiccine/work/miniconda3/envs/coffea2025/bin/python \
      analysis/topeft_run2/run_analysis.py \
      input_samples/cfgs/mc_signal_samples_NDSkim.cfg \
      --outname UL17_SRs_quickstart_test \
      --outpath histos/local_debug \
      --nworkers 1 \
      --summary-verbosity brief \
      --executor iterative \
      --skip-cr \
      --do-systs \
      --log-level INFO \
      -c 1 \
      -s 5 \
      --scenario TOP_22_006 \
      --pretend
   ```

* ✅ Logs show the resolved scenario/metadata pairing (TOP_22_006 → `metadata_TOP_22_006.yaml`).
* ✅ Planning completes in pretend mode with no `KeyError("Scenario 'TOP_22_006' not found in metadata.")` or missing-metadata failures.