### PR TITLE
Restructure Run-2 landing flow and mark legacy guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,198 +6,48 @@
 # topeft
 Top quark EFT analyses using the Coffea framework
 
-> **Workflow + YAML overview**: Start with the new [workflow and YAML hub](docs/workflow_and_yaml_hub.md) to see how the Run 2 presets, executors (futures or TaskVine), and metadata files fit together before diving into the rest of the docs.
+## Start here
+
+New to the project? Start with the [workflow and YAML hub](docs/workflow_and_yaml_hub.md).  
+It walks through the shared `coffea2025` environment, the Run‑2/Run‑3 YAML presets, and how to choose between the TaskVine and futures executors before handing you off to the Run‑2 quickstart and plotting guides. Consult [docs/index.md](docs/index.md) for a full map of the documentation tracks.
 
 ## Repository contents
-The `topeft/topeft` directory is set up to be installed as a pip installable package.
-- `topeft/topeft`: A package containing modules and files that will be installed into the environment.
-- `pyproject.toml`: PEP 517 metadata describing the package, dependencies, and bundled data.
-- `topeft/setup.py`: Minimal shim for invoking the package build
-- `topeft/analysis`: Subfolders with different analyses or studies.
-- `topeft/tests`: Scripts for testing the code with `pytest`. For additional details, please see the [README](https://github.com/TopEFT/topeft/blob/master/tests/README.md) in the `tests` directory.
-- `topeft/input_samples`: Configuration files that point to root files to process.
+
+The `topeft/topeft` directory is installable as a Python package:
+
+- `topeft/topeft`: Core modules shipped with the package.
+- `pyproject.toml`: PEP 517 metadata describing dependencies and bundled data.
+- `topeft/setup.py`: Minimal shim for invoking the package build.
+- `topeft/analysis`: Analysis- and workflow-specific scripts (e.g. `analysis/topeft_run2`).
+- `topeft/tests`: Pytest suites (see [`tests/README.md`](tests/README.md) for details).
+- `topeft/input_samples`: Sample manifests and CFG bundles used by the workflows.
+
+## Environment & dependencies
+
+The analysis relies on the shared `coffea2025` Conda environment and a sibling
+[`topcoffea`](https://github.com/TopEFT/topcoffea) checkout. The start-here hub
+summarises the setup steps and links to the TaskVine environment packaging guide.
+All CLI entry points validate that the `topcoffea` branch matches
+`ch_update_calcoffea` (or the release tag you specify via `TOPCOFFEA_BRANCH`).
 
 ### Legacy HistEFT support
-The repository now expects the [`topcoffea`](https://github.com/TopEFT/topcoffea) package to be installed in the active environment instead of shipping a partial vendor copy.  The upstream project still exposes the legacy `HistEFT` helpers via `topcoffea.modules.HistEFT`, so existing imports keep working once the dependency is installed.
-CI now includes a smoke test that asserts `import topcoffea` resolves outside the `topeft` checkout.  Remove any stray `topcoffea/` directories under this repository and reinstall the sibling package (for example via `pip install -e ../topcoffea`) if that guard triggers.
 
-## Getting started
+The repository now expects the `topcoffea` package to be installed in the active
+environment instead of shipping a partial vendor copy. The upstream project still
+exposes the legacy `HistEFT` helpers via `topcoffea.modules.HistEFT`, so existing
+imports keep working once the dependency is installed. CI includes a smoke test
+that asserts `import topcoffea` resolves outside the `topeft` checkout—remove any
+stray `topcoffea/` directories under this repository and reinstall the sibling
+package (for example via `pip install -e ../topcoffea`) if that guard triggers.
 
-New to the workflow? The [Run and plot quickstart](docs/run_and_plot_quickstart.md) walks through creating the environment, running `run_analysis.py` with both the futures and TaskVine executors, and turning the tuple-keyed histogram pickle into plots.
+## Related docs
 
-### Setting up
-If conda is not already available, download and install it:
-```
-curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh > conda-install.sh
-bash conda-install.sh
-```
-The topeft directory is set up to be installed as a python package. First clone the repository as shown, then run the following commands to set up the environment (note that `environment.yml` is a file that is a part of the `topeft` repository, so you should `cd` into `topeft` before running the command).  The refreshed workflow standardizes on the Coffea 2025.7.3 toolchain captured in the `coffea2025` Conda environment shared with the [`ttbarEFT`](https://github.com/TopEFT/ttbarEFT) analysis:
-```
-git clone https://github.com/TopEFT/topeft.git
-cd topeft
-unset PYTHONPATH # To avoid conflicts.
-conda env create -f environment.yml
-conda activate coffea2025
-pip install -e .
-```
-The commands above provision the refreshed `coffea2025` Conda environment, which tracks the Coffea 2025.7.3 base release used throughout the project.  Installing `topeft` with `pip install -e .` is now the expected workflow so that local developments are automatically folded into the packaged environment.
+Explore the rest of the documentation via:
 
-The Conda specification now also pins `hist=2.9.*` and `boost-histogram>=1.4` to mirror the histogram stack required by the sibling `topcoffea` checkout.  Keep the NumPy and pandas constraints intact when updating the environment so that ABI compatibility stays aligned across both projects.
-
-To install both sibling repositories in one step, either request the new optional dependency group or run the helper script:
-
-```
-pip install -e .[topcoffea]
-# or
-./scripts/dev_install.sh
-```
-
-The first form pulls `topcoffea` from a sibling checkout at `../topcoffea` while the second mirrors the original command (`pip install -e ../topcoffea -e .`) for contributors who prefer an explicit, reproducible installer.
-
-If your workstation already provides a `conda` executable, the helper commands above will reuse it.  On minimal runners or fresh containers where only `micromamba` is present, the `topeft` package now exposes a lightweight `conda` shim that forwards invocations to `micromamba` so `python -m topcoffea.modules.remote_environment` continues to work without a full Conda installation.
-
-Upgrading from an older checkout?  Reuse the same directory and run `conda env update -f environment.yml --prune` before activating the environment so the existing `coffea2025` install picks up the Coffea 2025.7.3 pins and removes stale dependencies.  If the solver prompts for an update, accept it or run `conda update -n base -c conda-forge conda` first to keep in sync with conda-forge builds.
-
-To catch configuration drift, CI hashes `environment.yml` and compares it to the upstream `ttbarEFT` coffea2025 specification (see `tests/test_environment_hash.py`).  When the upstream environment changes, update this repository's `environment.yml` and refresh the expected digest in that test so the guard continues to pass.
-
-The `-e` option installs the project in editable mode (i.e. setuptools "develop mode"). If you wish to uninstall the package, you can do so by running `pip uninstall topeft`.
-The [`topcoffea`](https://github.com/TopEFT/topcoffea) package upon which this analysis depends is not yet available on `PyPI`, so we need to clone the `topcoffea` repo and install it ourselves.  Keep the checkout next to `topeft` (for example `$HOME/workspace/topcoffea` beside `$HOME/workspace/topeft`) so paths such as `analysis/topeft_run2/../../topcoffea/cfg/...` resolve to the sibling repository when invoking older scripts.
-```
-cd /your/favorite/directory
-git clone https://github.com/TopEFT/topcoffea.git
-cd topcoffea
-git switch ch_update_calcoffea
-pip install -e .
-cd ../topeft
-python -m topcoffea.modules.remote_environment
-python -c "import topcoffea"
-```
-Keeping both repositories installed in editable mode ensures the remote-packaging helper inspects the current checkouts (and fails fast if there are unstaged edits).  **Always switch the sibling checkout to `ch_update_calcoffea` (or the matching release tag) before running `pip install -e ../topcoffea` _and_ when invoking `python -m topcoffea.modules.remote_environment`.**  Packaging the tarball from the same branch keeps the Conda + pip stack aligned with the processors.  Analysts relying on a detached tag can set `TOPCOFFEA_BRANCH=<tag>` before running `topeft` so the guard recognises the pinned reference.  All CLI entry points now validate that the resolved branch matches the expected `ch_update_calcoffea` baseline (using `.git/HEAD` when available or the `TOPCOFFEA_BRANCH` override), raising a clear error if the sibling checkout drifts.
-
-The `python -m topcoffea.modules.remote_environment` command calls into the updated `remote_environment.get_environment()` logic, which assembles a fresh TaskVine-ready tarball under `topeft-envs/`, captures the pinned Conda + pip stack, and returns the archive path that the workflow passes through the `environment_file` executor argument.  When the inputs match a previously cached build, it reuses the existing archive instead of rebuilding, but any change to the dependency specification or editable sources will trigger a refresh.  The final `python -c "import topcoffea"` line mirrors the CI smoke test and confirms the namespace import succeeds for downstream tooling.
-
-When editing dependencies (for example bumping NumPy/Pandas pins), recreate the `coffea2025` environment and force a new TaskVine tarball so the cached archive does not hold on to an outdated ABI mix.  Activate the refreshed environment for both local futures runs and TaskVine submissions so the manager and workers stay in sync.
-
-#### Packaged TaskVine environment cache
-
-The cached tarballs live in `topeft-envs/` and are named after the Conda + pip specification combined with the Git commits of editable packages.  Each invocation of `python -m topcoffea.modules.remote_environment` prints the active path and automatically rebuilds the archive when it detects new commits or unstaged edits in `topeft` or `topcoffea`.  If you need to force a rebuild (for example after cleaning a branch or rebasing), either remove the cached file or run `python -c "from topcoffea.modules.remote_environment import get_environment; print(get_environment(force=True))"`.  The resulting tarball is exactly what `processor.TaskVineExecutor` sends to remote workers through the `environment_file` parameter.
-
-Now all of the dependencies have been installed and the `topeft` repository is ready to be used. The packaged environment targets the Coffea 2025.7.3 release and can be re-generated at any time with `python -m topcoffea.modules.remote_environment`. The next time you want to use the project, activate the environment via `conda activate coffea2025`.
-
-
-### TaskVine distributed execution
-
-For a narrated walkthrough that ties environment preparation, tarball packaging, and worker submission together, see the [TaskVine workflow quickstart](docs/taskvine_workflow.md). The packaged archive produced by `python -m topcoffea.modules.remote_environment` is uploaded automatically when runs target the TaskVine executor. Launching a distributed job therefore becomes:
-
-1. Enable TaskVine in the YAML profile before launching the run.  Open
-   `analysis/topeft_run2/configs/fullR2_run.yml` and set the profile you plan
-   to execute to use the TaskVine backend (the preset defaults to
-   `executor: futures` for local smoke tests):
-
-   ```yaml
-   profiles:
-     cr:
-       # ...existing options...
-       executor: taskvine
-   ```
-
-   (When you prefer to keep both backends handy, copy the file to a new name
-   such as `fullR2_run_taskvine.yml` and adjust the `executor` there.)
-
-2. Configure the workflow with TaskVine enabled (for example, selecting the
-   Run 2 control preset).  Setting `executor: taskvine` in the YAML tells
-   `run_analysis.py` to launch `coffea.processor.TaskVineExecutor`, which
-   automatically streams tasks to the TaskVine manager while handing workers
-   the packaged environment via `environment_file`:
-
-   ```bash
-   python run_analysis.py \
-       ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \
-       --options configs/fullR2_run.yml
-   ```
-
-   The `analysis/topeft_run2/full_run.sh` wrapper automates this setup when you
-   want a single entry point. It activates the shared Conda environment when
-   available, refreshes the cached TaskVine tarball via
-   `python -m topcoffea.modules.remote_environment`, and forwards control- or
-   signal-region selections to `run_analysis.py` while keeping the TaskVine
-   executor defaults (manager name `${USER}-taskvine-coffea`, 5-tuple histogram
-   pickle outputs). Example end-to-end invocation:
-
-   ```bash
-   cd analysis/topeft_run2
-   ./full_run.sh --sr -y 2022 2022EE --outdir histos/run3_taskvine --tag nightly
-   ```
-
-3. Start one or more workers that match the manager name advertised by the run. A minimal local worker looks like:
-
-   ```bash
-   vine_worker --cores 1 --memory 8000 --disk 8000 -M ${USER}-taskvine-coffea
-   ```
-
-   When scaling out through TaskVine's submission helpers, prefer launching a worker pool with the packaged environment already attached:
-
-   ```bash
-   vine_submit_workers --cores 4 --memory 16000 --disk 16000 \
-       --python-env "$(python -m topcoffea.modules.remote_environment)" \
-       -M ${USER}-taskvine-coffea 10
-   ```
-
-   The `remote_environment.get_environment()` helper returns the same tarball path that the workflow passes through the `environment_file` executor argument; pre-loading it with `--python-env` avoids transferring the archive every time a new worker connects. If `--python-env` is omitted, the manager still hands the environment off automatically via `environment_file`, matching the behaviour of older Work Queue deployments.
-
-   For HTCondor-backed pools, `condor_submit_workers` and other submission helpers ship with TaskVine; point them at the same manager string and pass `--python-env` when the helper supports it. Refer to the [remote environment maintenance guide](docs/environment_packaging.md) for details on rebuilding the tarball whenever dependencies change.
-
-   The `analysis/topeft_run2/full_run.sh` wrapper now supports both TaskVine
-   (default) and local futures executions. Add `--executor futures` to switch to
-   the single-node path and `--dry-run` to print the resolved command without
-   launching Python. The same entrypoint accepts `--samples` overrides for quick
-   JSON-based smoke tests:
-
-   ```bash
-   cd analysis/topeft_run2
-   ./full_run.sh --sr -y UL17 --executor futures --samples \
-       ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \
-       --outdir histos/local_debug --tag quickstart --dry-run
-   ```
-
-   Work Queue has been retired from the workflow helpers. A condensed record of the historic instructions is preserved in [README_WORKQUEUE.md](README_WORKQUEUE.md) for teams pinned to older releases.
-
-### To run an example job
-
-The Run 2 workflow now ships with YAML presets under
-`analysis/topeft_run2/configs/`.  They mirror the historic shell scripts while
-allowing you to toggle signal and control regions from the command line.
-
-1. `cd` into `analysis/topeft_run2` and resolve the example input:
-
-   ```bash
-   cd analysis/topeft_run2
-   wget -nc http://www.crc.nd.edu/~kmohrman/files/root_files/for_ci/ttHJet_UL17_R1B14_NAOD-00000_10194_NDSkim.root
-   ```
-
-2. Launch the control-region (CR) pass of the reinterpretation with the shared
-   YAML configuration:
-
-   ```bash
-   python run_analysis.py ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \
-       --options configs/fullR2_run.yml
-   ```
-
-3. Switch to the signal-region (SR) profile by pointing to the same YAML bundle
-   and appending `:sr` to select the preset:
-
-   ```bash
-   python run_analysis.py ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \
-       --options configs/fullR2_run.yml:sr
-   ```
-
-Both commands emit verbose task summaries before execution so you can confirm
-the samples, regions, and histograms that will be processed.  When `--options`
-is present the YAML file becomes the single source of truth—CLI flags such as
-`--executor` or `--summary-verbosity` are ignored, so embed any overrides
-directly in the configuration or drop `--options` for ad-hoc command-line runs.
-You can still run without YAML by calling the scripts in
-`analysis/topeft_run2/examples/`, but the config-based approach keeps SR/CR
+- [Workflow & YAML hub](docs/workflow_and_yaml_hub.md) – start here.
+- [Documentation index](docs/index.md) – curated doc tracks.
+- [TaskVine workflow quickstart](docs/taskvine_workflow.md) – distributed execution focus.
+- [Run 2 metadata scenarios](docs/run2_scenarios.md) – scenario definitions and validators.
 toggles, output names, and executor settings in a single place.
 
 #### Supported metadata scenarios
@@ -368,4 +218,3 @@ The [v0.5 tag](https://github.com/TopEFT/topcoffea/releases/tag/v0.5) was used t
     ```
 
 5. Proceed to the [Steps for reproducing the "official" TOP-22-006 workspace](https://github.com/TopEFT/EFTFit#steps-for-reproducing-the-official-top-22-006-workspace) steps listed in the EFTFit Readme. Remember that in addition to the files cards and templates, you will also need the `selectedWCs.txt` file. 
-

--- a/README_FITTING.md
+++ b/README_FITTING.md
@@ -1,4 +1,9 @@
-# How to fit the results
+# How to fit the results *(archival reference)*
+
+> **Legacy status:** this guide preserves historic datacard/fit notes. For the
+> current Run‑2 workflow and outputs, start with
+> [docs/workflow_and_yaml_hub.md](docs/workflow_and_yaml_hub.md) and
+> [docs/quickstart_run2.md](docs/quickstart_run2.md).
 
 The first step is to produce the datacard text files and root files that combine will use, and this step takes place within `topcoffea`.  The next step is to run combine, which takes place inside of a CMSSW release, outside of `topcoffea`.
 
@@ -16,3 +21,6 @@ python make_cards.py path/to/your.pkl.gz -C --do-nuisance --var-lst lj0pt ptz -d
 ## Running combine
 
  The next step is to run combine. This takes place inside of a CMSSW release, outside of `topcoffea`. See the [EFTFit](https://github.com/TopEFT/EFTFit) repo for instructions.
+
+For the current analysis workflow, metadata, and plotting docs, start with
+[docs/index.md](docs/index.md) and the linked quickstarts.

--- a/README_WORKQUEUE.md
+++ b/README_WORKQUEUE.md
@@ -1,4 +1,9 @@
-# Distributed execution with TaskVine
+# Distributed execution with TaskVine *(archival notes)*
+
+> **Legacy status:** this file captures historical TaskVine/Work Queue guidance.
+> For the current workflow and quickstart, see
+> [docs/workflow_and_yaml_hub.md](docs/workflow_and_yaml_hub.md) and
+> [docs/taskvine_workflow.md](docs/taskvine_workflow.md).
 
 TaskVine is the supported distributed backend for `topeft`.  The helpers in
 `analysis/topeft_run2/workflow.py` and the command line interfaces default to the
@@ -66,3 +71,7 @@ instructions remain available in the Git history prior to this change.  If you
 are required to operate against a Coffea build that still exposes
 `WorkQueueExecutor`, pin the repository to a revision before the TaskVine-only
 switch and follow the historic instructions that accompanied that release.
+
+For active distributed-execution documentation, see
+[docs/taskvine_workflow.md](docs/taskvine_workflow.md) and the landing flow
+linked from [docs/index.md](docs/index.md).

--- a/analysis/topeft_run2/README.md
+++ b/analysis/topeft_run2/README.md
@@ -1,4 +1,9 @@
-## topEFT
+## topEFT *(legacy directory README)*
+
+> **Legacy status:** this file documents historic utilities in `analysis/topeft_run2/`.
+> For the current Run‑2 workflow and quickstart, see
+> [docs/workflow_and_yaml_hub.md](../docs/workflow_and_yaml_hub.md) and
+> [docs/quickstart_run2.md](../docs/quickstart_run2.md).
 This directory contains scripts for the Full Run 2 EFT analysis. This README documents and explains how to run the scrips.
 
 ### Scripts for remaking reference files that the CI tests against

--- a/docs/analysis_processing.md
+++ b/docs/analysis_processing.md
@@ -23,7 +23,7 @@ The high-level flow is:
    combinations by crossing samples, channel metadata, Coffea applications, and
    systematic toggles.  The result is a :class:`HistogramPlan` which records the
   ``(variable, channel, application, sample, systematic)`` tuples described in
-  the shared [tuple-key reference](https://github.com/TopEFT/topcoffea/blob/ch_update_calcoffea/docs/analysis_processing.md)
+  the shared [tuple-key reference](tuple_key_audit.md)
   before the tasks are processed.
 5. An :class:`analysis.topeft_run2.workflow.ExecutorFactory` creates the
    requested backend runner (``futures``, ``iterative`` or ``taskvine``).  Each
@@ -137,7 +137,7 @@ from analysis.topeft_run2.workflow import run_workflow
 parser = build_parser()
 args = parser.parse_args([
     "input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json",
-    "--options", "analysis/topeft_run2/examples/options.yml:sr",
+    "--options", "analysis/topeft_run2/configs/fullR2_run.yml:sr",
 ])
 
 builder = RunConfigBuilder()
@@ -150,5 +150,7 @@ utilities.  Persisting it (for example via ``dataclasses.asdict``) provides a
 compact audit trail that complements the stored output pickle.
 
 When ``--options`` is present the YAML file becomes authoritative—CLI flags are
-ignored so that the captured configuration remains reproducible.  Drop the
+ignored so that the captured configuration remains reproducible (aside from the
+handful of workload overrides noted in
+[run_analysis_configuration.md](run_analysis_configuration.md)).  Drop the
 argument entirely for ad-hoc runs driven purely from the command line.

--- a/docs/dataclasses_and_metadata.md
+++ b/docs/dataclasses_and_metadata.md
@@ -103,3 +103,37 @@ configuration, metadata catalogues, and the Coffea execution pipeline.  Editing
 one layer (for example, adding a new systematic in the YAML) automatically
 propagates through the JSON schema validation, histogram planning, and task
 summaries without additional glue code.
+
+## Metadata editing checklist
+
+Use this checklist when introducing or modifying Run‑2 metadata:
+
+1. **Edit locations**
+   - Clone ``topeft/params/metadata.yml`` to a tracked file (for example
+     ``analysis/topeft_run2/configs/metadata_dev.yml``) before making changes.
+   - Update scenario/group compositions in
+     ``analysis/metadata/run2_scenarios.yaml`` and related metadata files under
+     ``analysis/metadata/`` when adding new channel bundles.
+   - Point YAML options (such as ``analysis/topeft_run2/configs/fullR2_run.yml``)
+     at the new metadata file via the ``metadata`` key so the presets stay in sync.
+2. **Validate the updates**
+   - Run the validators under ``scratch/`` after each change:
+     - ``python scratch/validate_run2_scenarios_step5.py`` – confirms scenario
+       definitions and prints per-scenario counts.
+     - ``python scratch/validate_run2_groups_step5.py`` – compares YAML group
+       counts against the legacy JSON snapshot.
+     - ``python scratch/validate_run2_datacard_channels_step5.py`` – checks that
+       datacard channel counts match the expected SR totals.
+   - These scripts assume the Run‑2 metadata lives under ``analysis/metadata`` and
+     should be executed from the repository root so relative imports resolve.
+3. **Smoke-test the workflow**
+   - Use the [Run 2 quickstart pipeline](quickstart_run2.md) or
+     ``analysis/topeft_run2/full_run.sh`` with the updated YAML to confirm the
+     new metadata runs end to end (``--dry-run`` first, then a short futures pass).
+   - Keep scenario names consistent with ``run2_scenarios.yaml`` so CLI
+     invocations and presets (like ``fullR2_run.yml:sr``) continue to work.
+4. **Share presets wisely**
+   - For experimental configurations, create a dedicated YAML file (for example
+     ``fullR2_run_tau_dev.yml``) instead of editing production presets directly.
+     Reference the new metadata path in that file and document it alongside the
+     change so collaborators can reproduce your setup.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,10 +9,10 @@ overlapping quickstarts.
 
 - [Workflow and YAML hub](workflow_and_yaml_hub.md) – **Start here** for
   prerequisites, YAML merging, and executor choices.
-- [Run 2 quickstart pipeline](quickstart_run2.md) – Current end-to-end Run‑2
-  walkthrough (to be consolidated with plotting guides in a later step).
-- [Run and plot quickstart](run_and_plot_quickstart.md) – Plotting appendix for
-  the quickstart; slated for merger into the main quickstart during 6B.2.
+- [Run 2 quickstart pipeline](quickstart_run2.md) – Primary end-to-end Run‑2
+  walkthrough (environment → run → plot).
+- [Run and plot quickstart](run_and_plot_quickstart.md) – Legacy plotting
+  appendix with extra tips beyond the main quickstart.
 - [TOP-22-006 script walkthrough](quickstart_top22_006.md) – Scenario-specific
   quickstart extending the Run‑2 presets.
 
@@ -48,8 +48,7 @@ overlapping quickstarts.
 ## Legacy / archival
 
 - [analysis/topeft_run2/README.md](../analysis/topeft_run2/README.md) – Legacy
-  directory README; pending cleanup during later steps.
-- [README_WORKQUEUE.md](../README_WORKQUEUE.md) – Archived Work Queue/TaskVine
-  transition notes.
-- [README_FITTING.md](../README_FITTING.md) – Datacard/fit instructions retained
-  for historical reference.
+  directory README preserved for historical context.
+- [README_WORKQUEUE.md](../README_WORKQUEUE.md) – Archived notes for the retired
+  Work Queue backend (TaskVine is current).
+- [README_FITTING.md](../README_FITTING.md) – Historic datacard/fit instructions.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,22 +1,55 @@
 # TopEFT documentation map
 
-This overview links the most commonly used guides by category so you can jump
-straight to the information you need.
+Use this map to navigate the documentation tracks introduced during the docs
+reorganisation. Each section highlights the current source of truth for that
+topic so newcomers can follow a single path instead of bouncing between
+overlapping quickstarts.
 
-## Getting started
+## Landing & quickstart
 
-- [Workflow and YAML overview](workflow_and_yaml_hub.md) – single entry point covering executors, presets, and how options files are merged.
-- [TaskVine workflow quickstart](taskvine_workflow.md)
-- [Run 2 quickstart pipeline](quickstart_run2.md)
-- [TOP-22-006 script walkthrough](quickstart_top22_006.md)
+- [Workflow and YAML hub](workflow_and_yaml_hub.md) – **Start here** for
+  prerequisites, YAML merging, and executor choices.
+- [Run 2 quickstart pipeline](quickstart_run2.md) – Current end-to-end Run‑2
+  walkthrough (to be consolidated with plotting guides in a later step).
+- [Run and plot quickstart](run_and_plot_quickstart.md) – Plotting appendix for
+  the quickstart; slated for merger into the main quickstart during 6B.2.
+- [TOP-22-006 script walkthrough](quickstart_top22_006.md) – Scenario-specific
+  quickstart extending the Run‑2 presets.
 
-## Scenario playbooks
+## Running analyses
 
-- [Run 2 metadata scenarios guide](run2_scenarios.md)
+- [Run analysis configuration flow](run_analysis_configuration.md) – Narrative
+  walkthrough of CLI/YAML merging and workflow helpers.
+- [`run_analysis.py` CLI and YAML reference](run_analysis_cli_reference.md) –
+  Flag-by-flag lookup table.
+- [TaskVine workflow quickstart](taskvine_workflow.md) – Distributed executor
+  focus, including environment packaging pointers.
+- [Environment packaging](environment_packaging.md) – Maintaining the shared
+  TaskVine tarball.
 
-## Workflow reference
+## Metadata & scenarios
 
 - [Run configuration dataclasses and metadata overview](dataclasses_and_metadata.md)
-- [Run analysis configuration flow](run_analysis_configuration.md)
-- [`run_analysis.py` CLI and YAML reference](run_analysis_cli_reference.md)
-- [Workflow and processor reference](analysis_processing.md)
+  – How metadata is stored in dataclasses.
+- [Run 2 metadata scenarios guide](run2_scenarios.md) – Scenario/feature
+  definitions and validator pointers.
+- [Sample metadata reference](sample_metadata_reference.md) – JSON manifest
+  schema and troubleshooting tips.
+
+## Architecture & internals
+
+- [Workflow and processor reference](analysis_processing.md) – Processor ↔
+  workflow architecture and execution flow.
+- [Tuple key audit](tuple_key_audit.md) – 5‑tuple conventions for histogram
+  keys across the repository.
+- [analysis/topeft_run2/DEVELOPER_NOTES.md](../analysis/topeft_run2/DEVELOPER_NOTES.md)
+  – Metadata feature flag behaviours distilled from the processor.
+
+## Legacy / archival
+
+- [analysis/topeft_run2/README.md](../analysis/topeft_run2/README.md) – Legacy
+  directory README; pending cleanup during later steps.
+- [README_WORKQUEUE.md](../README_WORKQUEUE.md) – Archived Work Queue/TaskVine
+  transition notes.
+- [README_FITTING.md](../README_FITTING.md) – Datacard/fit instructions retained
+  for historical reference.

--- a/docs/quickstart_top22_006.md
+++ b/docs/quickstart_top22_006.md
@@ -1,63 +1,10 @@
 # TOP-22-006 Quickstart Guide
 
-This guide walks through the minimal setup needed to reproduce the Run 2
-signal-region (SR) and control-region (CR) histograms for the TOP-22-006
-analysis using the refactored `run_analysis.py` entrypoint.  It assumes you
-are starting from a clean checkout of the repository and would like to reuse
-the shared metadata bundles defined in the Run 2 preset YAML configuration.
-
-## Prerequisites
-
-Before running the workflow you will need (the
-[TaskVine workflow quickstart](taskvine_workflow.md) expands each step into a
-single distributed-execution checklist):
-
-1. **A working Python environment.**  The analysis is developed and tested
-   against the conda environment shipped with the repository.  Create and
-   activate it with:
-
-   ```bash
-   conda env create -f environment.yml
-   conda activate coffea2025
-   ```
-
-   The packaged environment tracks the Coffea 2025.7.3 release. Rebuild the TaskVine archive after dependency changes with `python -m topcoffea.modules.remote_environment`; the helper caches the resulting tarball under `topeft-envs/` using the Conda specification plus the Git commits of editable packages.  Each invocation prints the active path and automatically refreshes the archive when it detects new commits or unstaged edits in `topeft` or `topcoffea`.  To force a rebuild (for example after a branch reset), remove the cached file or run ``python -c "from topcoffea.modules.remote_environment import get_environment; print(get_environment(force=True))"``.  Developers upgrading an existing checkout can run `conda env update -f environment.yml --prune` instead of recreating the environment from scratch.
-
-2. **The editable `topeft` and `topcoffea` packages.**  From the repository
-   root install the local modules with:
-
-   ```bash
-   pip install -e .
-   ```
-
-   The workflow depends on the companion [`topcoffea`](https://github.com/TopEFT/topcoffea)
-   utilities.  Install them in the same environment:
-
-   ```bash
-   git clone https://github.com/TopEFT/topcoffea.git
-   cd topcoffea
-   git switch ch_update_calcoffea
-   pip install -e .
-   ```
-
-   Run `python -m topcoffea.modules.remote_environment` from the same branch (or
-   release tag) so the packaged tarball matches your processors.  The branch
-   guard embedded in the CLI entry points inspects `.git/HEAD` (or the
-   `TOPCOFFEA_BRANCH` override for detached tags) and aborts early when the
-   sibling checkout drifts from `ch_update_calcoffea`.
-
-3. **Access to the Run 2 metadata bundles.**  The YAML preset points to
-   configuration files already tracked in this repository under
-   `input_samples/cfgs/`.  Ensure your checkout includes the following files:
-
-   - `mc_signal_samples_NDSkim.cfg`
-   - `mc_background_samples_NDSkim.cfg`
-   - `data_samples_NDSkim.cfg`
-   - `mc_background_samples_cr_NDSkim.cfg`
-
-   These files enumerate the JSON sample metadata produced for the Run 2
-   campaign and do not require any additional downloads for the quickstart
-   example.
+This guide builds on the [Run 2 quickstart pipeline](quickstart_run2.md) and
+shows how to launch the canonical TOP‑22‑006 control- and signal-region passes
+using the shared YAML presets. Read the main quickstart (and the
+[workflow & YAML hub](workflow_and_yaml_hub.md)) first so your environment,
+sample manifests, and plotting workflow are already in place.
 
 ## Running the workflow with the preset YAML
 
@@ -131,18 +78,13 @@ scenarios declared in ``topeft/params/metadata.yml``.
    The SR profile keeps the shared defaults while swapping in the signal and
    data metadata bundles and disabling the control regions.
 
-5. Adjust any additional options directly inside the YAML file.  Once
+5. Adjust any additional options directly inside the YAML file. Once
    ``--options`` is provided, command-line flags (such as ``--executor`` or
    ``--outname``) are ignored so that the captured configuration remains
-   reproducible.  Drop ``--options`` entirely if you need a one-off CLI-driven
-   run.
-
-   When you need to test changes to the metadata catalogue, clone
-   ``topeft/params/metadata.yml`` and reference the new path from the YAML
-   profile you launch with ``--options``.  Add ``metadata: configs/metadata_dev.yml``
-   (or similar) near the top of your options file so the override is captured in
-   version control, then run ``python run_analysis.py --options <your_yaml>`` to
-   exercise the edits.
+   reproducible. Drop ``--options`` entirely if you need a one-off CLI-driven
+   run. When testing metadata changes, clone ``topeft/params/metadata.yml``,
+   reference it via ``metadata: …`` near the top of your options file, and
+   commit the override alongside the preset.
 
 ## Next steps {#top22-quickstart-next-steps}
 

--- a/docs/run_analysis_configuration.md
+++ b/docs/run_analysis_configuration.md
@@ -54,7 +54,7 @@ root::
 
     python analysis/topeft_run2/run_analysis.py \
         input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \
-        --options analysis/topeft_run2/examples/options.yml:sr
+        --options analysis/topeft_run2/configs/fullR2_run.yml:sr
 
 1. **Argument parsing** – :func:`analysis.topeft_run2.run_analysis.build_parser`
    defines the CLI options that downstream helpers understand.  The parser keeps
@@ -75,6 +75,15 @@ root::
    When an options file is supplied, the YAML becomes the single source of truth.
    Drop ``--options`` if you need to experiment with ad-hoc CLI flags; otherwise
    bake the desired configuration into the file before launching the workflow.
+
+   !!! note "CLI vs YAML precedence"
+       ``--options`` tells ``RunConfigBuilder`` to merge ``defaults``, the selected
+       profile, and any top-level keys before evaluating CLI flags. Workload knobs
+       such as ``--executor``, ``--chunksize``, and ``--nchunks`` are still honoured
+       so you can downscale a run without cloning the YAML, but most configuration
+       values (metadata, scenarios, region toggles, etc.) must be provided directly
+       in the options file. ``full_run.sh`` applies the same rules when it selects
+       the Run‑2 presets on your behalf.
 
 3. **Configuration normalization** – the builder converts all inputs into a
    :class:`analysis.topeft_run2.run_analysis_helpers.RunConfig` dataclass.  The

--- a/docs/run_and_plot_quickstart.md
+++ b/docs/run_and_plot_quickstart.md
@@ -1,10 +1,9 @@
 # Run and plot quickstart (legacy appendix)
 
-This page is no longer the primary starting point for new users. Follow the
-[Run 2 quickstart pipeline](quickstart_run2.md) for the current end-to-end
-instructions (environment → run → plot). The sections below collect a few extra
-plotting tips that did not fit in the main quickstart yet; they are safe to skip
-unless you need the additional context.
+> **Legacy appendix:** kept for historical plotting tips only. Follow the
+> [Run 2 quickstart pipeline](quickstart_run2.md) for the supported environment,
+> run, and plot workflow. Use this page only when you need the supplementary
+> plotting tricks recorded below.
 
 ## Additional plotting tips
 
@@ -36,5 +35,5 @@ unless you need the additional context.
   sample, systematic)` tuples match expectations before writing custom plotting
   helpers.
 
-This file will be retired once the remaining tips are merged into the main
-quickstart during the later 6B.* steps.
+This file is preserved for reference; the canonical Run‑2 quickstart lives in
+`docs/quickstart_run2.md`.

--- a/docs/run_and_plot_quickstart.md
+++ b/docs/run_and_plot_quickstart.md
@@ -1,118 +1,40 @@
-# Run and plot quickstart
+# Run and plot quickstart (legacy appendix)
 
-This guide walks through creating the shared environment, running `run_analysis.py` with the local futures and TaskVine executors, and turning the resulting histogram pickles into plots with the existing helpers. All runs rely on the 5-tuple histogram schema `(variable, channel, application, sample, systematic)` documented in [analysis_processing.md](analysis_processing.md) and enforced across the plotting stack, so ensure any downstream consumers preserve those keys.
+This page is no longer the primary starting point for new users. Follow the
+[Run 2 quickstart pipeline](quickstart_run2.md) for the current end-to-end
+instructions (environment → run → plot). The sections below collect a few extra
+plotting tips that did not fit in the main quickstart yet; they are safe to skip
+unless you need the additional context.
 
-## 1) Create the environment and install dependencies
+## Additional plotting tips
 
-1. Install Miniconda if it is not already available:
+- Re-run the plotting helper with different naming/era options to keep multiple
+  smoke tests separate:
 
-   ```bash
-   curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh > conda-install.sh
-   bash conda-install.sh
-   ```
+  ```bash
+  cd analysis/topeft_run2
+  python make_cr_and_sr_plots.py \
+      -f histos/local_debug/plotsTopEFT.pkl.gz \
+      -o plots/local_debug \
+      -n plots \
+      -y 2017 \
+      --skip-syst
+  ```
 
-2. Create and activate the shared `coffea2025` environment, then install `topeft` in editable mode:
+- Inspect tuple summaries directly from Python when experimenting in notebooks:
 
-   ```bash
-   cd /path/to/topeft
-   unset PYTHONPATH
-   conda env create -f environment.yml
-   conda activate coffea2025
-   pip install -e .
-   ```
+  ```python
+  import gzip, pickle
+  from topeft.modules.runner_output import materialise_tuple_dict
 
-   The shared spec now carries `hist=2.9.*` and `boost-histogram>=1.4` alongside the existing NumPy/pandas pins so the histogram helpers match the `topcoffea` baseline.
+  with gzip.open("histos/local_debug/plotsTopEFT.pkl.gz", "rb") as handle:
+      tuple_summary = materialise_tuple_dict(pickle.load(handle))
+  print(list(tuple_summary.items())[:2])
+  ```
 
-3. Clone and install the sibling [`topcoffea`](https://github.com/TopEFT/topcoffea) checkout **on the `ch_update_calcoffea` branch** so the processors and packaged environments agree on the dependency baseline:
+  The summaries make it easy to confirm that `(variable, channel, application,
+  sample, systematic)` tuples match expectations before writing custom plotting
+  helpers.
 
-   ```bash
-   cd /path/to
-   git clone https://github.com/TopEFT/topcoffea.git
-   cd topcoffea
-   git switch ch_update_calcoffea
-   pip install -e .
-   cd ../topeft
-   python -c "import topcoffea"  # smoke test
-   ```
-
-4. (TaskVine only) Build a packaged environment tarball to hand to remote workers. The helper detects editable changes and rebuilds automatically:
-
-   ```bash
-   python -m topcoffea.modules.remote_environment
-   ```
-
-   The printed path (under `topeft-envs/`) is passed to TaskVine via the executor `environment_file` argument; local futures runs do **not** need this tarball because they rely on the already-activated Conda environment.
-
-## 2) Run `run_analysis.py`
-
-Example commands assume `analysis/topeft_run2` as the working directory and the sample manifest from `input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json`.
-
-Fetch the UL17 CI ROOT sample before running the quickstart so `run_analysis.py` can locate the input file referenced by the manifest. Download it into your working directory or point `--prefix` at the containing path if you store it elsewhere:
-
-```bash
-cd analysis/topeft_run2
-wget -nc http://www.crc.nd.edu/~kmohrman/files/root_files/for_ci/ttHJet_UL17_R1B14_NAOD-00000_10194_NDSkim.root
-```
-
-### Local futures executor (single node)
-
-Use the default configuration bundle and force the futures backend for quick smoke tests:
-
-```bash
-cd analysis/topeft_run2
-python run_analysis.py \
-    ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \
-    --executor futures \
-    --outpath histos/local_futures_quickstart \
-    --outname plotsTopEFT
-```
-
-This path processes the signal-region profile locally and writes tuple-keyed histogram pickles such as `histos/local_futures_quickstart/plotsTopEFT.pkl.gz`.
-
-### TaskVine executor (distributed)
-
-Re-use the same YAML profile with the TaskVine backend enabled. Because the executor hands off work to a TaskVine manager, ensure workers connect to the advertised manager name and have access to the packaged environment tarball printed earlier.
-
-```bash
-cd analysis/topeft_run2
-python run_analysis.py \
-    ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \
-    --executor taskvine \
-    --environment-file "$(python -m topcoffea.modules.remote_environment)" \
-    --outpath histos/taskvine_quickstart \
-    --outname plotsTopEFT
-```
-
-Start at least one worker in another terminal, matching the manager string reported by the run (for example `vine_worker --cores 1 --memory 8000 --disk 8000 -M ${USER}-taskvine-coffea`). The TaskVine invocation requires the tarball supplied through `--environment-file`; omit it only when debugging locally with the futures executor.
-
-Both executors emit histogram pickles keyed by the `(variable, channel, application, sample, systematic)` tuples referenced above. Downstream plotting helpers rely on those keys to locate channel and systematic metadata.
-
-## 3) Turn the histogram pickle into plots
-
-The `analysis/topeft_run2/make_cr_and_sr_plots.py` helper consumes the tuple-keyed output and produces control- and signal-region plots. Point it at the pickle produced in the previous step:
-
-```bash
-cd analysis/topeft_run2
-python make_cr_and_sr_plots.py \
-    -f histos/taskvine_quickstart/plotsTopEFT.pkl.gz \
-    -o plots/taskvine_quickstart \
-    -n plots \
-    -y 2017 \
-    --skip-syst
-```
-
-For quick inspection inside a notebook or ad-hoc script, you can also materialise the tuple summary directly:
-
-```python
-import gzip
-import pickle
-from topeft.modules.runner_output import materialise_tuple_dict
-
-with gzip.open("histos/local_futures_quickstart/plotsTopEFT.pkl.gz", "rb") as handle:
-    histos = pickle.load(handle)
-
-tuple_summary = materialise_tuple_dict(histos)
-print(list(tuple_summary.items())[:2])
-```
-
-Both paths assume the stored histogram tuples follow the `(variable, channel, application, sample, systematic)` convention so channel- and systematic-aware plotting works as expected.
+This file will be retired once the remaining tips are merged into the main
+quickstart during the later 6B.* steps.

--- a/docs/workflow_and_yaml_hub.md
+++ b/docs/workflow_and_yaml_hub.md
@@ -1,6 +1,25 @@
 # Workflow and YAML overview
 
+> **Start here:** this hub is the recommended entry point for new contributors.
+> It links the shared environment, YAML presets, executor choices, and quickstart
+> workflows so you can go from “fresh checkout” to “first Run‑2 launch” without
+> jumping across multiple README files. For a fuller documentation map, see
+> [docs/index.md](index.md).
+
 This hub pulls together the essentials for launching Run 2 analyses, choosing between the local futures and distributed TaskVine executors, and understanding how the YAML options files drive the workflow. It is meant as a single place to start, with pointers back to the detailed references once you are comfortable with the flow.
+
+## Before you begin
+
+1. Create or update the shared `coffea2025` Conda environment and install both
+   `topeft` and the sibling [`topcoffea`](https://github.com/TopEFT/topcoffea)
+   checkout in editable mode. The commands are summarised in the repository
+   `README.md` and expanded in the [environment packaging guide](environment_packaging.md).
+2. Keep `topcoffea` on the `ch_update_calcoffea` branch (or matching release tag)
+   so the cache-free jet/MET corrections match what the Run‑2 workflow expects.
+3. If you plan to run distributed jobs, build the TaskVine environment tarball
+   via `python -m topcoffea.modules.remote_environment` before launching any runs.
+4. When you are ready for an end-to-end smoke test, follow the links at the end
+   of this page to the Run‑2 quickstart and plotting sections.
 
 ## Quick workflow walkthrough
 


### PR DESCRIPTION
### Summary

This PR completes the 6B.* docs reorg series for `topeft`. It:

- Establishes a clear landing flow (`README.md` → `docs/workflow_and_yaml_hub.md` → `docs/quickstart_run2.md` / `docs/quickstart_top22_006.md`).
- Documents the Run-2 workflow architecture and metadata entry points in one place.
- Demotes older READMEs and quickstarts to clearly labeled legacy/archival status so new users don’t bounce between overlapping guides.

All changes are documentation-only; no code or behaviour changes.

---

### Highlights

**1. New “start here” path**

- Rewrites the top of `README.md` to point newcomers at the new **workflow and YAML hub** and the docs index instead of an inline wall of environment instructions.
- Treats the `topeft/topeft` directory as a normal Python package and briefly describes the environment + sibling `topcoffea` setup, pushing detailed guidance into dedicated docs.
- Adds a “Related docs” section in `README.md` to steer readers to:
  - `docs/workflow_and_yaml_hub.md`
  - `docs/index.md`
  - `docs/taskvine_workflow.md`
  - `docs/run2_scenarios.md`

**2. Workflow & quickstart track**

- `docs/workflow_and_yaml_hub.md`
  - Now explicitly labeled **“Start here”** for new contributors.
  - Adds a “Before you begin” checklist (shared `coffea2025` environment, editable `topeft` + `topcoffea`, TaskVine env packaging).
  - Keeps the YAML/RunConfig merge story, executor choices, and pointers to quickstarts.

- `docs/quickstart_run2.md`
  - Reframed as **the single primary Run-2 quickstart**: “small job end-to-end: env → run helper/wrapper → first plot”.
  - Assumes the hub has already been read and focuses on:
    - Picking a sample manifest (JSON / cfg / directory).
    - Running `python -m topeft.quickstart …` with a small futures job.
    - Using `analysis/topeft_run2/full_run.sh` for “real” runs (TaskVine or futures).
    - Turning the tuple-keyed pickle into plots with `make_cr_and_sr_plots.py` or notebook helpers.

- `docs/quickstart_top22_006.md`
  - Now explicitly *builds on* `quickstart_run2.md` + the hub.
  - Drops duplicated environment instructions in favour of:
    - “Read hub + Run-2 quickstart first.”
    - Then: how to launch the TOP-22-006 SR/CR passes using the shared Run-2 YAML presets.
  - Clarifies how to test metadata changes via cloned `metadata.yml` and `metadata:` overrides committed alongside presets.

**3. Architecture & metadata documentation**

- `docs/analysis_processing.md`
  - Adds an **“Architecture overview”** section describing:
    - `RunConfigBuilder` merging CLI + YAML into `RunConfig`.
    - `RunWorkflow` stages: `SampleLoader`, `ChannelPlanner`, `HistogramPlanner`.
    - `ExecutorFactory` wiring to futures / iterative / TaskVine.
    - Tuple-keyed histogram outputs `(variable, channel, application, sample, systematic)` and how they flow into plotting helpers.
  - Points the tuple-key reference to the local `tuple_key_audit.md` instead of the external `topcoffea` link.
  - Updates the configuration example to use `analysis/topeft_run2/configs/fullR2_run.yml:sr` and notes that `--options` is authoritative aside from a small set of workload overrides.

- `docs/dataclasses_and_metadata.md`
  - Adds a **“Metadata editing checklist”** for Run-2:
    - Where to edit (`params/metadata.yml` clone, `analysis/metadata/run2_scenarios.yaml`, linked YAML configs).
    - How to validate (`scratch/validate_run2_*_step5.py` helpers).
    - How to smoke-test the workflow (`quickstart_run2.md`, `full_run.sh`, `--dry-run` → small futures pass).
    - How to share experimental configs via dedicated `*_dev.yml` presets.

- `docs/run_analysis_configuration.md`
  - Updates examples to use `configs/fullR2_run.yml:sr`.
  - Adds a `CLI vs YAML precedence` note clarifying:
    - `--options` merges defaults + selected profile + top-level keys *before* CLI flags.
    - Workload knobs (`--executor`, `--chunksize`, `--nchunks`) are still honoured.
    - All “semantic” config (metadata/scenarios/regions) should live in YAML; `full_run.sh` follows the same rules.

**4. Documentation map and legacy separation**

- `docs/index.md`
  - Reorganized into stable tracks:
    - **Landing & quickstart** – hub, Run-2 quickstart, legacy plotting appendix, TOP-22-006 quickstart.
    - **Running analyses** – configuration flow, CLI/YAML reference, TaskVine workflow, environment packaging.
    - **Metadata & scenarios** – dataclasses, Run-2 scenarios, sample metadata reference.
    - **Architecture & internals** – workflow/processor reference, tuple key audit, Run-2 developer notes.
    - **Legacy / archival** – clearly labeled links to directory READMEs and retired backends.
  - Removes all “slated for 6B.*”/roadmap breadcrumbs and describes the docs layout as the current source of truth.

**5. Legacy / archival docs**

- `docs/run_and_plot_quickstart.md`
  - Converted into **“Run and plot quickstart (legacy appendix)”**:
    - Big banner: “Legacy appendix – follow `quickstart_run2.md` for the supported workflow.”
    - Content trimmed to *only* extra plotting tips:
      - Re-running `make_cr_and_sr_plots.py` with different tags/eras.
      - Inspecting tuple summaries with `materialise_tuple_dict`.
    - Explicitly calls out that the canonical Run-2 quickstart now lives in `docs/quickstart_run2.md`.

- `analysis/topeft_run2/README.md`
  - Marked as **“topEFT (legacy directory README)”**.
  - Adds a short banner directing readers to:
    - `docs/workflow_and_yaml_hub.md`
    - `docs/quickstart_run2.md`
  - Keeps the historic script notes for anyone spelunking the old layout.

- `README_WORKQUEUE.md`
  - Retitled to **“Distributed execution with TaskVine (archival notes)”**.
  - Banner explains it captures historical TaskVine/Work Queue guidance.
  - Points users to:
    - `docs/taskvine_workflow.md` for current distributed execution docs.
    - `docs/index.md` / hub for the main flow.

- `README_FITTING.md`
  - Retitled to **“How to fit the results (archival reference)”**.
  - Banner clarifies it preserves historic datacard/fit notes while the main analysis workflow is documented under:
    - `docs/workflow_and_yaml_hub.md`
    - `docs/quickstart_run2.md`
    - `docs/index.md`.

---

### Files of interest

Key docs updated in this PR include:

- Top-level:
  - `README.md`
  - `README_WORKQUEUE.md`
  - `README_FITTING.md`
- Run-2 analysis docs:
  - `docs/workflow_and_yaml_hub.md`
  - `docs/index.md`
  - `docs/quickstart_run2.md`
  - `docs/run_and_plot_quickstart.md`
  - `docs/quickstart_top22_006.md`
  - `docs/analysis_processing.md`
  - `docs/dataclasses_and_metadata.md`
  - `docs/run_analysis_configuration.md`
- Run-2 directory README:
  - `analysis/topeft_run2/README.md`

(See individual commits for finer-grained diffs.)

---

### Testing

- Not run (docs-only changes).