### PR TITLE
refresh full_run.sh and fix run_analysis executor/chunk CLI

### DIFF
--- a/analysis/topeft_run2/README.md
+++ b/analysis/topeft_run2/README.md
@@ -153,6 +153,23 @@ This directory contains scripts for the Full Run 2 EFT analysis. This README doc
           ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \\
           --outdir histos/local_debug --tag quickstart``
 
+    - UL18 iterative dry-run smoke test relying on the default Run-2 SR profile::
+
+          analysis/topeft_run2/full_run.sh --sr -y UL18 \
+              --executor iterative \
+              --outdir histos/debug_iter_UL18 \
+              --chunksize 10 --nchunks 1 --dry-run
+
+      Prints the resolved command without running Python, making it easy to confirm the iterative executor wiring.
+
+    - Run-2 SR production-style launch using the canonical futures defaults (auto-injected Run-2 options profile and `TOP_22_006` scenario)::
+
+          analysis/topeft_run2/full_run.sh --sr -y run2 \
+              --executor futures \
+              --outdir histos/run2_TOP22_006
+
+      Leaves `--scenario/--options` unset so the wrapper auto-selects `analysis/topeft_run2/configs/fullR2_run.yml:sr` and the canonical Run-2 scenario.
+
     - Add ``--dry-run`` to print the resolved command without launching Python
       (handy for CI smoke tests and argument validation).
 

--- a/analysis/topeft_run2/full_run.sh
+++ b/analysis/topeft_run2/full_run.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# Unified wrapper for launching run_analysis.py with either TaskVine or the
-# Coffea futures executor.
+# Unified wrapper for launching run_analysis.py with TaskVine, Coffea futures,
+# or the local iterative executor now that Run-2 scenarios are driven by
+# run2_scenarios.yaml.
 #
-# Expectations before running:
+# Expectations before running (same as before):
 #   1. Activate the shared Conda environment shipped with this repository
 #      (name: coffea2025) or another compatible setup so the topeft and
 #      topcoffea editable installs are available. This script assumes the
@@ -24,31 +25,44 @@ set -euo pipefail
 PrintUsage() {
   cat <<'USAGE'
 Usage: full_run.sh [-y YEAR [YEAR ...]] [-t TAG] [--cr | --sr] \
-                   [--executor {taskvine,futures}] [--outdir PATH] [--manager NAME] \
-                   [--samples PATH [PATH ...]] [--log-level LEVEL] [--debug-logging] [--dry-run] \
-                   [extra run_analysis args]
+                   [--executor {taskvine,futures,iterative}] [--outdir PATH] [--manager NAME] \
+                   [--samples PATH [PATH ...]] [--scenario NAME] [--log-level LEVEL] \
+                   [--debug-logging] [--dry-run] [extra run_analysis args]
 
 Examples:
-  full_run.sh --cr -y run3 -t dev_validation
+  # Control-region TaskVine run over Run-3 bundles using defaults defined in the
+  # Run-3 configs (user-supplied --options forwarded via extra args).
+  full_run.sh --cr -y run3 -t dev_validation --executor taskvine \
+      --outdir histos/run3_validation --dry-run
+
+  # Signal-region futures launch for UL17 using explicit sample JSONs.
   full_run.sh --sr -y UL17 --executor futures --outdir histos/local_debug \
       --samples ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \
-      --chunksize 4000 --dry-run
+      --scenario TOP_22_006 --chunksize 4000 --dry-run
+
+  # Run-2 superset (all_analysis) using futures and the default Run-2 profile.
+  full_run.sh --sr -y run2 --executor futures --outdir histos/run2_all \
+      --scenario all_analysis --dry-run
 
 Notes:
   * YEARS accept explicit values (2022, 2022EE, UL17, etc.) or bundles
     (run2 -> UL16 UL16APV UL17 UL18, run3 -> 2022 2022EE).  Unknown entries
     are rejected so mis-typed eras fail fast.
+  * Run-2 invocations without an explicit --scenario will prefer the default
+    run_analysis options file (analysis/topeft_run2/configs/fullR2_run.yml) and
+    select the SR/CR profile automatically.  Provide --scenario or --options
+    explicitly to override this behaviour.
   * Required input cfg/json files live under input_samples/cfgs/ and are
-    selected automatically per year.  Use --samples when you want to override
-    the list (for example pointing at the UL17 quickstart JSON).  Add extra CLI
-    arguments (for example --options configs/fullR2_run.yml:sr) after the
-    recognized flags to pass through additional run_analysis toggles.
+    selected automatically per year when --samples is not specified.  Supply
+    --samples to point at bespoke JSONs.  Append additional run_analysis flags
+    (for example --options configs/fullR2_run.yml:sr or --split-lep-flavor)
+    after the recognized wrapper arguments.
   * The default output name is <YEARS>_(CRs|SRs)_<TAG>, saved to the specified
     output directory with the 5-tuple histogram schema used throughout this
     branch.  Use --dry-run to print the resolved command without launching
-    Python (helpful for smoke tests or CI guards).  Pass --debug-logging to forward
-    the instrumentation flag (always DEBUG) or --log-level LEVEL to tweak the Python
-    logging verbosity seen in run_analysis.py.
+    Python.  Pass --debug-logging to forward the instrumentation flag (always
+    DEBUG) or --log-level LEVEL to tweak the Python logging verbosity seen in
+    run_analysis.py.
 USAGE
 }
 
@@ -82,8 +96,11 @@ main() {
   local -a expanded_years=()
   local -a resolved_years=()
   local -a user_samples=()
+  local -a scenario_args=()
+  local scenario_specified=false
   local user_chunk_override=false
   local user_env_override=false
+  local user_options_override=false
   local outdir="histos"
   local manager_name="${USER:-coffea}-taskvine-coffea"
   local tag=""
@@ -95,6 +112,7 @@ main() {
   local dry_run=false
   local debug_logging=false
   local log_level=""
+  local auto_options_spec=""
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -178,6 +196,10 @@ main() {
         executor_choice="futures"
         shift
         ;;
+      --iterative)
+        executor_choice="iterative"
+        shift
+        ;;
       --cr)
         flag_cr=true
         shift
@@ -222,6 +244,40 @@ main() {
         fi
         shift
         ;;
+      --options)
+        user_options_override=true
+        if [[ $# -lt 2 ]]; then
+          echo "Error: --options expects a value" >&2
+          return 1
+        fi
+        extra_args+=("$1" "$2")
+        shift 2
+        ;;
+      --options=*)
+        user_options_override=true
+        extra_args+=("$1")
+        shift
+        ;;
+      --scenario)
+        scenario_specified=true
+        shift
+        if [[ $# -eq 0 || "$1" == -* ]]; then
+          echo "Error: --scenario expects a name" >&2
+          return 1
+        fi
+        scenario_args+=("$1")
+        shift
+        ;;
+      --scenario=*)
+        scenario_specified=true
+        local scenario_value="${1#*=}"
+        if [[ -z "$scenario_value" ]]; then
+          echo "Error: --scenario expects a name" >&2
+          return 1
+        fi
+        scenario_args+=("$scenario_value")
+        shift
+        ;;
       --environment-file|--environment-file=*)
         user_env_override=true
         extra_args+=("$1")
@@ -243,6 +299,11 @@ main() {
     echo "Error: specify exactly one of --cr or --sr" >&2
     echo
     PrintUsage
+    return 1
+  fi
+
+  if [[ "$user_options_override" == true && "$scenario_specified" == true ]]; then
+    echo "Error: --scenario cannot be combined with --options; encode the scenario inside the options profile instead." >&2
     return 1
   fi
 
@@ -297,8 +358,8 @@ main() {
     executor="taskvine"
   fi
 
-  if [[ "$executor" != "taskvine" && "$executor" != "futures" ]]; then
-    echo "Error: executor must be one of taskvine or futures (got '$executor')" >&2
+  if [[ "$executor" != "taskvine" && "$executor" != "futures" && "$executor" != "iterative" ]]; then
+    echo "Error: executor must be one of taskvine, futures, or iterative (got '$executor')" >&2
     return 1
   fi
 
@@ -366,6 +427,54 @@ main() {
     "$cfgs_path/2022_mc_background_samples.cfg"
     "$cfgs_path/2022EE_data_samples.cfg"
   )
+
+  local has_run2=false
+  local has_run3=false
+  for year in "${resolved_years[@]}"; do
+    local lower_year=${year,,}
+    if [[ -n "${run2_year_map[$lower_year]:-}" ]]; then
+      has_run2=true
+    elif [[ "$year" == "2022" || "$year" == "2022EE" ]]; then
+      has_run3=true
+    fi
+  done
+
+  if [[ "$has_run2" == true && "$has_run3" == true ]]; then
+    echo "Error: mixing Run-2 and Run-3 eras in a single invocation is not supported." >&2
+    return 1
+  fi
+
+  if [[ "$scenario_specified" == false ]]; then
+    if [[ "$has_run2" == true ]]; then
+      scenario_args=("TOP_22_006")
+    elif [[ "$has_run3" == true ]]; then
+      scenario_args=("fwd_analysis")
+    fi
+  fi
+
+  if [[ ${#scenario_args[@]} -gt 1 ]]; then
+    echo "Error: only one --scenario can be specified per run (requested: ${scenario_args[*]})." >&2
+    return 1
+  fi
+
+  local scenario_name=""
+  if [[ ${#scenario_args[@]} -eq 1 ]]; then
+    scenario_name="${scenario_args[0]}"
+  fi
+
+  if [[ "$scenario_specified" == false && "$user_options_override" == false && \
+        "$has_run2" == true && "$has_run3" == false ]]; then
+    local run2_options_path="$script_dir/configs/fullR2_run.yml"
+    if [[ -f "$run2_options_path" ]]; then
+      local profile_name
+      if [[ "$flag_cr" == true ]]; then
+        profile_name="cr"
+      else
+        profile_name="sr"
+      fi
+      auto_options_spec="$run2_options_path:$profile_name"
+    fi
+  fi
 
   declare -A seen_cfgs=()
   add_cfg() {
@@ -453,6 +562,11 @@ main() {
   local cfgs
   cfgs=$(IFS=,; echo "${input_specs[*]}")
 
+  local options_in_effect=false
+  if [[ "$user_options_override" == true || -n "$auto_options_spec" ]]; then
+    options_in_effect=true
+  fi
+
   echo "Resolved years: ${resolved_years[*]}"
   echo "Resolved cfg inputs: $cfgs"
   echo "Executor: $executor"
@@ -466,13 +580,29 @@ main() {
   else
     echo "Futures prefetch: $futures_prefetch | retries: $futures_retries"
   fi
+  if [[ "$options_in_effect" == true ]]; then
+    if [[ -n "$auto_options_spec" ]]; then
+      echo "Options profile: $auto_options_spec (auto-selected)"
+    else
+      echo "Options profile: supplied via CLI"
+    fi
+    echo "Scenario: controlled by options profile"
+  elif [[ -n "$scenario_name" ]]; then
+    echo "Scenario: $scenario_name"
+  fi
 
   if [[ -z "$workers" ]]; then
-    if [[ "$executor" == "taskvine" ]]; then
-      workers=8
-    else
-      workers=4
-    fi
+    case "$executor" in
+      taskvine)
+        workers=8
+        ;;
+      futures)
+        workers=4
+        ;;
+      iterative)
+        workers=1
+        ;;
+    esac
   fi
 
   local -a options=(
@@ -491,7 +621,7 @@ main() {
     if [[ "$user_env_override" == false && -n "$env_tarball" ]]; then
       options+=(--environment-file "$env_tarball")
     fi
-  else
+  elif [[ "$executor" == "futures" ]]; then
     options+=(--futures-prefetch "$futures_prefetch")
     options+=(--futures-retries "$futures_retries")
     options+=(--futures-retry-wait "$futures_retry_wait")
@@ -512,6 +642,12 @@ main() {
 
   local -a run_cmd=(python run_analysis.py "$cfgs")
   run_cmd+=("${options[@]}")
+  if [[ -n "$auto_options_spec" ]]; then
+    run_cmd+=(--options "$auto_options_spec")
+  fi
+  if [[ "$options_in_effect" == false && -n "$scenario_name" ]]; then
+    run_cmd+=(--scenario "$scenario_name")
+  fi
   run_cmd+=("${extra_args[@]}")
 
   printf "\nResolved command:\n%s\n\n" "${run_cmd[*]}"

--- a/analysis/topeft_run2/full_run.sh
+++ b/analysis/topeft_run2/full_run.sh
@@ -307,6 +307,17 @@ main() {
     return 1
   fi
 
+  if [[ "$user_options_override" == false && ${#extra_args[@]} -gt 0 ]]; then
+    for passthrough_arg in "${extra_args[@]}"; do
+      case "$passthrough_arg" in
+        --options|--options=*)
+          echo "Error: '--options' supplied after '--'. Pass --options before the passthrough separator so the wrapper can enforce the scenario/options guard (or drop --scenario)." >&2
+          return 1
+          ;;
+      esac
+    done
+  fi
+
   if [[ ${#years[@]} -eq 0 ]]; then
     echo "Warning: YEAR not provided, using default YEAR=$default_year"
     years=("$default_year")
@@ -445,6 +456,8 @@ main() {
   fi
 
   if [[ "$scenario_specified" == false ]]; then
+    # Default scenarios mirror the canonical Run-2/Run-3 bundles wired through
+    # analysis/topeft_run2/scenario_registry.py.
     if [[ "$has_run2" == true ]]; then
       scenario_args=("TOP_22_006")
     elif [[ "$has_run3" == true ]]; then


### PR DESCRIPTION
> ### Summary
>
> This PR finishes the Step 5C “polish” on the Run-2 workflow by:
>
> * refreshing `analysis/topeft_run2/full_run.sh` to be scenario-aware, support the `iterative` executor, and auto-wire the canonical Run-2 options profile, and
> * fixing `analysis/topeft_run2/run_analysis.py` so CLI executor / workload flags are correctly honoured even when using an options YAML profile.
>
> No changes to physics content or channel definitions; this is purely tooling/UX.

---

> ### Changes in `analysis/topeft_run2/full_run.sh`
>
> * **Executors**
>
>   * Extended the wrapper to support three backends:
>
>     * `--executor taskvine`
>     * `--executor futures`
>     * `--executor iterative` (for small local tests).
>   * Default worker counts are now tuned per executor:
>
>     * TaskVine → 8 workers
>     * futures → 4 workers
>     * iterative → 1 worker
> * **Scenario handling**
>
>   * Added explicit `--scenario NAME` support at the wrapper level.
>   * When **no** `--scenario` is provided:
>
>     * Run-2 eras (UL16/APV/17/18 / `run2`) default to `TOP_22_006`.
>     * Run-3 eras (2022/2022EE / `run3`) default to `fwd_analysis`.
>   * Mixing Run-2 and Run-3 eras in one call now fails fast with a clear error.
>   * `--scenario` and `--options` are treated as mutually exclusive at the wrapper level, mirroring the `run_analysis.py` constraint (you’re expected to encode the scenario inside the options profile when using `--options`).
> * **Run-2 options auto-wiring**
>
>   * For **pure Run-2** launches, when **both** of the following are true:
>
>     * no explicit `--scenario` and
>     * no explicit `--options`,
>
>     the wrapper will auto-inject:
>
>     ```bash
>     --options analysis/topeft_run2/configs/fullR2_run.yml:(sr|cr)
>     ```
>
>     choosing `sr` or `cr` based on the `--sr` / `--cr` flag.
>   * If an options profile is auto-selected, the wrapper logs:
>
>     * which profile is being used (and that it was auto-selected), and
>     * that the scenario is controlled by the profile.
> * **Samples, years, and logging**
>
>   * The existing year bundle logic is unchanged:
>
>     * `run2 → UL16 UL16APV UL17 UL18`
>     * `run3 → 2022 2022EE`
>   * `--samples` still overrides the automatic cfg list; when omitted, the wrapper selects the standard cfgs under `input_samples/cfgs/` per year and SR/CR.
>   * The wrapper now prints:
>
>     * resolved years and cfg inputs,
>     * executor and (if applicable) TaskVine manager / futures tuning,
>     * whether an options profile is in effect, and
>     * the resolved scenario when it’s not profile-driven.
>   * The final `python run_analysis.py ...` command is printed before execution, and `--dry-run` still exits after printing it.

---

> ### Changes in `analysis/topeft_run2/run_analysis.py`
>
> * **Executor behaviour fixed with options profiles**
>
>   * Previously, when `--options` was used, the `RunConfigBuilder` would take the executor from the YAML profile and the CLI `--executor` flag was effectively ignored.
>   * The entrypoint now:
>
>     * inspects `argv` to detect whether `--executor`/`-x` was explicitly supplied,
>     * computes a parser-level default executor from the `argparse` defaults (currently `taskvine`), and
>     * after config building + scenario defaults, re-applies the CLI executor choice if the user actually passed one.
>   * This guarantees:
>
>     * **If the user sets `--executor`, the CLI wins.**
>     * **If the user does not, the options profile (or parser default) wins.**
> * **`--chunksize` / `--nchunks` no longer “silent”**
>
>   * Added `type=int` for:
>
>     ```python
>     --chunksize / -s
>     --nchunks  / -c
>     ```
>   * Similar to the executor fix, the entrypoint now:
>
>     * detects whether `--chunksize` and/or `--nchunks` were explicitly passed on the CLI, and
>     * after the options profile is merged, re-applies those CLI values onto the final `RunConfig` when present.
>   * This restores the expected behaviour that:
>
>     * `run_analysis.py ... --chunksize N` actually controls the per-chunk event count, and
>     * `run_analysis.py ... --nchunks M` actually caps the number of chunks processed,
>       even when running through a YAML profile with its own defaults.
> * **Executor/workload logging**
>
>   * Instead of only logging the executor, the script now logs:
>
>     ```text
>     Using executor: <executor> | chunksize=<value> | maxchunks=<value-or-unbounded>
>     ```
>   * This makes it much easier to verify at a glance that:
>
>     * the requested backend is being used (`iterative`, `futures`, or `taskvine`), and
>     * the effective chunking configuration matches what you passed on the CLI.
> * **Other CLI flags**
>
>   * As part of this change, the rest of the workload/executor flags were audited:
>
>     * `--nworkers`, `--futures-prefetch`, `--futures-retries`, `--futures-retry-wait`, `--summary-verbosity`, `--skip-cr/--skip-sr`, `--log-tasks`, etc.
>   * All of these already map cleanly to fields on `RunConfig` and are consumed in `analysis/topeft_run2/workflow.py`, so no extra patching was needed.

---

> ### Validation
>
> * Syntax checks:
>
>   ```bash
>   PYTHONNOUSERSITE=1 PYTHONPATH="" $PYTHON_ENV -m compileall \
>       analysis/topeft_run2 \
>       topeft/modules \
>       scratch
>   ```
> * Run-2 validators (unchanged SR counts):
>
>   ```bash
>   PYTHONNOUSERSITE=1 PYTHONPATH="" $PYTHON_ENV scratch/validate_run2_scenarios_step5.py
>   PYTHONNOUSERSITE=1 PYTHONPATH="" $PYTHON_ENV scratch/validate_run2_datacard_channels_step5.py
>   PYTHONNOUSERSITE=1 PYTHONPATH="" $PYTHON_ENV scratch/validate_run2_groups_step5.py
>   ```
>
>   All three confirm the canonical SR-channel counts:
>
>   * `TOP_22_006 = 43`
>   * `tau_analysis = 68`
>   * `offz_tau_analysis = 48`
>   * `offz_fwd_analysis = 121`
>   * `all_analysis = 148`
> * Manual `run_analysis.py` smoke tests:
>
>   * Direct invocations with each executor:
>
>     * `--executor iterative`
>     * `--executor futures`
>     * `--executor taskvine`
>   * All now log the requested executor and the requested `chunksize`/`nchunks` values before failing later on environment/metadata availability in this sandbox (as expected).
> * `full_run.sh` smoke tests:
>
>   * `--dry-run` combinations for:
>
>     * Run-2 / Run-3, SR / CR
>     * `--executor iterative`, `--executor futures`, `--executor taskvine`
>     * with/without `--scenario` and with/without `--samples`
>   * Each case prints a consistent Python command with the expected executor, options profile (when applicable), and scenario.

---

> ### Notes
>
> * No changes to:
>
>   * physics selections,
>   * channel/group definitions,
>   * datacard content, or
>   * topcoffea internals.
> * This is purely a tooling/UX pass to make CLI behaviour match user expectations, especially around executors and chunking when driving the analysis via YAML options profiles and the `full_run.sh` helper.