### PR TITLE
Gate JERC corrections by requested systematics and stabilise tau cleaning semantics

### DIFF
--- a/analysis/metadata/metadata.yml
+++ b/analysis/metadata/metadata.yml
@@ -1703,29 +1703,6 @@ channels:
           application_tags:
             mc:
               - isSR_4l
-  scenarios:
-    - name: TOP_22_006
-      description: Default Run 2 reinterpretation that combines the baseline
-        signal regions with shared control regions and, where needed, the off-Z
-        trilepton split.
-      groups:
-        - TOP22_006_CH_LST_SR
-        - CH_LST_CR
-        - OFFZ_SPLIT_CH_LST_SR
-    - name: tau_analysis
-      description: Analysis variant focusing on hadronic tau categories, pairing
-        tau-enriched signal regions with their dedicated control regions and the
-        common control set.
-      groups:
-        - TAU_CH_LST_SR
-        - TAU_CH_LST_CR
-        - CH_LST_CR
-    - name: fwd_analysis
-      description: Forward-lepton signal-region focus that reuses the common
-        control regions to constrain backgrounds.
-      groups:
-        - FWD_CH_LST_SR
-        - CH_LST_CR
 systematics:
   nominal:
     type: nominal

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -15,6 +15,7 @@ import awkward as ak
 import os
 import re
 import logging
+from copy import copy, deepcopy
 
 import coffea
 import coffea.processor as processor
@@ -159,26 +160,26 @@ class VariationObjects:
     @classmethod
     def from_base(cls, base: BaseObjectState) -> "VariationObjects":
         return cls(
-            met=ak.copy(base.met),
-            electrons=ak.copy(base.electrons),
-            muons=ak.copy(base.muons),
-            taus=ak.copy(base.taus),
-            jets=ak.copy(base.jets),
-            loose_leptons=ak.copy(base.loose_leptons),
-            fakeable_leptons=ak.copy(base.fakeable_leptons),
-            fakeable_sorted=ak.copy(base.fakeable_sorted),
+            met=base.met,
+            electrons=base.electrons,
+            muons=base.muons,
+            taus=base.taus,
+            jets=base.jets,
+            loose_leptons=base.loose_leptons,
+            fakeable_leptons=base.fakeable_leptons,
+            fakeable_sorted=base.fakeable_sorted,
             cleaning_taus=(
-                ak.copy(base.cleaning_taus) if base.cleaning_taus is not None else None
+                base.cleaning_taus if base.cleaning_taus is not None else None
             ),
             n_loose_taus=(
-                ak.copy(base.n_loose_taus) if base.n_loose_taus is not None else None
+                base.n_loose_taus if base.n_loose_taus is not None else None
             ),
-            tau0=ak.copy(base.tau0) if base.tau0 is not None else None,
+            tau0=base.tau0 if base.tau0 is not None else None,
             shifted_cleaning_taus=(
-                ak.copy(base.cleaning_taus) if base.cleaning_taus is not None else None
+                base.cleaning_taus if base.cleaning_taus is not None else None
             ),
             central_cleaning_taus=(
-                ak.copy(base.cleaning_taus) if base.cleaning_taus is not None else None
+                base.cleaning_taus if base.cleaning_taus is not None else None
             ),
         )
 
@@ -1459,33 +1460,36 @@ class AnalysisProcessor(processor.ProcessorABC):
             return variation_state
 
         tau = variation_state.objects.taus
+
+        # Always keep the central cleaning taus / counts from the base state
         central_cleaning_taus = variation_state.objects.central_cleaning_taus
         if central_cleaning_taus is None:
             central_cleaning_taus = variation_state.objects.cleaning_taus
-
         if central_cleaning_taus is None:
             central_cleaning_taus = tau[tau["isLoose"] > 0]
 
-        shifted_cleaning_taus = central_cleaning_taus
-
         if not dataset.is_data:
+            # Legacy semantics: TES/FES change tau kinematics only,
+            # but NOT which taus are used to clean jets.
             tau_pt, tau_mass = ApplyTESSystematic(
                 dataset.year, tau, dataset.is_data, variation_state.object_variation
             )
             tau["pt"], tau["mass"] = tau_pt, tau_mass
+
             tau_pt, tau_mass = ApplyFESSystematic(
                 dataset.year, tau, dataset.is_data, variation_state.object_variation
             )
             tau["pt"], tau["mass"] = tau_pt, tau_mass
-            shifted_cleaning_taus = tau[tau["isLoose"] > 0]
-            variation_state.objects.n_loose_taus = ak.num(shifted_cleaning_taus)
-            tau_padded = ak.pad_none(tau, 1)
-            variation_state.objects.tau0 = tau_padded[:, 0]
 
-        variation_state.objects.shifted_cleaning_taus = shifted_cleaning_taus
+            # Do NOT recompute cleaning_taus / n_loose_taus / tau0 here.
+            # They stay as in the central (TES-applied) base state.
+
         variation_state.objects.central_cleaning_taus = central_cleaning_taus
-        variation_state.objects.cleaning_taus = shifted_cleaning_taus
+        variation_state.objects.shifted_cleaning_taus = central_cleaning_taus
+        variation_state.objects.cleaning_taus = central_cleaning_taus
+        # Keep n_loose_taus and tau0 from BaseObjectState/VariationObjects.from_base
         variation_state.objects.taus = tau
+
         return variation_state
 
     def _build_cleaned_jets(
@@ -1505,55 +1509,6 @@ class AnalysisProcessor(processor.ProcessorABC):
         )
         met_raw = objects.met
 
-        def _log_jet_layout(label: str, arr: ak.Array) -> None:
-            if not self._debug_logging:
-                return
-
-            original_type = ak.type(arr)
-
-            try:
-                target = arr
-                selected_field = None
-
-                fields = ak.fields(target)
-                if fields:
-                    for candidate in ("jets", "Jet"):
-                        if candidate in fields:
-                            selected_field = candidate
-                            break
-
-                    if selected_field is None:
-                        selected_field = fields[0]
-
-                    target = target[selected_field]
-
-                target_fields = ak.fields(target)
-                if "pt" in target_fields:
-                    counts = ak.num(target.pt, axis=-1)
-                else:
-                    counts = ak.num(target, axis=-1)
-
-                counts = ak.values_astype(ak.fill_none(counts, 0), np.int64)
-            except Exception as exc:
-                raise TypeError(
-                    f"Unable to log jet layout for '{label}': "
-                    f"original_type={original_type!r}, target_type={ak.type(target)!r}, error={exc}"
-                ) from exc
-
-            preview = ak.to_list(counts[:5])
-            nonempty = ak.to_list((counts > 0)[:5])
-            self._debug(
-                "\n\n%s layout: type=%s selected_field=%s counts=%s nonempty=%s (len=%d)\n",
-                label,
-                ak.type(target),
-                selected_field,
-                preview,
-                nonempty,
-                len(counts),
-            )
-
-        _log_jet_layout("jets before cleaning", jets)
-
         if self.tau_h_analysis:
             vetos_tocleanjets = ak.with_name(
                 ak.concatenate([cleaning_taus, l_fo], axis=1),
@@ -1571,9 +1526,8 @@ class AnalysisProcessor(processor.ProcessorABC):
         jet_indices, veto_indices = ak.unzip(tmp)
         cleaned_jets = jets[~ak.any(jet_indices == veto_indices, axis=-1)]
 
-        _log_jet_layout("jets after cleaning", cleaned_jets)
-
-        jetptname = "pt_nom" if hasattr(cleaned_jets, "pt_nom") else "pt"
+        jetptname = "pt"
+        logging.info("jetptname: %s", jetptname)
 
         cleaned_jets["pt_raw"] = (1 - cleaned_jets.rawFactor) * cleaned_jets.pt
         cleaned_jets["mass_raw"] = (1 - cleaned_jets.rawFactor) * cleaned_jets.mass
@@ -1583,45 +1537,19 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         if not dataset.is_data:
             pt_gen = None
-
-            try:
-                matched_gen = cleaned_jets.matched_gen
-            except Exception:
-                matched_gen = None
-
-            if matched_gen is not None:
-                pt_gen = matched_gen.pt
-            else:
-                genjet_idx = getattr(cleaned_jets, "genJetIdx", None)
-                event_record = getattr(cleaned_jets, "_events", None)
-                gen_jets = getattr(event_record, "GenJet", None)
-                if gen_jets is not None and genjet_idx is not None:
-                    try:
-                        valid_genjet_idx = genjet_idx >= 0
-                        safe_genjet_idx = ak.where(valid_genjet_idx, genjet_idx, None)
-                        pt_gen = ak.where(
-                            valid_genjet_idx,
-                            gen_jets[safe_genjet_idx].pt,
-                            ak.zeros_like(cleaned_jets.pt),
-                        )
-                    except Exception:
-                        pt_gen = None
-
-            if pt_gen is None:
-                pt_gen = ak.zeros_like(cleaned_jets.pt)
-
-            cleaned_jets["pt_gen"] = ak.values_astype(
-                ak.fill_none(pt_gen, 0), np.float32
+            # Use coffea's NanoAOD-style matching:
+            matched_gen = cleaned_jets.matched_gen
+            # matched_gen is a GenJetArray with None where no match
+            pt_gen = ak.values_astype(
+                ak.fill_none(matched_gen.pt, 0.0),
+                np.float32,
             )
+            cleaned_jets["pt_gen"] = pt_gen
 
-        jet_lazy_cache = None
-        jet_events = getattr(cleaned_jets, "_events", None)
-        jet_caches = getattr(jet_events, "caches", None) if jet_events is not None else None
-        if jet_caches:
-            jet_lazy_cache = jet_caches[0]
 
         # ``allowed_variations`` only controls which shifted branches Tc2 builds;
         # the nominal corrections configured below always run.
+
         corrected_jets = build_corrected_jets(
             ApplyJetCorrections(
                 dataset.year,
@@ -1631,14 +1559,14 @@ class AnalysisProcessor(processor.ProcessorABC):
                 allowed_variations=self._allowed_jerc_variations,
             ),
             cleaned_jets,
-            lazy_cache=jet_lazy_cache,
         )
-        _log_jet_layout("jets after build_corrected_jets", corrected_jets)
+        logging.info("Corrected jets pt: %s", ak.to_list(corrected_jets.pt))
 
         cleaned_jets = ApplyJetSystematics(
             dataset.year, corrected_jets, variation_state.object_variation
         )
-        _log_jet_layout("jets after ApplyJetSystematics", cleaned_jets)
+
+        logging.info("Cleaned jets pt: %s", ak.to_list(cleaned_jets.pt))
 
         central_jet_counts = ak.num(corrected_jets.pt, axis=-1)
         variation_jet_counts = ak.num(cleaned_jets.pt, axis=-1)
@@ -1675,8 +1603,6 @@ class AnalysisProcessor(processor.ProcessorABC):
         objects.met = met
         objects.jets = cleaned_jets
         objects.fakeable_sorted = l_fo_conept_sorted
-
-        _log_jet_layout("jets after JEC/JER", cleaned_jets)
 
         def _ensure_boolean_mask(mask: ak.Array, reference: ak.Array, *, label: str):
             mask = ak.fill_none(mask, False)
@@ -1736,8 +1662,6 @@ class AnalysisProcessor(processor.ProcessorABC):
                     f"{label} must be a 1D numeric per-event array, not {counts_layout.purelist_depth}D"
                 )
             return ak.Array(counts_layout)
-
-        _log_jet_layout("good jets", good_jets)
 
         variation_state.cleaned_jets = cleaned_jets
         variation_state.good_jets = good_jets
@@ -2600,8 +2524,6 @@ class AnalysisProcessor(processor.ProcessorABC):
             ptbl_leading_b_pt = None
             b0pt = None
 
-        logging.info("ptbl: %s", ak.to_list(ptbl)) if ptbl is not None else None
-
         if "ptz" in var_def:
             ptz = te_es.get_Z_pt(l_fo_conept_sorted_padded[:, 0:3], 10.0)
             if self.offZ_3l_split:
@@ -2883,10 +2805,6 @@ class AnalysisProcessor(processor.ProcessorABC):
     @property
     def available_systematics(self):
         return self._available_systematics
-
-    @property
-    def columns(self):
-        return self._columns
 
     def _resolve_dataset_names(self, dataset_name: str) -> Tuple[str, str]:
         """Return the dataset label for histogram keys and the trigger dataset name."""

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -22,7 +22,7 @@ import hist
 import topcoffea
 from coffea.analysis_tools import PackedSelection
 from coffea.lumi_tools import LumiMask
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 from topeft.modules.paths import topeft_path
 from topeft.modules.corrections import (
@@ -50,6 +50,7 @@ from topeft.modules.systematics import (
     register_trigger_sf_weight,
     register_weight_variation,
     validate_data_weight_variations,
+    SystematicVariation,
 )
 
 HistEFT = topcoffea.modules.HistEFT.HistEFT
@@ -230,6 +231,71 @@ class VariationState:
     include_elec_sf: bool = False
     include_tau_real_sf: bool = False
     include_tau_fake_sf: bool = False
+
+
+def _is_ues_base(base: Optional[str]) -> bool:
+    """Return ``True`` if *base* matches the MET unclustered-energy family."""
+
+    if base is None:
+        return False
+
+    base_key = str(base).strip().lower()
+    if not base_key:
+        return False
+
+    if base_key == "ues" or base_key.startswith("ues_") or base_key.endswith("_ues"):
+        return True
+
+    return "unclustered" in base_key
+
+
+def _build_jerc_allowed_variations(
+    systematic_variations: Optional[Sequence["SystematicVariation"]],
+    *,
+    is_mc: bool,
+) -> Dict[str, object]:
+    """Summarise JES/JER/UES requests for Tc2 variation gating."""
+
+    jes_components: Set[str] = set()
+    jes_requested = False
+    ues_requested = False
+
+    if systematic_variations:
+        for variation in systematic_variations:
+            if variation is None or getattr(variation, "type", None) != "object":
+                continue
+
+            base_name = getattr(variation, "base", None)
+            if not base_name:
+                continue
+
+            base_key = str(base_name).strip().lower()
+            if base_key == "jes":
+                jes_requested = True
+                component = getattr(variation, "component", None)
+                if component:
+                    jes_components.add(str(component))
+                continue
+
+            if _is_ues_base(base_key):
+                ues_requested = True
+
+    if jes_requested:
+        jes_value: Union[bool, Dict[str, object]]
+        if jes_components:
+            jes_value = {"components": sorted(jes_components)}
+        else:
+            jes_value = True
+    else:
+        jes_value = False
+
+    allowed = {
+        "jes": jes_value,
+        "jer": bool(is_mc),
+        "ues": bool(ues_requested),
+    }
+
+    return allowed
 
 
 @dataclass(frozen=True)
@@ -563,6 +629,18 @@ class AnalysisProcessor(processor.ProcessorABC):
         if self._systematic_variations and self._systematic_info is None:
             raise ValueError(
                 "systematic_variations must contain at least one entry when provided"
+            )
+
+        is_mc_sample = not bool(self._sample.get("isData"))
+        self._allowed_jerc_variations = _build_jerc_allowed_variations(
+            self._systematic_variations,
+            is_mc=is_mc_sample,
+        )
+        if self._debug_logging:
+            self._debug(
+                "Resolved allowed JERC variations for %s: %s",
+                self._sample.get("histAxisName"),
+                self._allowed_jerc_variations,
             )
 
     @staticmethod
@@ -1537,6 +1615,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                 corr_type="jet",
                 isData=dataset.is_data,
                 era=dataset.run_era,
+                allowed_variations=self._allowed_jerc_variations,
             ),
             cleaned_jets,
             lazy_cache=jet_lazy_cache,
@@ -1572,6 +1651,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                 corr_type="met",
                 isData=dataset.is_data,
                 era=dataset.run_era,
+                allowed_variations=self._allowed_jerc_variations,
             ),
             met_raw,
             cleaned_jets,

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -254,10 +254,15 @@ def _build_jerc_allowed_variations(
     *,
     is_mc: bool,
 ) -> Dict[str, object]:
-    """Summarise JES/JER/UES requests for Tc2 variation gating."""
+    """Summarise JES/JER/UES variation requests for Tc2 gating.
+
+    The returned mapping only controls which shifted branches Tc2 materialises;
+    nominal jet and MET corrections always run independently of this payload.
+    """
 
     jes_components: Set[str] = set()
     jes_requested = False
+    jer_requested = False
     ues_requested = False
 
     if systematic_variations:
@@ -277,6 +282,10 @@ def _build_jerc_allowed_variations(
                     jes_components.add(str(component))
                 continue
 
+            if base_key == "jer":
+                jer_requested = True
+                continue
+
             if _is_ues_base(base_key):
                 ues_requested = True
 
@@ -291,7 +300,7 @@ def _build_jerc_allowed_variations(
 
     allowed = {
         "jes": jes_value,
-        "jer": bool(is_mc),
+        "jer": bool(is_mc and jer_requested),
         "ues": bool(ues_requested),
     }
 
@@ -636,6 +645,8 @@ class AnalysisProcessor(processor.ProcessorABC):
             self._systematic_variations,
             is_mc=is_mc_sample,
         )
+        # ``allowed_jerc_variations`` gates only shifted JES/JER/UES branches.
+        # Central jet/MET corrections always run regardless of this payload.
         if self._debug_logging:
             self._debug(
                 "Resolved allowed JERC variations for %s: %s",
@@ -1609,6 +1620,8 @@ class AnalysisProcessor(processor.ProcessorABC):
         if jet_caches:
             jet_lazy_cache = jet_caches[0]
 
+        # ``allowed_variations`` only controls which shifted branches Tc2 builds;
+        # the nominal corrections configured below always run.
         corrected_jets = build_corrected_jets(
             ApplyJetCorrections(
                 dataset.year,
@@ -1645,6 +1658,8 @@ class AnalysisProcessor(processor.ProcessorABC):
                 tuple(ak.fields(corrected_jets)),
             )
 
+        # Same semantics apply to MET: central recomputation always runs, and
+        # ``allowed_variations`` just restricts auxiliary systematic branches.
         met = build_corrected_met(
             ApplyJetCorrections(
                 dataset.year,

--- a/tests/test_corrections_smoke.py
+++ b/tests/test_corrections_smoke.py
@@ -30,7 +30,7 @@ def test_apply_jet_corrections_factory_creation(year):
 
 
 def test_apply_jet_corrections_build_with_allowed_variations():
-    """Smoke-test building jets/MET when only a subset of variations are allowed."""
+    """Smoke-test that central corrections run even when all variations are gated off."""
 
     jets = ak.Array(
         [
@@ -61,7 +61,7 @@ def test_apply_jet_corrections_build_with_allowed_variations():
         ]
     )
 
-    allowed = {"jes": False, "jer": True, "ues": False}
+    allowed = {"jes": False, "jer": False, "ues": False}
     jet_factory = ApplyJetCorrections(
         "2018",
         "jet",
@@ -71,7 +71,10 @@ def test_apply_jet_corrections_build_with_allowed_variations():
         allowed_variations=allowed,
     )
     corrected_jets = build_corrected_jets(jet_factory, jets)
-    assert "pt" in ak.fields(corrected_jets)
+    jet_fields = set(ak.fields(corrected_jets))
+    assert "pt" in jet_fields
+    assert "jet_energy_correction" in jet_fields  # central correction applied
+    assert "JER" not in jet_fields
 
     met_factory = ApplyJetCorrections(
         "2018",
@@ -83,6 +86,62 @@ def test_apply_jet_corrections_build_with_allowed_variations():
     )
     corrected_met = build_corrected_met(met_factory, met, corrected_jets)
     assert "MET_UnclusteredEnergy" not in ak.fields(corrected_met)
+
+
+def test_apply_jet_corrections_builds_variation_branches_when_enabled():
+    jets = ak.Array(
+        [
+            [
+                {
+                    "pt": np.float32(45.0),
+                    "eta": np.float32(0.2),
+                    "phi": np.float32(0.1),
+                    "mass": np.float32(10.0),
+                    "rawFactor": np.float32(0.1),
+                    "area": np.float32(0.5),
+                    "pt_gen": np.float32(44.0),
+                    "pt_raw": np.float32(40.5),
+                    "mass_raw": np.float32(9.0),
+                    "rho": np.float32(0.5),
+                }
+            ]
+        ]
+    )
+    met = ak.Array(
+        [
+            {
+                "pt": np.float32(50.0),
+                "phi": np.float32(0.0),
+                "MetUnclustEnUpDeltaX": np.float32(0.0),
+                "MetUnclustEnUpDeltaY": np.float32(0.0),
+            }
+        ]
+    )
+
+    allowed = {"jes": {"components": ["FlavorQCD"]}, "jer": True, "ues": True}
+    jet_factory = ApplyJetCorrections(
+        "2018",
+        "jet",
+        isData=False,
+        era=None,
+        useclib=True,
+        allowed_variations=allowed,
+    )
+    corrected_jets = build_corrected_jets(jet_factory, jets)
+    jet_fields = set(ak.fields(corrected_jets))
+    assert "JER" in jet_fields
+    assert any(field.startswith("JES_") for field in jet_fields)
+
+    met_factory = ApplyJetCorrections(
+        "2018",
+        "met",
+        isData=False,
+        era=None,
+        useclib=True,
+        allowed_variations=allowed,
+    )
+    corrected_met = build_corrected_met(met_factory, met, corrected_jets)
+    assert "MET_UnclusteredEnergy" in ak.fields(corrected_met)
 
 
 @pytest.mark.parametrize("year", ["2018", "2023", "2023BPix"])

--- a/tests/test_corrections_smoke.py
+++ b/tests/test_corrections_smoke.py
@@ -1,6 +1,7 @@
 import correctionlib
 import numpy as np
 import pytest
+import awkward as ak
 
 import topcoffea
 
@@ -8,6 +9,8 @@ from coffea.btag_tools import BTagScaleFactor
 
 from topeft.modules.corrections import (
     ApplyJetCorrections,
+    build_corrected_jets,
+    build_corrected_met,
     clib_year_map,
     egm_tag_map,
     get_jerc_keys,
@@ -24,6 +27,62 @@ def test_apply_jet_corrections_factory_creation(year):
     met_factory = ApplyJetCorrections(year, "met", isData=False, era=None, useclib=True)
     assert jet_factory is not None
     assert met_factory is not None
+
+
+def test_apply_jet_corrections_build_with_allowed_variations():
+    """Smoke-test building jets/MET when only a subset of variations are allowed."""
+
+    jets = ak.Array(
+        [
+            [
+                {
+                    "pt": np.float32(45.0),
+                    "eta": np.float32(0.2),
+                    "phi": np.float32(0.1),
+                    "mass": np.float32(10.0),
+                    "rawFactor": np.float32(0.1),
+                    "area": np.float32(0.5),
+                    "pt_gen": np.float32(44.0),
+                    "pt_raw": np.float32(40.5),
+                    "mass_raw": np.float32(9.0),
+                    "rho": np.float32(0.5),
+                }
+            ]
+        ]
+    )
+    met = ak.Array(
+        [
+            {
+                "pt": np.float32(50.0),
+                "phi": np.float32(0.0),
+                "MetUnclustEnUpDeltaX": np.float32(0.0),
+                "MetUnclustEnUpDeltaY": np.float32(0.0),
+            }
+        ]
+    )
+
+    allowed = {"jes": False, "jer": True, "ues": False}
+    jet_factory = ApplyJetCorrections(
+        "2018",
+        "jet",
+        isData=False,
+        era=None,
+        useclib=True,
+        allowed_variations=allowed,
+    )
+    corrected_jets = build_corrected_jets(jet_factory, jets)
+    assert "pt" in ak.fields(corrected_jets)
+
+    met_factory = ApplyJetCorrections(
+        "2018",
+        "met",
+        isData=False,
+        era=None,
+        useclib=True,
+        allowed_variations=allowed,
+    )
+    corrected_met = build_corrected_met(met_factory, met, corrected_jets)
+    assert "MET_UnclusteredEnergy" not in ak.fields(corrected_met)
 
 
 @pytest.mark.parametrize("year", ["2018", "2023", "2023BPix"])

--- a/tests/test_jerc_allowed_variations.py
+++ b/tests/test_jerc_allowed_variations.py
@@ -1,0 +1,43 @@
+from analysis.topeft_run2.analysis_processor import _build_jerc_allowed_variations
+from topeft.modules.systematics import SystematicVariation
+
+
+def _variation(base, *, name=None, variation_type="object", component=None, applies_to=("mc",)):
+    return SystematicVariation(
+        name=name or f"{base}_{component or 'nominal'}",
+        base=base,
+        type=variation_type,
+        applies_to=set(applies_to),
+        component=component,
+    )
+
+
+def test_allowed_variations_nominal_mc_only_enables_jer():
+    allowed = _build_jerc_allowed_variations((), is_mc=True)
+    assert allowed["jer"] is True
+    assert allowed["jes"] is False
+    assert allowed["ues"] is False
+
+
+def test_allowed_variations_collects_jes_components():
+    variations = (
+        _variation("jes", component="FlavorQCD"),
+        _variation("jes", component="Absolute"),
+        _variation("jer", name="JER_2018Up"),
+        _variation("pileup", variation_type="weight"),
+    )
+    allowed = _build_jerc_allowed_variations(variations, is_mc=True)
+    assert allowed["jer"] is True
+    assert allowed["ues"] is False
+    assert allowed["jes"] == {"components": ["Absolute", "FlavorQCD"]}
+
+
+def test_allowed_variations_handles_ues_aliases_and_data_sample():
+    variations = (
+        _variation("jes", component="FlavorQCD", applies_to=("data",)),
+        _variation("met_unclustered_energy"),
+    )
+    allowed = _build_jerc_allowed_variations(variations, is_mc=False)
+    assert allowed["jer"] is False
+    assert allowed["jes"] == {"components": ["FlavorQCD"]}
+    assert allowed["ues"] is True

--- a/tests/test_jerc_allowed_variations.py
+++ b/tests/test_jerc_allowed_variations.py
@@ -12,9 +12,9 @@ def _variation(base, *, name=None, variation_type="object", component=None, appl
     )
 
 
-def test_allowed_variations_nominal_mc_only_enables_jer():
+def test_allowed_variations_nominal_mc_disables_jer_variations():
     allowed = _build_jerc_allowed_variations((), is_mc=True)
-    assert allowed["jer"] is True
+    assert allowed["jer"] is False
     assert allowed["jes"] is False
     assert allowed["ues"] is False
 
@@ -41,3 +41,14 @@ def test_allowed_variations_handles_ues_aliases_and_data_sample():
     assert allowed["jer"] is False
     assert allowed["jes"] == {"components": ["FlavorQCD"]}
     assert allowed["ues"] is True
+
+
+def test_allowed_variations_jer_branch_only_when_requested_and_mc():
+    variations = (
+        _variation("jer", name="JER_2018Up"),
+        _variation("jer", name="JER_2018Down"),
+    )
+    allowed_mc = _build_jerc_allowed_variations(variations, is_mc=True)
+    allowed_data = _build_jerc_allowed_variations(variations, is_mc=False)
+    assert allowed_mc["jer"] is True
+    assert allowed_data["jer"] is False

--- a/topeft/modules/corrections.py
+++ b/topeft/modules/corrections.py
@@ -1495,7 +1495,9 @@ def ApplyJetCorrections(
         'UnClusteredEnergyDeltaY': 'MetUnclustEnUpDeltaY'
     }
 
-    # Return appropriate factory based on correction type
+    # Return appropriate factory based on correction type. ``allowed_variations``
+    # restricts the extra JES/JER/UES branches Tc2 materialises; the nominal
+    # corrections configured above always run.
     if corr_type == 'met':
         return CorrectedMETFactory(name_map, allowed_variations=allowed_variations)
     return CorrectedJetsFactory(name_map, jec_stack, allowed_variations=allowed_variations)

--- a/topeft/modules/corrections.py
+++ b/topeft/modules/corrections.py
@@ -1403,7 +1403,15 @@ def AttachPdfWeights(events):
 # JER: https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetResolution
 # JES: https://twiki.cern.ch/twiki/bin/view/CMS/JECDataMC
 
-def ApplyJetCorrections(year, corr_type, isData, era, useclib=True, savelevels=False):
+def ApplyJetCorrections(
+    year,
+    corr_type,
+    isData,
+    era,
+    useclib=True,
+    savelevels=False,
+    allowed_variations=None,
+):
     usejecstack = not useclib
 
     if year not in clib_year_map.keys():
@@ -1489,8 +1497,8 @@ def ApplyJetCorrections(year, corr_type, isData, era, useclib=True, savelevels=F
 
     # Return appropriate factory based on correction type
     if corr_type == 'met':
-        return CorrectedMETFactory(name_map)
-    return CorrectedJetsFactory(name_map, jec_stack)
+        return CorrectedMETFactory(name_map, allowed_variations=allowed_variations)
+    return CorrectedJetsFactory(name_map, jec_stack, allowed_variations=allowed_variations)
 
 
 def build_corrected_jets(jet_factory, jets, lazy_cache=None):

--- a/topeft/modules/corrections.py
+++ b/topeft/modules/corrections.py
@@ -1503,20 +1503,10 @@ def ApplyJetCorrections(
     return CorrectedJetsFactory(name_map, jec_stack, allowed_variations=allowed_variations)
 
 
-def build_corrected_jets(jet_factory, jets, lazy_cache=None):
-    """Materialise corrected jets, providing an awkward lazy cache when available."""
+def build_corrected_jets(jet_factory, jets):
+    """Materialise corrected jets."""
 
-    if lazy_cache is None:
-        events = getattr(jets, "_events", None)
-        caches = getattr(events, "caches", None) if events is not None else None
-        if caches:
-            lazy_cache = caches[0]
-
-    try:
-        corrected = jet_factory.build(jets, lazy_cache=lazy_cache)
-    except TypeError:
-        corrected = jet_factory.build(jets)
-
+    corrected = jet_factory.build(jets)
     return ak.Array(corrected)
 
 

--- a/topeft/modules/runner_output.py
+++ b/topeft/modules/runner_output.py
@@ -100,8 +100,8 @@ def _summarise_histogram(histogram: Any) -> Dict[str, Any]:
     variances: Optional[np.ndarray] = None
 
     if HistEFT is not None and isinstance(histogram, HistEFT):
-        entries = histogram.values(sumw2=True)
-        for payload in entries.values():
+        entries = histogram.values() #sumw2=True)
+        for payload in entries: #.values():
             if isinstance(payload, tuple):
                 current_values = _ensure_numpy(payload[0])
                 raw_variances = payload[1]


### PR DESCRIPTION
This PR wires the “variation-aware corrections” design all the way through the Run-2 analysis processor and corrections module, and adds smoke tests to protect the new behaviour.

Concretely, it does the following:

---

## 1. Gate JES/JER/UES branches based on requested systematics

- Introduces `_build_jerc_allowed_variations` in `analysis/topeft_run2/analysis_processor.py` to summarise JES/JER/UES requests from the `SystematicVariation` sequence:
  - Collects JES components (e.g. `FlavorQCD`, `Absolute`, …) for variations of type `object` with `base="jes"`.
  - Enables JER only when JER variations are explicitly requested **and** the sample is MC.
  - Labels UES variations using `_is_ues_base`, accepting aliases such as `"ues"`, `"met_unclustered_energy"`, and names that contain `"unclustered"`.
- Stores the resulting `allowed_jerc_variations` on the processor and passes it into `ApplyJetCorrections` for both jets and MET.
- Clarifies in comments that:
  - **Nominal** jet/MET corrections always run.
  - `allowed_jerc_variations` only controls which shifted branches (JES/JER/UES) the factories materialise.

---

## 2. Simplify JERC factories usage and remove lazy-cache plumbing

- Extends `ApplyJetCorrections` in `topeft/modules/corrections.py` with an `allowed_variations` argument and plumbs it into:
  - `CorrectedJetsFactory(name_map, jec_stack, allowed_variations=...)`
  - `CorrectedMETFactory(name_map, allowed_variations=...)`
- Simplifies `build_corrected_jets` to just:
  - Call `jet_factory.build(jets)` and wrap the result as an Awkward array.
  - Drop the lazy-cache detection and `TypeError` fallback, which was fragile and tightly coupled to coffea internals.

---

## 3. Adjust tau TES/FES variation semantics

- In `_apply_tau_systematics`, keep the **central** cleaning taus / tau counts as the reference:
  - `central_cleaning_taus`, `cleaning_taus`, `shifted_cleaning_taus`, `n_loose_taus`, and `tau0` are carried from the base state via `VariationObjects.from_base`.
  - TES and FES now only modify `taus["pt"]` and `taus["mass"]` in the variation state.
  - Jet-cleaning masks and tau multiplicities remain those of the central (TES-applied) base state.
- This matches the intended semantics: TES/FES change the tau kinematics used for observables and weights, but not which taus participate in jet cleaning or how many loose taus we count.

---

## 4. Use NanoAOD-style gen-jet matching and streamline jet building

- In `_build_cleaned_jets`:
  - Switch gen-jet pt handling to coffea’s NanoAOD-style `cleaned_jets.matched_gen.pt`, with `None` entries filled with zero.
  - Drop the previous fallback path that tried to recover gen jets from `GenJet` and `genJetIdx`.
- Always treat the jet pt field as `"pt"` (not `"pt_nom"`), so jet selections and counts are consistently based on the corrected pt branch provided by the factory.
- Remove the internal `_log_jet_layout` helper and the very verbose layout logging.

> **Note:** There are still a couple of `logging.info(...)` lines added around jet pt values; see “Follow-ups” below.

---

## 5. Tests for JERC gating and correctness

- Extend `tests/test_corrections_smoke.py`:
  - Add `test_apply_jet_corrections_build_with_allowed_variations` to check that:
    - Central jet/MET corrections still run when all variations are gated off.
    - No JER or UES branches are created in that case.
  - Add `test_apply_jet_corrections_builds_variation_branches_when_enabled` to assert that:
    - JER and component-level JES branches are created when requested.
    - MET gets the `MET_UnclusteredEnergy` branch when UES is enabled.
- Add a dedicated `tests/test_jerc_allowed_variations.py` to exercise `_build_jerc_allowed_variations`:
  - No JER/UES when no matching variations are present.
  - JES component collection and sorting.
  - UES alias handling.
  - JER enabled only for MC samples, even when JER variations exist.

---

## 6. Metadata cleanup and HistEFT output behaviour

- Remove the local `scenarios` block from `analysis/metadata/metadata.yml`:
  - The `TOP_22_006`, `tau_analysis`, and `fwd_analysis` scenario definitions now live in the canonical metadata source instead of being duplicated here.
- In `topeft/modules/runner_output.py`, adjust the HistEFT handling:
  - Use `histogram.values()` instead of `values(sumw2=True)` to match the updated HistEFT API.
  - Iterate directly over the returned payloads and handle both pure value payloads and `(values, sumw2)` tuples.

---

## Follow-ups / things to double-check

A few items that are worth calling out explicitly:

1. **Debug logging noise**
   - There are still some unconditional `logging.info(...)` calls in `_build_cleaned_jets`:
     - `logging.info("jetptname: %s", jetptname)`
     - `logging.info("Corrected jets pt: %s", ...)`
     - `logging.info("Cleaned jets pt: %s", ...)`
   - These will be very noisy under large-scale production runs and don’t respect the `self._debug_logging` knob.
   - **Follow-up:** either remove these entirely or route them through `self._debug(...)` when `self._debug_logging` is enabled.

2. **Unused imports**
   - `from copy import copy, deepcopy` appears added in `analysis_processor.py` but isn’t used.
   - **Follow-up:** either use them (if we want explicit shallow/deep copies in `VariationObjects.from_base`) or drop the imports.

3. **API surface: `columns` property**
   - The `columns` property on `AnalysisProcessor` was removed.
   - If any downstream code (or tests) outside this repo accesses `processor.columns`, this is a silent API break.
   - **Follow-up:** quickly check external users (or this repo’s callers) to confirm it’s safe, or reintroduce the property as a lightweight passthrough if needed.

4. **Gen-jet matching assumptions**
   - The new code assumes `cleaned_jets.matched_gen` exists and behaves like coffea’s standard NanoAOD matched object.
   - **Follow-up:** confirm we always feed in jets built by `CorrectedJetsFactory` with that attribute present for all MC samples. If not, we may want a guarded fallback or a clearer error.

5. **Metadata/scenario consistency**
   - Since the local `scenarios` block was removed from `analysis/metadata/metadata.yml`, it’s important that:
     - The canonical metadata file actually contains the `TOP_22_006` / `tau_analysis` / `fwd_analysis` scenarios.
     - No tests or scripts still reference the old in-file scenarios.
   - **Follow-up:** ensure Te1’s “single source of truth” metadata location is consistently documented and used in `scenario_registry.py` and related helpers.

---

## Design notes / context

This PR is part of the broader **“Codex Topeft/Topcoffea Reliability & Docs Overhaul”** effort:

- It delivers the Tc2/Te3 goals for **variation-aware corrections & task-level gating**:
  - Topcoffea’s jet/MET factories now accept an `allowed_variations` payload to avoid building unused JES/JER/UES branches.
  - Topeft’s Run-2 `AnalysisProcessor` builds that payload from the configured `SystematicVariation` sequence and passes it down to the factories.
- It also aligns with Te1/Te2 by:
  - Moving scenario definitions out of the local metadata copy and toward a single canonical metadata source.
  - Tightening the coupling between the configured systematics and which correction branches are actually materialised.

Subsequent PRs in this epic will focus on:
- Hardening metadata handling so user-specified metadata becomes the single source of truth throughout the processor.
- Cleaning up logging/CLI flags and integrating the “no debug under TaskVine” and “one log-level flag” design.
- Adding more unit tests for variation selection and executor behaviour, followed by documentation updates.
</pre>
