### PR TITLE
Bind `taskvine` executor to DDR in Run-2 workflow

### DIFF
--- a/analysis/topeft_run2/full_run.sh
+++ b/analysis/topeft_run2/full_run.sh
@@ -25,7 +25,7 @@ set -euo pipefail
 PrintUsage() {
   cat <<'USAGE'
 Usage: full_run.sh [-y YEAR [YEAR ...]] [-t TAG] [--cr | --sr] \
-                   [--executor {taskvine,futures,iterative,ddr}] [--outdir PATH] [--manager NAME] \
+                   [--executor {taskvine,futures,iterative}] [--outdir PATH] [--manager NAME] \
                    [--samples PATH [PATH ...]] [--scenario NAME] [--log-level LEVEL] \
                    [--debug-logging] [--dry-run] [extra run_analysis args]
 
@@ -381,7 +381,7 @@ main() {
     executor="taskvine"
   fi
 
-  if [[ "$executor" != "taskvine" && "$executor" != "futures" && "$executor" != "iterative" && "$executor" != "ddr" ]]; then
+  if [[ "$executor" != "taskvine" && "$executor" != "futures" && "$executor" != "iterative" ]]; then
     echo "Error: executor must be one of taskvine, futures, or iterative (got '$executor')" >&2
     return 1
   fi

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -73,10 +73,7 @@ logger = logging.getLogger(__name__)
 
 remote_environment = topcoffea.modules.remote_environment
 
-EXECUTOR_ALIASES = {
-    "taskvine_ddr": "ddr",
-    "work_queue": "taskvine",
-}
+SUPPORTED_EXECUTORS: tuple[str, ...] = ("futures", "iterative", "taskvine")
 
 
 EXECUTOR_CLI = ExecutorCLIHelper(
@@ -317,12 +314,19 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def _normalize_executor_name(value: str | None) -> str:
-    """Return a normalized executor identifier after applying aliases."""
+    """Return a canonical executor identifier without applying aliases."""
 
-    normalized = (value or "").strip().lower()
-    if not normalized:
-        return ""
-    return EXECUTOR_ALIASES.get(normalized, normalized)
+    return (value or "").strip().lower()
+
+
+def _ensure_supported_executor(value: str) -> None:
+    """Raise an error when ``value`` is not a supported executor."""
+
+    if value and value not in SUPPORTED_EXECUTORS:
+        raise ValueError(
+            f"Unsupported executor '{value}'. "
+            f"Valid options are: {', '.join(SUPPORTED_EXECUTORS)}."
+        )
 
 
 def _resolve_logging_controls(config: RunConfig) -> tuple[str, bool]:
@@ -479,6 +483,7 @@ def main(argv: Sequence[str] | None = None) -> None:
         current_executor = executor_choice
     elif not current_executor:
         current_executor = executor_choice
+    _ensure_supported_executor(current_executor)
     config.executor = current_executor
     logger.info(
         "Using executor: %s | chunksize=%s | maxchunks=%s",

--- a/analysis/topeft_run2/workflow.py
+++ b/analysis/topeft_run2/workflow.py
@@ -102,7 +102,7 @@ if TYPE_CHECKING:  # pragma: no cover - used only for type checking
     from topeft.modules.channel_metadata import ChannelMetadataHelper
     from topeft.modules.systematics import SystematicsHelper
 
-LST_OF_KNOWN_EXECUTORS = ["futures", "iterative", "taskvine", "ddr"]
+LST_OF_KNOWN_EXECUTORS = ["futures", "iterative", "taskvine"]
 
 
 @dataclass(frozen=True)
@@ -1040,13 +1040,13 @@ class RunWorkflow:
             from topcoffea.modules import dynamic_data_reduction as ddr_helpers
         except ImportError as exc:  # pragma: no cover - dependency guard
             raise RuntimeError(
-                "The 'ddr' executor requires topcoffea.modules.dynamic_data_reduction. "
+                "The 'taskvine' executor requires topcoffea.modules.dynamic_data_reduction. "
                 "Update the topcoffea checkout to include tc/feat-ddr-helpers."
             ) from exc
 
         from coffea.nanoevents import NanoAODSchema
 
-        context = self._executor_factory.taskvine_context("ddr")
+        context = self._executor_factory.taskvine_context("taskvine")
         data = ddr_helpers.build_ddr_data_from_flist(
             flist,
             object_path=self._config.treename or "Events",
@@ -1060,10 +1060,10 @@ class RunWorkflow:
             ecut_threshold=ecut_threshold,
         )
         if not processors:
-            logger.warning("DDR executor selected but no histogram tasks were constructed; returning empty output.")
+            logger.warning("TaskVine executor selected but no histogram tasks were constructed; returning empty output.")
             return {}
 
-        logger.info("[ddr] Launching CoffeaDynamicDataReduction with %d processors", len(processors))
+        logger.info("[taskvine] Launching CoffeaDynamicDataReduction with %d processors", len(processors))
         manager = self._create_ddr_manager(context)
         log_configurator = taskvine_log_configurator(context.logs_dir)
         try:
@@ -1079,7 +1079,7 @@ class RunWorkflow:
         except Exception:
             logger.debug("DDR manager tuning failed", exc_info=True)
 
-        results_dir = context.logs_dir.parent / "ddr-results"
+        results_dir = context.logs_dir.parent / "taskvine-results"
         results_dir.mkdir(parents=True, exist_ok=True)
         ddr_kwargs = {
             "results_directory": str(results_dir),
@@ -1119,7 +1119,7 @@ class RunWorkflow:
             channel_dict = task.channel_metadata
             if not channel_dict:
                 logger.debug(
-                    "[ddr] Skipping task %s (%s/%s) due to missing channel metadata",
+                    "[taskvine] Skipping task %s (%s/%s) due to missing channel metadata",
                     idx,
                     task.sample,
                     task.clean_channel,
@@ -1129,7 +1129,7 @@ class RunWorkflow:
             sample_info = samplesdict.get(sample_name)
             if sample_info is None:
                 logger.warning(
-                    "[ddr] Skipping task %s (%s/%s) because sample is absent from samplesdict",
+                    "[taskvine] Skipping task %s (%s/%s) because sample is absent from samplesdict",
                     idx,
                     sample_name,
                     task.clean_channel,
@@ -1147,7 +1147,7 @@ class RunWorkflow:
             processor_key = self._ddr_processor_key(idx, task)
             processors[processor_key] = processor_instance
             logger.debug(
-                "[ddr] Added processor %s for sample=%s channel=%s variable=%s application=%s",
+                "[taskvine] Added processor %s for sample=%s channel=%s variable=%s application=%s",
                 processor_key,
                 task.sample,
                 task.clean_channel,
@@ -1155,7 +1155,7 @@ class RunWorkflow:
                 task.application,
             )
         logger.info(
-            "[ddr] Constructed %d processors from %d histogram tasks",
+            "[taskvine] Constructed %d processors from %d histogram tasks",
             len(processors),
             total_tasks,
         )
@@ -1262,7 +1262,14 @@ class RunWorkflow:
 
         tstart = time.time()
         executor_mode = (self._config.executor or "taskvine").strip().lower()
-        if executor_mode == "ddr":
+        allowed_executors = set(LST_OF_KNOWN_EXECUTORS)
+        if executor_mode not in allowed_executors:
+            raise ValueError(
+                f"Unsupported executor mode '{executor_mode}'. Expected one of: {', '.join(LST_OF_KNOWN_EXECUTORS)}."
+            )
+        self._config.executor = executor_mode
+
+        if executor_mode == "taskvine":
             output = self._execute_ddr(
                 histogram_plan=histogram_plan,
                 samplesdict=samplesdict,
@@ -1275,13 +1282,13 @@ class RunWorkflow:
             dt = time.time() - tstart
             if nevts_total:
                 logger.info(
-                    "[ddr] Processed %d events in %.2f seconds (%.2f evts/sec)",
+                    "[taskvine] Processed %d events in %.2f seconds (%.2f evts/sec)",
                     nevts_total,
                     dt,
                     (nevts_total / dt) if dt else 0.0,
                 )
             else:
-                logger.info("[ddr] CoffeaDynamicDataReduction finished in %.2f seconds", dt)
+                logger.info("[taskvine] CoffeaDynamicDataReduction finished in %.2f seconds", dt)
             self._store_output(output)
             return
 
@@ -1382,14 +1389,6 @@ class RunWorkflow:
             output.update(out)
 
         dt = time.time() - tstart
-
-        if self._config.executor == "taskvine" and nevts_total:
-            logger.info(
-                "Processed %d events in %.2f seconds (%.2f evts/sec)",
-                nevts_total,
-                dt,
-                (nevts_total / dt) if dt else 0.0,
-            )
 
         if self._config.executor == "futures":
             logger.info(

--- a/topeft/modules/executor_cli.py
+++ b/topeft/modules/executor_cli.py
@@ -186,7 +186,7 @@ class ExecutorCLIHelper:
             "--executor",
             "-x",
             default=self._default_executor,
-            help="Which executor to use (futures, iterative, taskvine, or ddr)",
+            help="Which executor to use (futures, iterative, or taskvine; taskvine runs via DDR)",
         )
         parser.add_argument(
             "--port",


### PR DESCRIPTION
## Summary

This PR simplifies the Run-2 executor interface and formally ties the `taskvine` executor to the Coffea Dynamic Data Reduction (DDR) path:

- Only three executors are now supported: **`futures`**, **`iterative`**, and **`taskvine`**.
- `taskvine` is the single TaskVine-style mode and **always runs via DDR**.
- Legacy aliases (`ddr`, `taskvine_ddr`, `work_queue`, etc.) are no longer accepted; invalid executor names now fail fast with a clear error.
- CLI help, `full_run.sh`, and runtime logging have been updated to reflect this “taskvine = DDR” contract.

---

## Technical changes

### `analysis/topeft_run2/run_analysis.py`

- Introduced a canonical executor set and explicit validation:

  ```python
  SUPPORTED_EXECUTORS: tuple[str, ...] = ("futures", "iterative", "taskvine")
  ```

- Kept executor normalization simple (strip + lowercase):

  ```python
  def _normalize_executor_name(value: str | None) -> str:
      return (value or "").strip().lower()
  ```

- Added `_ensure_supported_executor(...)` to reject unsupported names early:

  ```python
  def _ensure_supported_executor(value: str) -> None:
      if value and value not in SUPPORTED_EXECUTORS:
          raise ValueError(
              f"Unsupported executor '{value}'. "
              f"Valid options are: {', '.join(SUPPORTED_EXECUTORS)}."
          )
  ```

- Applied normalization + validation when resolving the effective executor in `main()`:
  - Defaults from `ExecutorCLIHelper` are normalized.
  - CLI-provided `--executor` values are normalized.
  - The final `config.executor` must be one of `futures`, `iterative`, or `taskvine`, otherwise a `ValueError` is raised.
- Removed the previous alias map (`EXECUTOR_ALIASES` with `ddr`, `taskvine_ddr`, `work_queue`), so legacy names now fail fast instead of silently mapping.

### `analysis/topeft_run2/workflow.py`

- Reduced the internal executor whitelist:

  ```python
  LST_OF_KNOWN_EXECUTORS = ["futures", "iterative", "taskvine"]
  ```

- At the top of `RunWorkflow.run()`:
  - Normalize the configured executor.
  - Enforce that it is in `LST_OF_KNOWN_EXECUTORS`, otherwise raise a `ValueError` with a clear message.
  - Persist the normalized value back into `self._config.executor` for downstream consumers.

- Bound `taskvine` to the DDR path:

  ```python
  executor_mode = (self._config.executor or "taskvine").strip().lower()
  ...
  if executor_mode == "taskvine":
      output = self._execute_ddr(...)
      ...
      self._store_output(output)
      return
  ```

- Kept `futures` and `iterative` on the existing non-DDR runner path.

- In `_execute_ddr(...)`:
  - Updated error messages to say “`taskvine` executor requires topcoffea.modules.dynamic_data_reduction” instead of “`ddr`”.
  - Request a TaskVine context under the `"taskvine"` label:

    ```python
    context = self._executor_factory.taskvine_context("taskvine")
    ```

  - Adjusted result directory naming to be TaskVine-branded:

    ```python
    results_dir = context.logs_dir.parent / "taskvine-results"
    ```

  - Renamed log tags from `[ddr]` to `[taskvine]`:

    - Skipped tasks:
      ```python
      "[taskvine] Skipping task %s ..."
      ```
    - Processor construction:
      ```python
      "[taskvine] Added processor %s ..."
      ```
    - Final planner summary:
      ```python
      "[taskvine] Constructed %d processors from %d histogram tasks"
      ```
    - Overall throughput:
      ```python
      "[taskvine] Processed %d events in %.2f seconds ... / [taskvine] CoffeaDynamicDataReduction finished in ..."
      ```

- Removed the old non-DDR TaskVine throughput block at the end of `run()`, since `taskvine` is now exclusively DDR.

### `analysis/topeft_run2/full_run.sh`

- Updated usage and validation so only the three supported executors are accepted:

  ```bash
  Usage: full_run.sh ... [--executor {taskvine,futures,iterative}] ...

  if [[ "$executor" != "taskvine" && "$executor" != "futures" && "$executor" != "iterative" ]]; then
      echo "Error: executor must be one of taskvine, futures, or iterative (got '$executor')" >&2
      return 1
  fi
  ```

- Removed any mention of `ddr` from the usage text.

### `topeft/modules/executor_cli.py`

- Clarified the CLI help message for `--executor`:

  ```python
  help="Which executor to use (futures, iterative, or taskvine; taskvine runs via DDR)"
  ```

- No behaviour changes here beyond the help text; the semantics are now aligned with the new normalization/validation in `run_analysis.py`.

---

## Behavioural impact

- **Supported executor values:**
  - ✅ `--executor futures`
  - ✅ `--executor iterative`
  - ✅ `--executor taskvine` → always uses the DDR + TaskVine path.

- **Unsupported / legacy values:**
  - ❌ `--executor ddr`
  - ❌ `--executor taskvine_ddr`
  - ❌ `--executor work_queue`
  - Any other unexpected string.

- For unsupported values, `run_analysis.py` now raises a clear `ValueError`, e.g.:

  > `Unsupported executor 'ddr'. Valid options are: futures, iterative, taskvine.`

- TaskVine logging is consistently tagged as `[taskvine]`, including DDR planning, manager creation, and throughput statistics, and results are written under a `taskvine-results` directory.

---

## Testing

Using the `coffea2025` environment:

```bash
PYTHON_ENV="/users/apiccine/work/miniconda3/envs/coffea2025/bin/python"

cd /users/apiccine/work/ChUpdate/topeft

# 1) Compile-time check
$PYTHON_ENV -m compileall analysis/topeft_run2

# 2) CLI help – ensure only futures/iterative/taskvine are advertised
PYTHONPATH="" \
$PYTHON_ENV analysis/topeft_run2/run_analysis.py --help

# 3) Negative test – legacy DDR aliases now fail fast
PYTHONPATH="" \
$PYTHON_ENV analysis/topeft_run2/run_analysis.py --executor ddr --pretend
# -> raises ValueError: Unsupported executor 'ddr'. Valid options are: futures, iterative, taskvine.
```

Additionally, a small `taskvine` run was issued (with DDR wiring active) and reached the expected external dependency error in `topcoffea.modules.dynamic_data_reduction` (missing `dynamic_data_reduction` package), confirming that:

- `taskvine` flows through the DDR code path as intended.
- Executor normalization, validation, and branching work end-to-end.

---

## Risks / notes

- **CLI breaking change:** Existing scripts or configs that still use `--executor ddr`, `taskvine_ddr`, or `work_queue` will now fail loudly instead of silently aliasing. This is intentional to enforce the new clean interface.
- **DDR dependency:** The `taskvine` mode requires `topcoffea.modules.dynamic_data_reduction` and the external `dynamic_data_reduction` package. Until that dependency is installed in the analysis and worker environments, `taskvine` runs will fail with an explicit import error.
- If new executors are added in the future, they must be:
  - Added to `SUPPORTED_EXECUTORS` in `run_analysis.py`,
  - Added to `LST_OF_KNOWN_EXECUTORS` in `workflow.py`,
  - Mentioned in `full_run.sh` and the `ExecutorCLIHelper` help string,  
  so that validation and docs stay in sync.