### PR TITLE
Datacard tooling: switch to scenario YAMLs and ChannelMetadataHelper

### DIFF
--- a/analysis/topeft_run2/datacards_post_processing.py
+++ b/analysis/topeft_run2/datacards_post_processing.py
@@ -2,8 +2,12 @@ import os
 import shutil
 import argparse
 import json
+import sys
+from typing import Iterable, List, Tuple
+
 import yaml
-from topeft.modules.paths import topeft_path
+
+from analysis.topeft_run2.scenario_registry import resolve_scenario_choice
 from topeft.modules.channel_metadata import ChannelMetadataHelper
 
 # This script does some basic checks of the cards and templates produced by the `make_cards.py` script.
@@ -17,6 +21,10 @@ IGNORE_LINES = [
     "ImportError: coffea.hist is deprecated",
     "warnings.warn(message, FutureWarning)",
 ]
+
+# Default scenario to mirror run_analysis.py
+DEFAULT_SCENARIO = "TOP_22_006"
+
 
 # Return list of lines in a file
 def read_file(filename):
@@ -76,34 +84,107 @@ def determine_histogram_suffix(region, jet_value, analysis_mode):
 
     return "lj0pt"
 
-# Check the output of the datacard maekr
+def _analysis_mode_for_group(group, scenario_name):
+    features = set(group.features)
+    if "offz_split" in features:
+        return "offZdivision"
+    if "requires_tau" in features or scenario_name == "tau_analysis":
+        return "tau"
+    if "requires_forward" in features or scenario_name == "fwd_analysis":
+        return "fwd"
+    return "top22006"
+
+
+def resolve_scenario_metadata(scenario_args: Iterable[str]) -> Tuple[str, str, ChannelMetadataHelper]:
+    """Return the scenario name, metadata path, and helper for ``scenario_args``."""
+
+    scenario_names = [name for name in (scenario_args or []) if name]
+    if not scenario_names:
+        scenario_names = [DEFAULT_SCENARIO]
+
+    if len(scenario_names) != 1:
+        raise ValueError(
+            "Datacard tooling currently supports one scenario per run. "
+            f"Requested scenarios: {', '.join(scenario_names)}"
+        )
+
+    scenario_name = scenario_names[0]
+    resolution = resolve_scenario_choice(scenario_name)
+
+    with open(resolution.metadata_path, "r", encoding="utf-8") as metadata_file:
+        metadata = yaml.safe_load(metadata_file) or {}
+
+    channels_metadata = metadata.get("channels")
+    if not channels_metadata:
+        raise ValueError(
+            f"Channel metadata is missing from the metadata YAML ({resolution.metadata_path})."
+        )
+
+    helper = ChannelMetadataHelper(channels_metadata)
+    return scenario_name, resolution.metadata_path, helper
+
+
+def collect_datacard_channels(
+    channel_helper: ChannelMetadataHelper, scenario_name: str
+) -> List[str]:
+    """Derive the list of datacard channel names for ``scenario_name``."""
+
+    channel_names: List[str] = []
+    group_names = channel_helper.selected_group_names([scenario_name])
+    for group_name in group_names:
+        if group_name.endswith("_CR"):
+            continue
+        group = channel_helper.group(group_name)
+        analysis_mode = _analysis_mode_for_group(group, scenario_name)
+        for category in group.categories():
+            jet_bins = [extract_number(item) for item in category.jet_bins]
+            jet_bins = [jet for jet in jet_bins if jet]
+            for region in category.region_definitions:
+                for jet in jet_bins:
+                    hist_suffix = determine_histogram_suffix(region, jet, analysis_mode)
+                    channel_names.append(f"{region.name}_{jet}j_{hist_suffix}")
+
+    seen = set()
+    ordered_unique: List[str] = []
+    for name in sorted(channel_names):
+        if name in seen:
+            continue
+        seen.add(name)
+        ordered_unique.append(name)
+    return ordered_unique
+
+
+# Check the output of the datacard maker
 def main():
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("datacards_path", help = "The path to the directory with the datacards in it.")
-    parser.add_argument("-c", "--check-condor-logs", action="store_true", help = "Check the contents of the condor err files.")
-    parser.add_argument("-s", "--set-up-top22006", action="store_true", help = "Copy the ptz and lj0pt cards used in TOP-22-006 into their own directory.")
-    parser.add_argument("-z", "--set-up-offZdivision", action="store_true", help = "Copy the ptz and lj0pt cards with 3l offZ division.")
-    parser.add_argument("-t", "--tau-flag", action="store_true", help = "Copy the ptz, lj0pt, and ptz_wtau cards for tau channels.")
-    parser.add_argument("-f", "--fwd-flag", action="store_true", help = "Copy the ptz, lj0pt, and lt cards for forward channels.")
+    parser.add_argument("datacards_path", help="The path to the directory with the datacards in it.")
+    parser.add_argument(
+        "-c",
+        "--check-condor-logs",
+        action="store_true",
+        help="Check the contents of the condor err files.",
+    )
+    parser.add_argument(
+        "--scenario",
+        action="append",
+        default=[],
+        help=(
+            "Scenario name to copy channels for (e.g. TOP_22_006, tau_analysis, fwd_analysis). "
+            "Only one scenario per run is currently supported."
+        ),
+    )
     args = parser.parse_args()
 
-    ###### Check that you run one only type of analysis ######
+    try:
+        scenario_name, metadata_path, channel_helper = resolve_scenario_metadata(args.scenario)
+    except ValueError as exc:
+        print(f"ERROR: {exc}")
+        sys.exit(1)
 
-    # collect your booleans
-    flags = [
-        args.set_up_top22006,
-        args.set_up_offZdivision,
-        args.tau_flag,
-        args.fwd_flag,
-    ]
-
-    # check exactly one is True
-    if sum(flags) != 1:
-        raise ValueError(
-            "Exactly one of --set_up_top22006, "
-            "--set_up_offZdivision, --tau_flag, --fwd_flag must be set."
-        )
+    CATSELECTED = collect_datacard_channels(channel_helper, scenario_name)
+    if not CATSELECTED:
+        raise ValueError(f"No signal-region channels found for scenario '{scenario_name}'.")
 
     ###### Print out general info ######
 
@@ -156,59 +237,12 @@ def main():
             print(f"\t\t* In {line[0]}: {line[1]}")
 
 
-    ####### Copy the TOP-22-006 relevant files to their own dir ######
-    metadata_path = topeft_path("params/metadata.yml")
-    with open(metadata_path, "r") as metadata_file:
-        metadata = yaml.safe_load(metadata_file)
-
-    channels_metadata = metadata.get("channels") if metadata else None
-    if not channels_metadata:
-        raise ValueError("Channel metadata missing from params/metadata.yml")
-
-    channel_helper = ChannelMetadataHelper(channels_metadata)
-
-    if args.set_up_top22006:
-        selected_groups = [channel_helper.group("TOP22_006_CH_LST_SR")]
-        analysis_mode = "top22006"
-    elif args.set_up_offZdivision:
-        selected_groups = [channel_helper.group("OFFZ_SPLIT_CH_LST_SR")]
-        analysis_mode = "offZdivision"
-    elif args.tau_flag:
-        selected_groups = [channel_helper.group("TAU_CH_LST_SR")]
-        analysis_mode = "tau"
-    elif args.fwd_flag:
-        selected_groups = [channel_helper.group("FWD_CH_LST_SR")]
-        analysis_mode = "fwd"
-
-    CATSELECTED = []
-    for group in selected_groups:
-        for category in group.categories():
-            jet_bins = [extract_number(item) for item in category.jet_bins]
-            if not jet_bins:
-                continue
-            for region in category.region_definitions:
-                for jet in jet_bins:
-                    if not jet:
-                        continue
-                    hist_suffix = determine_histogram_suffix(region, jet, analysis_mode)
-                    channelname = f"{region.name}_{jet}j_{hist_suffix}"
-                    CATSELECTED.append(channelname)
-
-    CATSELECTED = sorted(CATSELECTED)
-
-    # Grab the ptz-lj0pt cards we want for TOP-22-006, copy into a dir
+    # Grab the ptz/lj0pt/lt cards we want for the selected scenario
     n_txt = 0
     n_root = 0
     ptzlj0pt_path = os.path.join(args.datacards_path,"ptz-lj0pt_withSys")
     os.mkdir(ptzlj0pt_path)
-    if args.set_up_top22006:
-        print(f"\nCopying TOP-22-006 relevant files to {ptzlj0pt_path}...")
-    elif args.set_up_offZdivision:
-        print(f"\nCopying 3l-offZ-division relevant files to {ptzlj0pt_path}...")
-    elif args.tau_flag:
-        print(f"\nCopying tau analysis relevant files to {ptzlj0pt_path}...")
-    elif args.fwd_flag:
-        print(f"\nCopying forward jets analysis relevant files to {ptzlj0pt_path}...")
+    print(f"\nCopying {scenario_name} relevant files to {ptzlj0pt_path}...")
 
     for fname in datacard_files:
         file_name_strip_ext = os.path.splitext(fname)[0]
@@ -234,8 +268,8 @@ def main():
     # Check that we got the expected number and print what we learn
     print(f"\tNumber of text templates copied: {n_txt}")
     print(f"\tNumber of root templates copied: {n_root}")
-    if (args.set_up_top22006 and ((n_txt != 43) or (n_root != 43)))   or   (args.set_up_offZdivision and ((n_txt != 75) or (n_root != 75))):
-        raise Exception(f"Error, unexpected number of text ({n_txt}) or root ({n_root}) files copied")
     print("Done.\n")
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/analysis/topeft_run2/make_cards.py
+++ b/analysis/topeft_run2/make_cards.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 import json
 import shutil
@@ -8,6 +9,10 @@ import numpy as np
 import topcoffea
 
 from topeft.modules.datacard_tools import *
+from analysis.topeft_run2.datacards_post_processing import (
+    collect_datacard_channels,
+    resolve_scenario_metadata,
+)
 
 regex_match = topcoffea.modules.utils.regex_match
 clean_dir = topcoffea.modules.utils.clean_dir
@@ -181,6 +186,15 @@ def main():
     parser.add_argument("--use-AAC","-A",action="store_true",help="Include all EFT templates in datacards for AAC model")
     parser.add_argument("--wc-vals", default="",action="store", nargs="+", help="Specify the corresponding wc values to set for the wc list")
     parser.add_argument("--wc-scalings", default=[],action="extend",nargs="+",help="Specify a list of wc ordering for scalings.json")
+    parser.add_argument(
+        "--scenario",
+        action="append",
+        default=[],
+        help=(
+            "Scenario name to determine default channel list (e.g. TOP_22_006, "
+            "tau_analysis, fwd_analysis). Only one scenario per run is supported."
+        ),
+    )
 
     args = parser.parse_args()
     pkl_file   = args.pkl_file
@@ -209,6 +223,23 @@ def main():
 
     if isinstance(wcs,str):
         wcs = wcs.split(",")
+
+    try:
+        scenario_name, metadata_path, channel_helper = resolve_scenario_metadata(args.scenario)
+    except ValueError as exc:
+        print(f"ERROR: {exc}")
+        sys.exit(1)
+
+    scenario_channels = collect_datacard_channels(channel_helper, scenario_name)
+    if not ch_lst:
+        ch_lst = scenario_channels
+        print(
+            f"Using all {len(ch_lst)} channels resolved from scenario '{scenario_name}'"
+        )
+    else:
+        print(
+            f"Using user-specified channel selection ({len(ch_lst)} entries) for scenario '{scenario_name}'"
+        )
 
     kwargs = {
         "wcs": wcs,
@@ -309,4 +340,6 @@ def main():
     print(f"Total Time: {dt:.2f} s")
     print("Finished!")
 
-main()
+
+if __name__ == "__main__":
+    main()

--- a/analysis/topeft_run2/make_cards.py
+++ b/analysis/topeft_run2/make_cards.py
@@ -230,6 +230,8 @@ def main():
         print(f"ERROR: {exc}")
         sys.exit(1)
 
+    # Channel naming is centralized via collect_datacard_channels so both
+    # datacard scripts operate on identical identifiers.
     scenario_channels = collect_datacard_channels(channel_helper, scenario_name)
     if not ch_lst:
         ch_lst = scenario_channels


### PR DESCRIPTION
### Summary of changes

* **Scenario-driven channel selection in `datacards_post_processing.py`**

  * Introduces `DEFAULT_SCENARIO = "TOP_22_006"` to mirror `run_analysis.py`.
  * Adds `resolve_scenario_metadata(...)`, which:

    * Resolves a single scenario name (defaulting to `TOP_22_006`) via `resolve_scenario_choice` from `analysis/topeft_run2/scenario_registry.py`.
    * Loads the corresponding metadata YAML and constructs a `ChannelMetadataHelper` from `metadata["channels"]`.
  * Adds `collect_datacard_channels(...)`, which:

    * Uses `ChannelMetadataHelper.selected_group_names([scenario_name])` to retrieve the active groups.
    * Skips groups whose name ends with `_CR`.
    * Iterates categories, `jet_bins`, and `region_definitions` to rebuild channel names as
      `"{region.name}_{N}j_{suffix}"`, with `suffix` from the existing `determine_histogram_suffix(...)` logic.
    * Deduplicates and returns a sorted list of channel names.

* **Scenario CLI for datacard post-processing**

  * Replaces the old mode flags:

    * `--set-up-top22006`
    * `--set-up-offZdivision`
    * `--tau-flag`
    * `--fwd-flag`
  * With a single repeatable `--scenario` option:

    * `--scenario TOP_22_006`, `--scenario tau_analysis`, `--scenario fwd_analysis`, …
    * For now, the script enforces **exactly one** scenario per run and errors otherwise.
  * On startup, `datacards_post_processing.py` resolves the scenario and constructs `CATSELECTED` from metadata instead of hard-coded group names.
  * The “copy relevant files” step now reports:

    * `Copying <scenario_name> relevant files to ...`
      rather than branching on individual flags.

* **Analysis mode inference from group features**

  * Introduces `_analysis_mode_for_group(group, scenario_name)` which maps each group to an `analysis_mode` used by `determine_histogram_suffix(...)`:

    * `offZdivision` if the group has the `offz_split` feature.
    * `tau` if the group has `requires_tau` **or** the scenario is `tau_analysis`.
    * `fwd` if the group has `requires_forward` **or** the scenario is `fwd_analysis`.
    * `top22006` otherwise.
  * This keeps the existing suffix behaviour (`_ptz`, `_lj0pt`, `_lt`, `_ptz_wtau`, …) while moving the decision to metadata features + scenario mapping.

* **Scenario-aware channel defaults in `make_cards.py`**

  * Imports and reuses `resolve_scenario_metadata(...)` and `collect_datacard_channels(...)` from `datacards_post_processing.py`.
  * Adds a `--scenario` CLI option with the same semantics (one scenario per run, defaulting to `TOP_22_006`).
  * If `--ch-lsts` is **not** provided:

    * Automatically populates `ch_lst` with all channels derived from the chosen scenario’s metadata.
    * Logs:
      `Using all <N> channels resolved from scenario '<name>'`.
  * If `--ch-lsts` is provided:

    * Preserves the user-specified channel list.
    * Logs:
      `Using user-specified channel selection (<N> entries) for scenario '<name>'`.

* **Miscellaneous**

  * Adds `if __name__ == "__main__": main()` guards to both scripts so they can be safely imported as helpers.
  * Drops the old per-mode file-count assertion in `datacards_post_processing.py` (the previous checks were tied to the specific TOP-22-006 / offZ CLI flags; the new scenario-based behaviour may include a different mix of groups and counts).
  * `topeft/channels/ch_lst.json` is no longer referenced by these scripts; it can now be considered legacy and removed once we’re confident there are no external users.

### Behavioural notes / review comments

* **Channel naming and suffixes**
  The channel names are still built from `{region.name}`, jet bin (via `extract_number`), and `determine_histogram_suffix(...)`; the suffix logic itself is unchanged. The main difference is that the list of categories now comes from scenario YAMLs through `ChannelMetadataHelper` instead of `ch_lst.json`.

* **Scenario → groups mapping**
  `collect_datacard_channels` uses `ChannelMetadataHelper.selected_group_names([scenario_name])`, which:

  * For legacy metadata with `channels.scenarios`, respects the explicit scenario → group mapping.
  * For per-scenario YAMLs (no `channels.scenarios`), simply returns **all** groups defined in the file, with CR groups filtered out by name (`*_CR`).
    It’s worth double-checking that for each scenario (`TOP_22_006`, `tau_analysis`, `fwd_analysis`) this set of SR groups matches the intended datacard coverage.

* **Sanity checks**
  The previous hard-coded counts for TOP-22-006 / offZ files have been removed. If we still want coverage checks, we could reintroduce them in a scenario-aware way (e.g. checking expected `(n_txt, n_root)` per scenario once the new metadata-driven channel lists are validated).

You can tweak the “Behavioural notes” section down if you prefer a shorter PR description, but this should capture what changed and what’s worth paying attention to during review.
