### PR TITLE
docs: refresh run2 workflow scenarios

### DIFF
--- a/analysis/topeft_run2/README.md
+++ b/analysis/topeft_run2/README.md
@@ -141,7 +141,12 @@ This directory contains scripts for the Full Run 2 EFT analysis. This README doc
   ``fullR3_run.sh`` behavior from the Run 3 development branch.  The script
   expands ``run2``/``run3`` bundles, resolves the appropriate cfg/json inputs,
   and builds the ``run_analysis.py`` invocation for both distributed and
-  single-node runs.
+  single-node runs. When you request Run-2 eras without passing `--scenario` or
+  `--options`, the wrapper auto-selects `analysis/topeft_run2/configs/fullR2_run.yml`
+  (picking the SR/CR profile based on `--sr/--cr`) and sets the scenario to
+  `TOP_22_006`. Run-3 invocations default to the `fwd_analysis` scenario and
+  Run-3 cfg bundles. Explicit `--scenario` or `--options` arguments override
+  these defaults.
 
     - TaskVine example:
 
@@ -160,7 +165,7 @@ This directory contains scripts for the Full Run 2 EFT analysis. This README doc
               --outdir histos/debug_iter_UL18 \
               --chunksize 10 --nchunks 1 --dry-run
 
-      Prints the resolved command without running Python, making it easy to confirm the iterative executor wiring.
+      Prints the resolved command without running Python, making it easy to confirm the iterative executor wiring and chunk overrides.
 
     - Run-2 SR production-style launch using the canonical futures defaults (auto-injected Run-2 options profile and `TOP_22_006` scenario)::
 
@@ -170,8 +175,26 @@ This directory contains scripts for the Full Run 2 EFT analysis. This README doc
 
       Leaves `--scenario/--options` unset so the wrapper auto-selects `analysis/topeft_run2/configs/fullR2_run.yml:sr` and the canonical Run-2 scenario.
 
+    - Run-3 TaskVine control-region run (defaults to the `fwd_analysis` scenario and Run-3 cfg bundles)::
+
+          analysis/topeft_run2/full_run.sh --cr -y run3 \
+              --executor taskvine \
+              --outdir histos/run3_fwd_validation \
+              --tag dev_validation
+
+      Requests the Run-3 year bundle (2022+2022EE), keeps the default TaskVine executor, and prints the resolved `fwd_analysis` scenario plus manager/environment settings.
+
     - Add ``--dry-run`` to print the resolved command without launching Python
       (handy for CI smoke tests and argument validation).
+
+    Guardrails enforced by the wrapper:
+
+    - Run-2 and Run-3 eras cannot be mixed in a single invocation.
+    - `--scenario` and `--options` are mutually exclusive at the wrapper level,
+      mirroring the CLI. Embed the scenario in the YAML profile when using
+      `--options`.
+    - `--options` supplied after the `--` passthrough separator is rejected with
+      a clear error so that the guard above cannot be bypassed accidentally.
 
 * `run_sow.py` for `sow_processor.py`:
     - This script runs over the provided json files and calculates the properer sum of weights

--- a/docs/run2_scenarios.md
+++ b/docs/run2_scenarios.md
@@ -99,7 +99,9 @@ for convenience.
    ```
 
    The scripts compare the YAML source against the generated channel lists and
-   will raise if group definitions conflict.
+   will raise if group definitions conflict. For the canonical Run‑2 scenarios,
+   the validators also echo the SR-channel counts (43 / 68 / 48 / 121 / 148),
+   providing a quick sanity check that your metadata has not drifted.
 
 By following these steps the CLI, quickstart helpers, and `full_run.sh` wrapper
 will all recognize the scenario automatically, keeping the Run‑2 documentation

--- a/docs/run2_scenarios.md
+++ b/docs/run2_scenarios.md
@@ -1,161 +1,106 @@
-# Run 2 metadata scenarios guide
+# Run‑2 scenarios, groups, and workflows
 
-This guide expands on the quickstart documentation by showing how to run the
-Run 2 workflows with the three metadata scenarios distributed in
-`topeft/params/metadata.yml`:
+Run‑2 executions are driven entirely by metadata rather than ad‑hoc JSON lists.
+Two layers work together:
 
-- `TOP_22_006`
-- `tau_analysis`
-- `fwd_analysis`
+* **Groups** – Logical bundles of channels defined in
+  `analysis/metadata/metadata_run2_groups.yaml`. Each group enumerates the
+  regions, applications, and histogram selections that the processor should
+  evaluate. The `ChannelMetadataHelper` from `topeft.modules.channel_metadata`
+  reads this file and exposes the groups by name.
+* **Scenarios** – Named combinations of one or more groups. The mapping lives in
+  `analysis/metadata/run2_scenarios.yaml` and is loaded by
+  `analysis/topeft_run2/run2_scenarios.py`. The CLI and quickstart helpers look
+  up scenarios through `analysis/topeft_run2/scenario_registry.py`, which
+  returns the correct metadata bundle (for example `metadata_TOP_22_006.yaml`)
+  and tracks the names exposed to `--scenario` and YAML profiles.
 
-Each section starts from a clean checkout of the repository with the editable
-``topeft`` and ``topcoffea`` packages installed (see the
-[TOP-22-006 quickstart](quickstart_top22_006.md#prerequisites) for the
-recommended environment setup).  The commands shown below assume that you are in
-``analysis/topeft_run2`` unless otherwise noted.
+When `run_analysis.py` or `full_run.sh` receives a `--scenario` value, the
+workflow:
 
-The CLI always resolves `--scenario` via
-[`analysis/topeft_run2/scenario_registry.py`](../analysis/topeft_run2/scenario_registry.py),
-so passing a friendly name (or relying on the default `TOP_22_006`) automatically
-selects the corresponding metadata YAML.  A minimal pretend run looks like:
+1. Resolves the scenario through `scenario_registry.py` to find the metadata
+   document.
+2. Loads the groups referenced in `run2_scenarios.yaml`.
+3. Passes the fully expanded channel list to `ChannelMetadataHelper`, which
+   feeds `ChannelPlanner` and `HistogramPlanner`.
 
-```bash
-python run_analysis.py \
-    ../../input_samples/cfgs/mc_signal_samples_NDSkim.cfg \
-    --scenario TOP_22_006 \
-    --pretend --executor iterative --nworkers 1
-```
+Legacy JSON manifests (such as `scratch/ch_lst_step5.json`) are now used only by
+the validation scripts; production code is 100% YAML‑driven.
 
-!!! warning
-    When ``--options`` is supplied the YAML profile becomes the source of truth
-    for scenarios and metadata paths.  Do not repeat ``--scenario`` on the CLI in
-    that case—define the scenario list directly inside the profile instead.
+## Canonical Run‑2 scenarios
 
-For details on how the scenarios map onto metadata-driven channel and histogram
-definitions, refer back to the [metadata configuration guide](run_analysis_configuration.md#metadata-configuration).
+| Scenario | Description | Typical uses |
+| --- | --- | --- |
+| `TOP_22_006` | Baseline TOP‑22‑006 reinterpretation groups plus shared control regions. | Default Run‑2 SR/CR campaigns, QA launches, and `fullR2_run.yml` presets. |
+| `tau_analysis` | Adds tau‑enriched SRs/CRs on top of the core control suite. | Tau reinterpretation studies and datacard cross‑checks. |
+| `offz_tau_analysis` | Keeps the off‑Z split used during tau studies without activating the forward categories. | Targeted comparisons against the tau analysis without the full scenario stack. |
+| `offz_fwd_analysis` | Preserves the forward/off‑Z split required for forward‑jet studies. | Forward‑jet reinterpretations and closure tests. |
+| `all_analysis` | Union of the canonical Run‑2 groups (core, tau, forward, off‑Z). | Comprehensive bookkeeping runs or datacard production that needs every category at once. |
 
-!!! important
-    Once ``--options`` is supplied the YAML file becomes authoritative.  Append
-    ``:profile`` to select a preset (for example ``configs/fullR2_run.yml:sr``)
-    and edit the YAML directly to enable additional scenarios.  Drop
-    ``--options`` entirely if you need to experiment with ad-hoc CLI flags.
-
-!!! note
-    The ``--channel-feature`` flag has been retired.  Use the scenarios below—on
-    their own or in combination—to activate the tau, forward, and off-Z
-    variations.
-
-## Running individual scenarios
-
-### TOP_22_006 baseline
-
-The TOP-22-006 scenario powers both the Run 2 quickstart helper and the default
-YAML profile.  To launch the full control-region job from the preset YAML, run:
-
-```bash
-python run_analysis.py --options configs/fullR2_run.yml
-```
-
-Switch to the signal-region profile by appending ``:sr`` to the YAML path:
-
-```bash
-python run_analysis.py --options configs/fullR2_run.yml:sr
-```
-
-You can reach the same configuration from the quickstart helper with:
-
-```bash
-python -m topeft.quickstart \
-    ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \
-    --prefix root://cmsxrootd.fnal.gov/ \
-    --scenario TOP_22_006
-```
-
-### Tau-enriched workflow
-
-The ``tau_analysis`` bundle adds the dedicated signal and control regions needed
-by the tau reinterpretation.  When using ``run_analysis.py`` with the preset
-YAML, edit the configuration to include ``tau_analysis`` in the ``scenarios``
-list (for example by copying ``configs/fullR2_run.yml`` to
-``configs/fullR2_run_tau.yml`` and updating the defaults).  After the edit, run
-``python run_analysis.py --options configs/fullR2_run_tau.yml``.
-
-From the quickstart helper the equivalent command is:
-
-```bash
-python -m topeft.quickstart \
-    ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \
-    --prefix root://cmsxrootd.fnal.gov/ \
-    --scenario tau_analysis
-```
-
-### Forward-jet workflow
-
-The ``fwd_analysis`` bundle activates the forward-jet categories while reusing
-the shared Run 2 control regions.  Update your YAML preset to list
-``fwd_analysis`` under ``scenarios`` (or create a dedicated profile) before
-launching ``python run_analysis.py --options <your_yaml>``.
-
-And the matching quickstart invocation is:
-
-```bash
-python -m topeft.quickstart \
-    ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \
-    --prefix root://cmsxrootd.fnal.gov/ \
-    --scenario fwd_analysis
-```
+The Run‑3 default scenario is `fwd_analysis` (reused from the table above), but
+when you request Run‑3 eras the wrapper automatically switches to the Run‑3
+metadata bundle.
 
 ## Combining scenarios
 
-Metadata scenarios can be combined to produce hybrid category selections.  The
-planner validates that the requested combinations are compatible before any
-processing starts, so invalid bundles fail fast.  The baseline ``TOP_22_006``
-scenario already ships with the refined off-Z split; layering ``tau_analysis``
-or ``fwd_analysis`` on top keeps those specialised categories active alongside
-the shared control regions.
+Scenarios can be combined on the CLI or inside YAML:
 
-### YAML profiles
+```bash
+python analysis/topeft_run2/run_analysis.py \
+    input_samples/cfgs/mc_signal_samples_NDSkim.cfg \
+    --scenario TOP_22_006 \
+    --scenario tau_analysis \
+    --scenario offz_fwd_analysis \
+    --executor iterative --nchunks 1 --chunksize 5
+```
 
-To combine scenarios in a YAML profile, set the ``scenario`` key to a list.  The
-following snippet extends the default Run 2 configuration with both the tau and
-forward regions:
+When you supply `--options path.yml` the YAML becomes authoritative. Encode the
+scenario list there instead of repeating `--scenario`:
 
 ```yaml
-# configs/fullR2_run_tau_fwd.yml
-infile: ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json
-scenario:
-  - TOP_22_006
-  - tau_analysis
-  - fwd_analysis
+# analysis/topeft_run2/configs/fullR2_run_tau_fwd.yml
+defaults:
+  scenarios:
+    - TOP_22_006
+    - tau_analysis
+    - offz_fwd_analysis
+profiles:
+  sr:
+    skip_cr: true
+  cr:
+    skip_sr: true
 ```
 
-YAML values merge with the base profile when the file is passed through
-``--options``.  CLI flags are ignored in this mode, so bake any additional
-overrides into the file before launching the workflow.
+Remember that the CLI enforces a mutual exclusion rule: `--scenario` cannot be
+combined with `--options`. The wrapper (`full_run.sh`) surfaces the same guard
+for convenience.
 
-### Command-line runs without YAML
+## Adding or modifying a scenario
 
-You can request the same combination directly on the command line by dropping
-``--options``.  Each time ``--scenario`` is provided the value is appended to the
-active set:
+1. **Update the metadata groups** – Extend
+   `analysis/metadata/metadata_run2_groups.yaml` (or the relevant metadata file)
+   with the new regions, variables, or applications. Run
+   `python -m topeft.quickstart --emit-options` to sanity‑check your changes.
+2. **Register the group composition** – Edit
+   `analysis/metadata/run2_scenarios.yaml` to add or modify the scenario name
+   and its group list. Keep names descriptive and avoid overlapping the
+   canonical identifiers above unless you intend to redefine them.
+3. **Expose the scenario to the CLI** – If the metadata bundle changed, update
+   `analysis/topeft_run2/scenario_registry.py` so the new metadata path is
+   discoverable via `--scenario`. For Run‑2 additions this typically means
+   reusing `metadata_run2_groups.yaml` and pointing the registry to the same
+   file.
+4. **Validate** – Run the Step‑5 validators from `scratch/` to confirm the new
+   scenario is internally consistent:
 
-```bash
-python run_analysis.py \
-    --scenario TOP_22_006 \
-    --scenario tau_analysis \
-    --scenario fwd_analysis
-```
+   ```bash
+   PYTHONNOUSERSITE=1 PYTHONPATH="" /users/apiccine/work/miniconda3/envs/coffea2025/bin/python \
+       scratch/validate_run2_scenarios_step5.py
+   ```
 
-For quickstart tests, the equivalent call is:
+   The scripts compare the YAML source against the generated channel lists and
+   will raise if group definitions conflict.
 
-```bash
-python -m topeft.quickstart \
-    ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \
-    --prefix root://cmsxrootd.fnal.gov/ \
-    --scenario TOP_22_006 \
-    --scenario tau_analysis \
-    --scenario fwd_analysis
-```
-
-The planner will echo the resolved scenario list before launching the Coffea
-processor, making it easy to confirm the combined configuration.
+By following these steps the CLI, quickstart helpers, and `full_run.sh` wrapper
+will all recognize the scenario automatically, keeping the Run‑2 documentation
+and workflow in sync with the metadata source of truth.

--- a/docs/run_analysis_configuration.md
+++ b/docs/run_analysis_configuration.md
@@ -110,7 +110,8 @@ it used so that you can plug the same object into :func:`run_workflow` later.
 ## CLI highlights
 
 While the dedicated [`run_analysis.py` CLI reference](run_analysis_cli_reference.md)
-lists every flag, the most important Run‑2 knobs are summarised below:
+lists every flag in detail (path and default values, grouped by category), the
+most important Run‑2 knobs are summarised below:
 
 * **Scenario selection** – Use `--scenario NAME` to enable a metadata scenario
   (for example `TOP_22_006`). Repeat the flag to combine scenarios. When a YAML
@@ -139,11 +140,15 @@ lists every flag, the most important Run‑2 knobs are summarised below:
   encoded in the profile depending on how reproducible you need the launch to
   be.
 
+For a comprehensive, flag-by-flag breakdown (including defaults and YAML keys),
+refer to [`run_analysis_cli_reference.md`](run_analysis_cli_reference.md).
+
 ### Example commands
 
 Direct CLI runs remain useful for tiny tests or bespoke scans:
 
 ```bash
+# From the topeft repository root
 # UL18 smoke test using the iterative executor and small chunks
 python analysis/topeft_run2/run_analysis.py \
     input_samples/cfgs/mc_signal_samples_NDSkim.cfg \
@@ -155,6 +160,7 @@ python analysis/topeft_run2/run_analysis.py \
 ```
 
 ```bash
+# From the topeft repository root
 # Futures run driven by the canonical Run-2 SR profile
 python analysis/topeft_run2/run_analysis.py \
     input_samples/cfgs/mc_signal_samples_NDSkim.cfg,\

--- a/docs/run_analysis_configuration.md
+++ b/docs/run_analysis_configuration.md
@@ -107,6 +107,79 @@ The helpers are designed so that the resulting :class:`RunConfig` can be stored
 or passed around.  For example, the quickstart workflow returns the configuration
 it used so that you can plug the same object into :func:`run_workflow` later.
 
+## CLI highlights
+
+While the dedicated [`run_analysis.py` CLI reference](run_analysis_cli_reference.md)
+lists every flag, the most important Run‑2 knobs are summarised below:
+
+* **Scenario selection** – Use `--scenario NAME` to enable a metadata scenario
+  (for example `TOP_22_006`). Repeat the flag to combine scenarios. When a YAML
+  profile is supplied via `--options path.yml[:profile]`, the profile becomes
+  authoritative and `--scenario` must be encoded inside the YAML. The CLI
+  enforces the mutual exclusion rule so that misconfigured runs fail fast.
+* **YAML profiles (`--options`)** – Apply reusable presets such as
+  `analysis/topeft_run2/configs/fullR2_run.yml:sr`. `RunConfigBuilder` merges
+  `defaults`, the selected profile, then any top‑level overrides. Explicit CLI
+  flags still win for key workload controls like `--executor`, `--chunksize`,
+  and `--nchunks`, so you can tweak those without cloning the YAML file.
+  `full_run.sh` automatically selects the Run‑2 SR/CR profiles when you request
+  Run‑2 eras without `--scenario/--options`; for Run‑3 runs you typically pass a
+  dedicated Run‑3 YAML.
+* **Executor choice** – `--executor taskvine|futures|iterative` selects the
+  backend. TaskVine is recommended for distributed campaigns, `futures` for
+  local multi‑core runs, and `iterative` for tiny smoke tests. The wrapper
+  (`full_run.sh`) defaults to TaskVine but exposes the same flag.
+* **Workload controls** – `--chunksize` (number of events per chunk),
+  `--nchunks` (maximum chunks processed), and `--nworkers` (threads/processes)
+  are the primary levers when tuning runtimes. Futures runs also accept
+  `--futures-prefetch`, `--futures-retries`, and `--futures-retry-wait` to
+  control task pipelining and retry behaviour.
+* **Region toggles** – `--skip-sr`, `--skip-cr`, and `--do-systs` mirror the
+  settings embedded in the Run‑2 YAML profiles. They can be set from the CLI or
+  encoded in the profile depending on how reproducible you need the launch to
+  be.
+
+### Example commands
+
+Direct CLI runs remain useful for tiny tests or bespoke scans:
+
+```bash
+# UL18 smoke test using the iterative executor and small chunks
+python analysis/topeft_run2/run_analysis.py \
+    input_samples/cfgs/mc_signal_samples_NDSkim.cfg \
+    --scenario TOP_22_006 \
+    --executor iterative \
+    --chunksize 10 --nchunks 2 \
+    --summary-verbosity brief \
+    --skip-cr --do-systs
+```
+
+```bash
+# Futures run driven by the canonical Run-2 SR profile
+python analysis/topeft_run2/run_analysis.py \
+    input_samples/cfgs/mc_signal_samples_NDSkim.cfg,\
+    input_samples/cfgs/mc_background_samples_NDSkim.cfg,\
+    input_samples/cfgs/data_samples_NDSkim.cfg \
+    --options analysis/topeft_run2/configs/fullR2_run.yml:sr \
+    --executor futures --nworkers 8 --chunksize 50000
+```
+
+The first example relies purely on CLI flags; the second mirrors a typical
+`full_run.sh` command, showing how the YAML preset controls scenarios, metadata,
+and SR/CR toggles while still allowing executor overrides.
+
+### Common pitfalls
+
+* `--scenario` and `--options` are mutually exclusive on the CLI. When the
+  wrapper (`full_run.sh`) detects `--options` in the passthrough arguments it
+  aborts early so that the guard remains enforced.
+* If a YAML profile sets `executor: taskvine` but you want to run locally,
+  override it with `--executor futures`. The CLI now normalizes the value before
+  `RunConfigBuilder` runs so that explicit CLI choices always win.
+* `--chunksize` and `--nchunks` follow the same precedence rules: YAML provides
+  defaults, but CLI overrides are reapplied after merging so that experimental
+  runs can shrink their workload without editing the options file.
+
 ## Systematic handling
 
 Systematic switches are managed collaboratively by the helpers:


### PR DESCRIPTION
## Summary

This PR refreshes the Run-2 workflow documentation to match the current YAML-driven metadata and `run_analysis.py` / `full_run.sh` behavior. It adds a clearer description of scenarios vs groups, documents the canonical Run-2 scenario set and channel counts, and updates the Run-2 helper README with practical wrapper examples and guardrails.

---

### Technical changes

**1. `docs/run2_scenarios.md`**

- Rewrites the page around the modern **groups → scenarios → workflow** pipeline:
  - Groups from `analysis/metadata/metadata_run2_groups.yaml`.
  - Scenarios from `analysis/metadata/run2_scenarios.yaml`, resolved via `analysis/topeft_run2/scenario_registry.py`.
- Introduces a **canonical Run-2 scenarios table** with short descriptions and typical use cases:
  - `TOP_22_006`, `tau_analysis`, `offz_tau_analysis`, `offz_fwd_analysis`, `all_analysis`.
- Documents how to:
  - Combine scenarios via repeated `--scenario` flags or YAML profiles.
  - Add/modify scenarios by touching group metadata, `run2_scenarios.yaml`, and `scenario_registry.py`.
- Anchors the **canonical SR channel counts** (43 / 68 / 48 / 121 / 148) to the Step-5 validators so it’s clear how to interpret their output.

**2. `docs/run_analysis_configuration.md`**

- Adds a **“CLI highlights”** section summarising the most important knobs:
  - Scenario selection (`--scenario`).
  - YAML profiles (`--options path.yml[:profile]`) and how they interact with CLI overrides.
  - Executor selection (`--executor taskvine|futures|iterative`).
  - Workload controls (`--chunksize`, `--nchunks`, `--nworkers`, futures options).
  - Region toggles (`--skip-sr`, `--skip-cr`, `--do-systs`).
- Provides explicit **example commands** (from the topeft repo root) for:
  - An UL18 iterative smoke test using CLI-only configuration.
  - A futures run driven by `analysis/topeft_run2/configs/fullR2_run.yml:sr`, mirroring a typical `full_run.sh` launch.
- Adds a **“Common pitfalls”** section:
  - Mutual exclusion of `--scenario` and `--options`.
  - How CLI `--executor` overrides YAML defaults.
  - How `--chunksize` and `--nchunks` overrides are reapplied after options merging.

**3. `analysis/topeft_run2/README.md`**

- Extends the `full_run.sh` section to document:
  - Run-2 default behavior: if you request Run-2 eras without `--scenario`/`--options`, the wrapper auto-selects `analysis/topeft_run2/configs/fullR2_run.yml:(sr|cr)` and `TOP_22_006`.
  - Run-3 default behavior: Run-3 bundles default to `fwd_analysis` and the Run-3 cfgs.
  - The enforced **guardrails**:
    - No mixing of Run-2 and Run-3 eras in one invocation.
    - `--scenario` and `--options` are mutually exclusive at the wrapper level.
    - `--options` after `--` is rejected so the guard cannot be bypassed by accident.
- Adds concrete examples:
  - UL18 iterative dry-run with small chunks.
  - Run-2 SR futures launch relying on the auto-selected Run-2 options profile and `TOP_22_006`.
  - Run-3 TaskVine CR run defaulting to `fwd_analysis`.

---

### Testing

- Documentation-only changes; no code or workflow logic was modified.
- No automated tests run as part of this PR.

---

### Risks / notes

- This PR is **purely documentation** and should not affect any analysis outputs or runtime behavior.
- If we later rename or extend scenarios/groups, we should update:
  - `docs/run2_scenarios.md`
  - `docs/run_analysis_configuration.md`
  - `analysis/topeft_run2/README.md`
  to keep the docs in sync with the metadata and CLI.