### PR TITLE
Make metadata a single source of truth and neutralize scenario helpers

### DIFF
--- a/analysis/topeft_run2/comp.py
+++ b/analysis/topeft_run2/comp.py
@@ -21,24 +21,40 @@ import time
 import json
 import os
 import topcoffea
-import yaml
 from topeft.modules.paths import topeft_path
+from analysis.topeft_run2.metadata_loader import load_metadata
 
 GetParam = topcoffea.modules.get_param_from_jsons.GetParam
 topcoffea_path = topcoffea.modules.paths.topcoffea_path
 get_tc_param = GetParam(topcoffea_path("params/params.json"))
 
-metadata_path = topeft_path("analysis/metadata/metadata.yml")
-with open(metadata_path, "r") as f:
-    metadata = yaml.safe_load(f)
-axes_info = metadata["variables"]
+_CANONICAL_METADATA_PATH = topeft_path("analysis/metadata/metadata.yml")
+BINNING = {}
 
-BINNING = {k: v['variable'] for k,v in axes_info.items() if 'variable' in v}
+
+def _set_binning(metadata_path: str):
+    bundle = load_metadata(metadata_path, required_sections=("variables",))
+    variables = bundle.variables or {}
+    global BINNING
+    BINNING = {
+        name: value["variable"]
+        for name, value in variables.items()
+        if isinstance(value, dict) and "variable" in value
+    }
+
+
+def _require_binning():
+    if not BINNING:
+        raise RuntimeError(
+            "Histogram variable binning is unavailable. Load metadata via --metadata before running comparisons."
+        )
+    return BINNING
 
 def comp(fin1, fin2, hists1, hists2, newHist1, newHist2, tolerance):
     fout = open('comp_log.txt', 'w')
     old_hist = True if 'kmohrman' in fin2 else False # Official anatest25 was made _before_ the luminosity step was added
     match = True
+    binning = _require_binning()
     if '_np' in fin1 and '_np' in fin2:
         for hname in hists2:
             if 'njets' in hname: continue
@@ -137,12 +153,12 @@ def comp(fin1, fin2, hists1, hists2, newHist1, newHist2, tolerance):
                             # Rebin old histogram to match new variable binning
                             if 'njets' not in hname and not newHist1:
                                 v1norebin = h1_syst.values(overflow='all')[()]
-                                bins = BINNING[hname]
+                                bins = binning[hname]
                                 v1rebin = h1_syst.rebin(hname, Bin(hname, h1_syst.axis(hname).label, bins))
                                 v1 = v1rebin.values(overflow='all')[()]
                                 #v1norebin = h1_syst.rebin(hname, Bin(hname, h1_syst.axis(hname).label, bins)).values(overflow='all')[()]
                             if 'njets' not in hname and not newHist2:
-                                bins = BINNING[hname]
+                                bins = binning[hname]
                                 v2 = h2_syst.rebin(hname, Bin(hname, h2_syst.axis(hname).label, bins)).values(overflow='all')[()]
                             if old_hist and 'data' not in proc:
                                 v2 = v2*lumi
@@ -163,7 +179,7 @@ def comp(fin1, fin2, hists1, hists2, newHist1, newHist2, tolerance):
                                     edg = h1_syst.axes()[0].edges()[:-1]
                                 else:
                                     edg = h1_syst.axes[0].edges[:-1]
-                                bins = BINNING[hname]#[:-1]
+                                bins = binning[hname]
                                 #if not newHist1 and 'TTTo2L2Nu_centralUL18' in proc: print(proc, 'full1', edg, v1norebin)
                                 #if 'TTTo2L2Nu_centralUL18' in proc: print(proc, 'rebin', bins, v1)
                                 #if not newHist1 and 'TTTo2L2Nu_centralUL18' in proc: print(proc, 'manre', bins, [v1norebin[0], sum(v1norebin[1:3]), sum(v1norebin[4:5]), sum(v1norebin[6:11])])
@@ -295,10 +311,10 @@ def comp(fin1, fin2, hists1, hists2, newHist1, newHist2, tolerance):
                             else: v2 = h2_syst.values(overflow='all')[()]
                             # Rebin old histogram to match new variable binning
                             if 'njets' not in hname and not newHist1:
-                                bins = BINNING[hname]
+                                bins = binning[hname]
                                 v1 = h1_syst.rebin(hname, Bin(hname, h1_syst.axis(hname).label, bins)).values(overflow='all')[()]
                             if 'njets' not in hname and not newHist2:
-                                bins = BINNING[hname]
+                                bins = binning[hname]
                                 v2 = h2_syst.rebin(hname, Bin(hname, h2_syst.axis(hname).label, bins)).values(overflow='all')[()]
                             if old_hist and 'data' not in proc:
                                 v2 = v2*lumi
@@ -335,12 +351,26 @@ if __name__ == '__main__':
     parser.add_argument('--newHist1', action='store_true', help='First file was made with the new histEFT')
     parser.add_argument('--newHist2', action='store_true', help='Second file was made with the new histEFT')
     parser.add_argument('--tolerance', '-t', default='1e-3', help='Tolerance for warnings')
+    parser.add_argument(
+        '--metadata',
+        default=None,
+        help=(
+            "Metadata YAML describing histogram binning. Defaults to the canonical "
+            "analysis/metadata/metadata.yml bundle."
+        ),
+    )
     args    = parser.parse_args()
     fin1    = args.fin1
     fin2    = args.fin2
     newHist1 = args.newHist1
     newHist2 = args.newHist2
     tolerance = float(args.tolerance)
+    metadata_file = args.metadata or _CANONICAL_METADATA_PATH
+    _set_binning(metadata_file)
+    if args.metadata is None:
+        print(
+            "No metadata override provided; using canonical analysis/metadata/metadata.yml for histogram binning."
+        )
 
     if ('_np' in fin1 and '_np' not in fin2) or ('_np' in fin2 and '_np' not in fin1):
         raise Exception("Looks like you're trying to compare a non-prompt subtracted file to one without!")

--- a/analysis/topeft_run2/datacards_post_processing.py
+++ b/analysis/topeft_run2/datacards_post_processing.py
@@ -120,7 +120,12 @@ def resolve_scenario_metadata(
     metadata_path: str | None = None,
     require_variables: bool = False,
 ) -> Tuple[str, MetadataBundle, ChannelMetadataHelper]:
-    """Return the scenario name, metadata bundle, and helper for ``scenario_args``."""
+    """Return the scenario name, metadata bundle, and helper for ``scenario_args``.
+
+    The returned :class:`MetadataBundle` mirrors the metadata already loaded by
+    the workflow so downstream helpers (datacards, plotting, etc.) stay aligned
+    with the user-selected metadata file instead of reopening canonical paths.
+    """
 
     scenario_names = [name for name in (scenario_args or []) if name]
     if not scenario_names:

--- a/analysis/topeft_run2/datacards_post_processing.py
+++ b/analysis/topeft_run2/datacards_post_processing.py
@@ -5,9 +5,8 @@ import json
 import sys
 from typing import Iterable, List, Tuple
 
-import yaml
-
-from analysis.topeft_run2.scenario_registry import resolve_scenario_choice
+from analysis.topeft_run2.metadata_loader import load_metadata, MetadataBundle
+from analysis.topeft_run2.scenario_registry import select_metadata_path
 from topeft.modules import scenario_groups
 from topeft.modules.channel_metadata import ChannelMetadataHelper
 
@@ -115,8 +114,13 @@ def _analysis_mode_for_group(group, scenario_name):
     return "top22006"
 
 
-def resolve_scenario_metadata(scenario_args: Iterable[str]) -> Tuple[str, str, ChannelMetadataHelper]:
-    """Return the scenario name, metadata path, and helper for ``scenario_args``."""
+def resolve_scenario_metadata(
+    scenario_args: Iterable[str],
+    *,
+    metadata_path: str | None = None,
+    require_variables: bool = False,
+) -> Tuple[str, MetadataBundle, ChannelMetadataHelper]:
+    """Return the scenario name, metadata bundle, and helper for ``scenario_args``."""
 
     scenario_names = [name for name in (scenario_args or []) if name]
     if not scenario_names:
@@ -129,17 +133,21 @@ def resolve_scenario_metadata(scenario_args: Iterable[str]) -> Tuple[str, str, C
         )
 
     scenario_name = scenario_names[0]
-    resolution = resolve_scenario_choice(scenario_name)
-
-    with open(resolution.metadata_path, "r", encoding="utf-8") as metadata_file:
-        metadata = yaml.safe_load(metadata_file) or {}
+    metadata_file = select_metadata_path(scenario_name, metadata_path)
+    required = ["channels"]
+    if require_variables:
+        required.append("variables")
+    bundle = load_metadata(metadata_file, required_sections=tuple(required))
+    metadata = bundle.payload
 
     channels_metadata = metadata.get("channels")
     channels_data = channels_metadata
     if scenario_groups.is_run2_scenario(scenario_name):
         try:
             channels_data = scenario_groups.load_run2_channels_for_scenario(
-                scenario_name
+                scenario_name,
+                metadata=metadata,
+                metadata_path=bundle.path,
             )
         except Exception as exc:
             print(
@@ -151,11 +159,11 @@ def resolve_scenario_metadata(scenario_args: Iterable[str]) -> Tuple[str, str, C
     if not channels_data:
         raise ValueError(
             f"Channel metadata is missing for scenario '{scenario_name}'. "
-            f"Checked canonical Run 2 definitions and metadata YAML ({resolution.metadata_path})."
+            f"Checked canonical Run 2 definitions and metadata YAML ({bundle.path})."
         )
 
     helper = ChannelMetadataHelper(channels_data)
-    return scenario_name, resolution.metadata_path, helper
+    return scenario_name, bundle, helper
 
 
 def collect_datacard_channels(
@@ -213,10 +221,21 @@ def main():
             "Only one scenario per run is currently supported."
         ),
     )
+    parser.add_argument(
+        "--metadata",
+        default=None,
+        help=(
+            "Metadata YAML to use for channel definitions. When omitted the scenario registry "
+            "default for the selected scenario is used."
+        ),
+    )
     args = parser.parse_args()
 
     try:
-        scenario_name, metadata_path, channel_helper = resolve_scenario_metadata(args.scenario)
+        scenario_name, metadata_bundle, channel_helper = resolve_scenario_metadata(
+            args.scenario,
+            metadata_path=args.metadata,
+        )
     except ValueError as exc:
         print(f"ERROR: {exc}")
         sys.exit(1)

--- a/analysis/topeft_run2/datacards_post_processing.py
+++ b/analysis/topeft_run2/datacards_post_processing.py
@@ -149,7 +149,7 @@ def resolve_scenario_metadata(
     channels_data = channels_metadata
     if scenario_groups.is_run2_scenario(scenario_name):
         try:
-            channels_data = scenario_groups.load_run2_channels_for_scenario(
+            channels_data = scenario_groups.load_channels_for_scenario(
                 scenario_name,
                 metadata=metadata,
                 metadata_path=bundle.path,

--- a/analysis/topeft_run2/datacards_post_processing.py
+++ b/analysis/topeft_run2/datacards_post_processing.py
@@ -147,7 +147,7 @@ def resolve_scenario_metadata(
 
     channels_metadata = metadata.get("channels")
     channels_data = channels_metadata
-    if scenario_groups.is_run2_scenario(scenario_name):
+    if scenario_groups.is_scenario(scenario_name):
         try:
             channels_data = scenario_groups.load_channels_for_scenario(
                 scenario_name,
@@ -156,7 +156,7 @@ def resolve_scenario_metadata(
             )
         except Exception as exc:
             print(
-                f"WARNING: Failed to load canonical Run 2 channels for {scenario_name}: {exc}. "
+                f"WARNING: Failed to load canonical scenario channels for {scenario_name}: {exc}. "
                 "Falling back to metadata YAML contents."
             )
             channels_data = channels_metadata
@@ -164,7 +164,7 @@ def resolve_scenario_metadata(
     if not channels_data:
         raise ValueError(
             f"Channel metadata is missing for scenario '{scenario_name}'. "
-            f"Checked canonical Run 2 definitions and metadata YAML ({bundle.path})."
+            f"Checked canonical scenario definitions and metadata YAML ({bundle.path})."
         )
 
     helper = ChannelMetadataHelper(channels_data)

--- a/analysis/topeft_run2/make_cards.py
+++ b/analysis/topeft_run2/make_cards.py
@@ -195,6 +195,14 @@ def main():
             "tau_analysis, fwd_analysis). Only one scenario per run is supported."
         ),
     )
+    parser.add_argument(
+        "--metadata",
+        default=None,
+        help=(
+            "Metadata YAML supplying channels/variables for datacards. "
+            "Defaults to the scenario registry path for the selected scenario."
+        ),
+    )
 
     args = parser.parse_args()
     pkl_file   = args.pkl_file
@@ -225,7 +233,11 @@ def main():
         wcs = wcs.split(",")
 
     try:
-        scenario_name, metadata_path, channel_helper = resolve_scenario_metadata(args.scenario)
+        scenario_name, metadata_bundle, channel_helper = resolve_scenario_metadata(
+            args.scenario,
+            metadata_path=args.metadata,
+            require_variables=True,
+        )
     except ValueError as exc:
         print(f"ERROR: {exc}")
         sys.exit(1)
@@ -269,6 +281,7 @@ def main():
         shutil.copy("make_cards.py",out_dir)
 
     tic = time.time()
+    kwargs["metadata"] = metadata_bundle.payload
     dc = DatacardMaker(pkl_file,**kwargs)
 
     # convert wc_vals string to a dictionary

--- a/analysis/topeft_run2/make_cr_and_sr_plots.py
+++ b/analysis/topeft_run2/make_cr_and_sr_plots.py
@@ -3,7 +3,6 @@ import os
 import copy
 import datetime
 import argparse
-import yaml
 import matplotlib as mpl
 mpl.use('Agg')
 import matplotlib.pyplot as plt
@@ -15,11 +14,10 @@ import topcoffea
 
 from topeft.modules.paths import topeft_path
 from topeft.modules.topcoffea_imports import require_script
+from analysis.topeft_run2.metadata_loader import load_metadata
 
-metadata_path = topeft_path("analysis/metadata/metadata.yml")
-with open(metadata_path, "r") as f:
-    metadata = yaml.safe_load(f)
-axes_info = metadata["variables"]
+_CANONICAL_METADATA_PATH = topeft_path("analysis/metadata/metadata.yml")
+_AXES_INFO = None
 
 from topeft.modules.yield_tools import YieldTools
 import topeft.modules.get_rate_systs as grs
@@ -139,6 +137,20 @@ SR_GRP_MAP = {
     "tttt" : [],
     "tXq" : [],
 }
+
+
+def _set_axes_info(axes_info):
+    global _AXES_INFO
+    _AXES_INFO = axes_info
+
+
+def _require_axes_info():
+    if not _AXES_INFO:
+        raise RuntimeError(
+            "Histogram variable definitions have not been loaded. "
+            "Pass --metadata or call _set_axes_info with the desired mapping."
+        )
+    return _AXES_INFO
 
 # Best fit point from TOP-19-001 with madup numbers for the 10 new WCs
 WCPT_EXAMPLE = {
@@ -918,6 +930,7 @@ def make_all_sr_data_mc_plots(dict_of_hists,year,save_dir_path):
     #        '4l': [2,3,4,dict_of_hists['njets'].axis('njets').edges()[-1]]
     #    }
     #}
+    axes_info = _require_axes_info()
     analysis_bins['ptz'] = axes_info['ptz']['variable']
     analysis_bins['lj0pt'] = axes_info['lj0pt']['variable']
 
@@ -979,7 +992,14 @@ def make_all_sr_data_mc_plots(dict_of_hists,year,save_dir_path):
                 print("Warning: empty data histo, continuing")
                 continue
 
-            fig = make_cr_fig(hist_mc, hist_data, var=var_name, unit_norm_bool=False, bins=axes_info[var_name]['variable'],group=SR_GRP_MAP)
+            fig = make_cr_fig(
+                hist_mc,
+                hist_data,
+                var=var_name,
+                unit_norm_bool=False,
+                bins=axes_info[var_name]['variable'],
+                group=SR_GRP_MAP,
+            )
             if year is not None: year_str = year
             else: year_str = "ULall"
             title = chan_name + "_" + var_name + "_" + year_str
@@ -1061,7 +1081,11 @@ def make_all_sr_plots(dict_of_hists,year,unit_norm_bool,save_dir_path,split_by_c
                 if not hist_sig_integrated_ch.eval({}):
                     print("Warning: empty mc histo, continuing")
                     continue
-                fig = make_single_fig(hist_sig_integrated_ch,unit_norm_bool,bins=axes_info[var_name]['variable'])
+                fig = make_single_fig(
+                    hist_sig_integrated_ch,
+                    unit_norm_bool,
+                    bins=axes_info[var_name]['variable'],
+                )
                 title = hist_cat+"_"+var_name
                 if unit_norm_bool: title = title + "_unitnorm"
                 fig.savefig(os.path.join(save_dir_path_tmp,title))
@@ -1103,7 +1127,11 @@ def make_all_sr_plots(dict_of_hists,year,unit_norm_bool,save_dir_path,split_by_c
                         continue
 
                     # Make plots
-                    fig = make_single_fig(hist_sig_grouped_tmp[{'channel': sr_cat_dict[grouped_hist_cat]}][{'channel': sum}],unit_norm_bool,bins=axes_info[var_name]['variable'])
+                    fig = make_single_fig(
+                        hist_sig_grouped_tmp[{'channel': sr_cat_dict[grouped_hist_cat]}][{'channel': sum}],
+                        unit_norm_bool,
+                        bins=axes_info[var_name]['variable'],
+                    )
                     title = proc_name+"_"+grouped_hist_cat+"_"+var_name
                     if unit_norm_bool: title = title + "_unitnorm"
                     fig.savefig(os.path.join(save_dir_path_tmp,title))
@@ -1324,7 +1352,23 @@ def main():
     parser.add_argument("-y", "--year", default=None, help = "The year of the sample")
     parser.add_argument("-u", "--unit-norm", action="store_true", help = "Unit normalize the plots")
     parser.add_argument("-s", "--skip-syst", default=False, action="store_true", help = "Skip syst errs in plots, only relevant for CR plots right now")
+    parser.add_argument(
+        "--metadata",
+        default=None,
+        help=(
+            "Metadata YAML describing histogram variables. Defaults to the canonical "
+            "analysis/metadata/metadata.yml bundle."
+        ),
+    )
     args = parser.parse_args()
+
+    metadata_file = args.metadata or _CANONICAL_METADATA_PATH
+    bundle = load_metadata(metadata_file, required_sections=("variables",))
+    _set_axes_info(bundle.variables or {})
+    if args.metadata is None:
+        print(
+            "No metadata override provided; using canonical analysis/metadata/metadata.yml for binning."
+        )
 
     # Whether or not to unit norm the plots
     unit_norm_bool = args.unit_norm

--- a/analysis/topeft_run2/metadata_loader.py
+++ b/analysis/topeft_run2/metadata_loader.py
@@ -1,4 +1,9 @@
-"""Shared helpers for loading metadata bundles once per execution."""
+"""Shared helpers for loading metadata bundles once per execution.
+
+This module is the canonical entry point for reading metadata YAML files.
+Callers elsewhere in the codebase should inject metadata loaded here instead
+of reopening YAML files directly.
+"""
 
 from __future__ import annotations
 

--- a/analysis/topeft_run2/metadata_loader.py
+++ b/analysis/topeft_run2/metadata_loader.py
@@ -1,0 +1,106 @@
+"""Shared helpers for loading metadata bundles once per execution."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, MutableMapping, Optional, Sequence
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class MetadataBundle:
+    """Container describing a resolved metadata YAML payload."""
+
+    path: Path
+    payload: MutableMapping[str, Any]
+    channels: Optional[Mapping[str, Any]]
+    systematics: Optional[Mapping[str, Any]]
+    variables: Optional[Mapping[str, Any]]
+
+
+def resolve_metadata_path(metadata_path: str | Path) -> Path:
+    """Return the absolute path to ``metadata_path`` ensuring it exists."""
+
+    if not metadata_path:
+        raise ValueError("metadata_path must be provided")
+    candidate = Path(metadata_path).expanduser()
+    if not candidate.is_absolute():
+        candidate = Path.cwd() / candidate
+    try:
+        return candidate.resolve(strict=True)
+    except FileNotFoundError as exc:  # pragma: no cover - filesystem error details
+        raise FileNotFoundError(
+            f"Metadata file '{candidate}' could not be found."
+        ) from exc
+
+
+def _ensure_mapping(payload: object, description: str) -> MutableMapping[str, Any]:
+    if not isinstance(payload, MutableMapping):
+        raise TypeError(f"{description} must be a mapping at the top level")
+    return payload
+
+
+def _extract_section(
+    payload: MutableMapping[str, Any],
+    section: str,
+) -> Optional[Mapping[str, Any]]:
+    raw_value = payload.get(section)
+    if raw_value is None:
+        return None
+    if not isinstance(raw_value, Mapping):
+        raise TypeError(f"metadata['{section}'] must be a mapping when present")
+    return raw_value
+
+
+def load_metadata(
+    metadata_path: str | Path,
+    *,
+    required_sections: Sequence[str] | None = None,
+) -> MetadataBundle:
+    """Load the metadata YAML at ``metadata_path`` and return its contents.
+
+    Args:
+        metadata_path: Path (absolute or relative) pointing to the metadata YAML.
+        required_sections: Optional iterable of top-level keys that must exist
+            and be mappings (for example ``("channels", "variables")``).
+
+    Raises:
+        FileNotFoundError: when ``metadata_path`` does not exist.
+        RuntimeError: if the YAML cannot be parsed.
+        TypeError: when the payload or a requested section is not a mapping.
+        KeyError: when a required section is missing.
+    """
+
+    resolved_path = resolve_metadata_path(metadata_path)
+    try:
+        with resolved_path.open("r", encoding="utf-8") as handle:
+            payload = yaml.safe_load(handle) or {}
+    except yaml.YAMLError as exc:  # pragma: no cover - depends on parser internals
+        raise RuntimeError(
+            f"Failed to parse metadata YAML '{resolved_path}': {exc}"
+        ) from exc
+
+    mapping_payload = _ensure_mapping(payload, str(resolved_path))
+
+    sections = tuple(required_sections or ())
+    for section in sections:
+        if not isinstance(mapping_payload.get(section), Mapping):
+            raise KeyError(
+                f"metadata[{section!r}] is required but missing or not a mapping in '{resolved_path}'."
+            )
+
+    return MetadataBundle(
+        path=resolved_path,
+        payload=mapping_payload,
+        channels=_extract_section(mapping_payload, "channels"),
+        systematics=_extract_section(mapping_payload, "systematics"),
+        variables=_extract_section(mapping_payload, "variables"),
+    )
+
+
+__all__ = ["MetadataBundle", "load_metadata", "resolve_metadata_path"]

--- a/analysis/topeft_run2/quickstart.py
+++ b/analysis/topeft_run2/quickstart.py
@@ -27,6 +27,8 @@ from .run_analysis_helpers import (
     unique_preserving_order,
     weight_variations_from_metadata,
 )
+from .metadata_loader import load_metadata
+
 try:
     from .workflow import (
         DEFAULT_SCENARIO_NAME,
@@ -45,6 +47,7 @@ except ImportError:  # pragma: no cover - optional workflow helper
     RunWorkflow = None  # type: ignore[assignment]
 
 _DEFAULT_VARIABLES: Tuple[str, ...] = ("lj0pt",)
+_DEFAULT_METADATA_PATH = topeft_path("analysis/metadata/metadata.yml")
 
 
 @dataclass(frozen=True)
@@ -72,22 +75,12 @@ class PreparedSamples:
 
 
 def _load_metadata(metadata_path: Optional[str]) -> Tuple[MutableMapping[str, object], Path]:
-    try:  # pragma: no cover - optional dependency resolution
-        import yaml
-    except ImportError as exc:  # pragma: no cover
-        raise ImportError("PyYAML is required to use the quickstart helpers") from exc
-
-    if metadata_path is None:
-        metadata_path = topeft_path("analysis/metadata/metadata.yml")
-    candidate = Path(metadata_path).expanduser()
-    if not candidate.is_absolute():
-        candidate = Path.cwd() / candidate
-    metadata_file = candidate.resolve(strict=True)
-    with metadata_file.open("r", encoding="utf-8") as handle:
-        loaded = yaml.safe_load(handle) or {}
-    if not isinstance(loaded, MutableMapping):
+    resolved_path = metadata_path or _DEFAULT_METADATA_PATH
+    bundle = load_metadata(resolved_path)
+    metadata = bundle.payload
+    if not isinstance(metadata, MutableMapping):
         raise TypeError("Metadata YAML must define a mapping of configuration blocks")
-    return copy.deepcopy(loaded), metadata_file  # ensure callers can mutate safely
+    return copy.deepcopy(metadata), bundle.path  # ensure callers can mutate safely
 
 
 def _select_variables(

--- a/analysis/topeft_run2/scenario_registry.py
+++ b/analysis/topeft_run2/scenario_registry.py
@@ -73,9 +73,18 @@ def resolve_scenario_path(name: str) -> str:
     return resolve_scenario_choice(name).metadata_path
 
 
+def select_metadata_path(name: str, explicit_path: str | None) -> str:
+    """Return ``explicit_path`` when provided, otherwise fall back to the registry."""
+
+    if explicit_path:
+        return explicit_path
+    return resolve_scenario_path(name)
+
+
 __all__ = [
     "ScenarioResolution",
     "known_scenarios",
     "resolve_scenario_choice",
     "resolve_scenario_path",
+    "select_metadata_path",
 ]

--- a/analysis/topeft_run2/workflow.py
+++ b/analysis/topeft_run2/workflow.py
@@ -1668,13 +1668,13 @@ def run_workflow(config: RunConfig) -> None:
 
     channels_metadata = metadata.get("channels")
     channels_data = channels_metadata
-    use_run2_channels = scenario_groups.is_run2_scenario(primary_scenario)
-    if use_run2_channels:
+    use_canonical_scenario_channels = scenario_groups.is_scenario(primary_scenario)
+    if use_canonical_scenario_channels:
         if len(config.scenario_names) > 1:
             logger.warning(
-                "Run 2 scenario '%s' requested alongside additional scenarios (%s). "
-                "Only the primary scenario can be used for channel selection; "
-                "ignoring the rest.",
+                "Scenario '%s' from the canonical scenario definitions was requested "
+                "alongside additional scenarios (%s). Only the primary scenario can be "
+                "used for channel selection; ignoring the rest.",
                 primary_scenario,
                 ", ".join(config.scenario_names[1:]),
             )
@@ -1684,7 +1684,7 @@ def run_workflow(config: RunConfig) -> None:
                 primary_scenario
             )
             logger.info(
-                "Loaded %d Run 2 channel groups for scenario '%s'.",
+                "Loaded %d canonical channel groups for scenario '%s'.",
                 len((channels_data or {}).get("groups", {})),
                 primary_scenario,
             )
@@ -1699,7 +1699,7 @@ def run_workflow(config: RunConfig) -> None:
     if not channels_data:
         raise ValueError(
             f"Channel metadata is missing for scenario '{primary_scenario}'. "
-            f"Checked canonical Run 2 definitions and metadata YAML ({metadata_file})."
+            f"Checked canonical scenario definitions and metadata YAML ({metadata_file})."
         )
 
     channel_helper = ChannelMetadataHelper(channels_data)

--- a/analysis/topeft_run2/workflow.py
+++ b/analysis/topeft_run2/workflow.py
@@ -1680,7 +1680,7 @@ def run_workflow(config: RunConfig) -> None:
             )
             config.scenario_names = [primary_scenario]
         try:
-            channels_data = scenario_groups.load_run2_channels_for_scenario(
+            channels_data = scenario_groups.load_channels_for_scenario(
                 primary_scenario
             )
             logger.info(

--- a/analysis/topeft_run2/workflow.py
+++ b/analysis/topeft_run2/workflow.py
@@ -94,6 +94,7 @@ from .run_analysis_helpers import (
     unique_preserving_order,
     weight_variations_from_metadata,
 )
+from .metadata_loader import load_metadata
 from .nanoevents_helpers import nanoevents_factory_from_root
 from .systematics_validation import (
     metadata_non_nominal_bases,
@@ -1618,7 +1619,6 @@ class RunWorkflow:
 def run_workflow(config: RunConfig) -> None:
     """Convenience wrapper mirroring the behaviour of ``run_analysis.py``."""
 
-    import yaml
     from topeft.modules.channel_metadata import ChannelMetadataHelper
 
     metadata_source = config.metadata_path
@@ -1627,20 +1627,10 @@ def run_workflow(config: RunConfig) -> None:
             "RunConfig.metadata_path is not set. The scenario registry or options profile "
             "must select a metadata bundle before launching run_workflow."
         )
-    candidate_path = Path(metadata_source).expanduser()
-    if not candidate_path.is_absolute():
-        candidate_path = Path.cwd() / candidate_path
-    try:
-        metadata_file = candidate_path.resolve(strict=True)
-    except FileNotFoundError as exc:
-        raise FileNotFoundError(
-            f"Metadata file '{candidate_path}' could not be found."
-        ) from exc
-
+    bundle = load_metadata(metadata_source)
+    metadata_file = bundle.path
+    metadata = bundle.payload
     config.metadata_path = str(metadata_file)
-
-    with metadata_file.open("r", encoding="utf-8") as handle:
-        metadata = yaml.safe_load(handle) or {}
 
     metadata_variations = metadata_non_nominal_bases(metadata)
     if metadata_variations:

--- a/scratch/validate_run2_scenarios_step5.py
+++ b/scratch/validate_run2_scenarios_step5.py
@@ -7,8 +7,8 @@ from typing import Dict, Iterable, List, Mapping, Sequence
 
 from topeft.modules.channel_metadata import ChannelGroup, ChannelMetadataHelper
 from topeft.modules.scenario_groups import (
-    load_run2_channels_for_scenario,
-    load_run2_scenarios,
+    load_channels_for_scenario,
+    load_scenarios,
 )
 
 DEFAULT_SAMPLE_SCENARIOS = (
@@ -52,7 +52,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
 def main(argv: Sequence[str] | None = None) -> None:
     args = parse_args(argv)
-    scenario_map = load_run2_scenarios()
+    scenario_map = load_scenarios()
 
     if not scenario_map:
         raise SystemExit("No scenarios are defined in analysis/metadata/run2_scenarios.yaml.")
@@ -62,7 +62,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     channels_cache: Dict[str, List[str]] = {}
 
     for scenario_name in selected_names:
-        metadata = load_run2_channels_for_scenario(scenario_name)
+        metadata = load_channels_for_scenario(scenario_name)
         helper = ChannelMetadataHelper(metadata)
         sr_channels = collect_datacard_channels(helper, scenario_name)
         scenario_def = scenario_map[scenario_name]

--- a/tests/test_metadata_datacards_integration.py
+++ b/tests/test_metadata_datacards_integration.py
@@ -1,5 +1,7 @@
 import gzip
+import json
 import pickle
+import sys
 from pathlib import Path
 
 import pytest
@@ -15,6 +17,7 @@ metadata_stubs._install_boost_histogram_stub()
 metadata_stubs._install_uproot_stub()
 metadata_stubs._install_coffea_stub()
 
+from analysis.topeft_run2 import datacards_post_processing as dpp  # noqa: E402
 from topeft.modules import datacard_tools  # noqa: E402  (imports after stubs)
 
 
@@ -47,3 +50,60 @@ def test_datacard_maker_requires_variable_definitions(tmp_path, monkeypatch):
 
     with pytest.raises(ValueError):
         datacard_tools.DatacardMaker(str(dummy_hist), metadata={"channels": {}})
+
+
+def test_datacards_cli_respects_metadata_override(tmp_path, monkeypatch):
+    cards_dir = tmp_path / "cards"
+    cards_dir.mkdir()
+    (cards_dir / "job_logs").mkdir()
+
+    scalings_file = cards_dir / "scalings-preselect.json"
+    scalings_file.write_text(json.dumps([{"channel": "dummy_channel"}]), encoding="utf-8")
+    for suffix in ("txt", "root"):
+        path = cards_dir / f"ttx_multileptons_dummy_channel.{suffix}"
+        path.write_text("placeholder", encoding="utf-8")
+    (cards_dir / "selectedWCs.txt").write_text("{}", encoding="utf-8")
+
+    metadata_file = tmp_path / "meta.yml"
+    metadata_file.write_text(
+        "\n".join(
+            [
+                "channels:",
+                "  groups:",
+                "    TOP22_006_CH_LST_SR:",
+                "      regions: []",
+                "variables:",
+                "  ptz:",
+                "    variable: [0.0, 1.0]",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    calls = {}
+    original_loader = dpp.load_metadata
+
+    def spy_loader(path, **kwargs):
+        calls["path"] = Path(path)
+        return original_loader(path, **kwargs)
+
+    monkeypatch.setattr(dpp, "load_metadata", spy_loader)
+    monkeypatch.setattr(dpp, "ChannelMetadataHelper", lambda data: data)
+    monkeypatch.setattr(dpp, "collect_datacard_channels", lambda helper, scenario: ["dummy_channel"])
+    monkeypatch.setattr(dpp, "EXPECTED_FILE_COUNTS", {})
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "datacards_post_processing.py",
+            str(cards_dir),
+            "--scenario",
+            "TOP_22_006",
+            "--metadata",
+            str(metadata_file),
+        ],
+    )
+
+    dpp.main()
+
+    assert calls["path"] == metadata_file.resolve()

--- a/tests/test_metadata_datacards_integration.py
+++ b/tests/test_metadata_datacards_integration.py
@@ -1,0 +1,49 @@
+import gzip
+import pickle
+from pathlib import Path
+
+import pytest
+
+from tests import test_metadata_single_source as metadata_stubs
+
+# Ensure the lightweight stubs used in the metadata-single-source tests are also
+# active here so DatacardMaker can be exercised without heavy dependencies.
+metadata_stubs._install_topcoffea_stub()
+metadata_stubs._install_numpy_stub()
+metadata_stubs._install_matplotlib_stubs()
+metadata_stubs._install_boost_histogram_stub()
+metadata_stubs._install_uproot_stub()
+metadata_stubs._install_coffea_stub()
+
+from topeft.modules import datacard_tools  # noqa: E402  (imports after stubs)
+
+
+def _write_empty_histogram_pickle(path: Path) -> None:
+    with gzip.open(path, "wb") as handle:
+        pickle.dump({}, handle)
+
+
+def test_datacard_maker_uses_injected_metadata(tmp_path, monkeypatch):
+    dummy_hist = tmp_path / "dummy.pkl.gz"
+    _write_empty_histogram_pickle(dummy_hist)
+
+    metadata_payload = {
+        "variables": {"custom_pt": {"variable": [0.0, 1.0, 2.0]}},
+        "channels": {},
+    }
+
+    monkeypatch.setattr(datacard_tools.DatacardMaker, "load_systematics", lambda self, *_: {})
+
+    maker = datacard_tools.DatacardMaker(str(dummy_hist), metadata=metadata_payload)
+
+    assert "custom_pt" in maker.variable_binning
+    assert maker.variable_binning["custom_pt"] == [0.0, 1.0, 2.0]
+
+
+def test_datacard_maker_requires_variable_definitions(tmp_path, monkeypatch):
+    dummy_hist = tmp_path / "dummy.pkl.gz"
+    _write_empty_histogram_pickle(dummy_hist)
+    monkeypatch.setattr(datacard_tools.DatacardMaker, "load_systematics", lambda self, *_: {})
+
+    with pytest.raises(ValueError):
+        datacard_tools.DatacardMaker(str(dummy_hist), metadata={"channels": {}})

--- a/tests/test_metadata_single_source.py
+++ b/tests/test_metadata_single_source.py
@@ -14,6 +14,7 @@ def _install_topcoffea_stub() -> None:
     utils_mod = ModuleType("topcoffea.modules.utils")
     utils_mod.get_hist_from_pkl = lambda *args, **kwargs: {}
     utils_mod.dump_to_pkl = lambda *args, **kwargs: None
+    utils_mod.regex_match = lambda choices, patterns: list(choices)
     remote_env_mod = ModuleType("topcoffea.modules.remote_environment")
     remote_env_mod.PIP_LOCAL_TO_WATCH = {}
     remote_env_mod.get_environment = lambda **kwargs: "env.tar.gz"
@@ -95,6 +96,7 @@ def _install_matplotlib_stubs() -> None:
         hist_mod.Hist = type("DummyHist", (), {})
         axis_mod = ModuleType("hist.axis")
         axis_mod.Variable = lambda *args, **kwargs: None
+        axis_mod.Regular = lambda *args, **kwargs: None
         hist_mod.axis = axis_mod
         sys.modules["hist"] = hist_mod
     if "cycler" not in sys.modules:
@@ -104,6 +106,27 @@ def _install_matplotlib_stubs() -> None:
 
 
 _install_matplotlib_stubs()
+def _install_boost_histogram_stub() -> None:
+    if "boost_histogram" in sys.modules:
+        return
+    module = ModuleType("boost_histogram")
+    storage_mod = ModuleType("boost_histogram.storage")
+    storage_mod.Weight = lambda *args, **kwargs: object()
+    module.storage = storage_mod
+    sys.modules["boost_histogram"] = module
+    sys.modules["boost_histogram.storage"] = storage_mod
+
+
+def _install_uproot_stub() -> None:
+    if "uproot" in sys.modules:
+        return
+    uproot_mod = ModuleType("uproot")
+    uproot_mod.open = lambda *args, **kwargs: object()
+    sys.modules["uproot"] = uproot_mod
+
+
+_install_boost_histogram_stub()
+_install_uproot_stub()
 def _install_coffea_stub() -> None:
     if "coffea" in sys.modules:
         return

--- a/tests/test_metadata_single_source.py
+++ b/tests/test_metadata_single_source.py
@@ -1,0 +1,236 @@
+import sys
+from types import ModuleType
+
+import yaml
+
+
+def _install_topcoffea_stub() -> None:
+    if "topcoffea" in sys.modules:
+        return
+    modules_pkg = ModuleType("topcoffea.modules")
+    modules_pkg.__path__ = []
+    paths_mod = ModuleType("topcoffea.modules.paths")
+    paths_mod.topcoffea_path = lambda relative: relative
+    utils_mod = ModuleType("topcoffea.modules.utils")
+    utils_mod.get_hist_from_pkl = lambda *args, **kwargs: {}
+    utils_mod.dump_to_pkl = lambda *args, **kwargs: None
+    remote_env_mod = ModuleType("topcoffea.modules.remote_environment")
+    remote_env_mod.PIP_LOCAL_TO_WATCH = {}
+    remote_env_mod.get_environment = lambda **kwargs: "env.tar.gz"
+    modules_pkg.paths = paths_mod
+    modules_pkg.utils = utils_mod
+    modules_pkg.remote_environment = remote_env_mod
+    modules_pkg.dynamic_data_reduction = ModuleType("topcoffea.modules.dynamic_data_reduction")
+    hist_mod = ModuleType("topcoffea.modules.HistEFT")
+    hist_mod.HistEFT = type("HistEFT", (), {})
+    modules_pkg.HistEFT = hist_mod
+    get_param_mod = ModuleType("topcoffea.modules.get_param_from_jsons")
+    get_param_mod.GetParam = lambda *args, **kwargs: lambda key: 1.0
+    modules_pkg.get_param_from_jsons = get_param_mod
+    html_mod = ModuleType("topcoffea.modules.HTMLGenerator")
+    html_mod.make_html = lambda *args, **kwargs: None
+    modules_pkg.HTMLGenerator = html_mod
+    scripts_pkg = ModuleType("topcoffea.scripts")
+    scripts_pkg.__path__ = []
+    make_html_mod = ModuleType("topcoffea.scripts.make_html")
+    make_html_mod.make_html = lambda *args, **kwargs: None
+    scripts_pkg.make_html = make_html_mod
+
+    topcoffea_stub = ModuleType("topcoffea")
+    topcoffea_stub.modules = modules_pkg
+    topcoffea_stub.scripts = scripts_pkg
+    topcoffea_stub.__path__ = []
+
+    sys.modules["topcoffea"] = topcoffea_stub
+    sys.modules["topcoffea.modules"] = modules_pkg
+    sys.modules["topcoffea.modules.paths"] = paths_mod
+    sys.modules["topcoffea.modules.utils"] = utils_mod
+    sys.modules["topcoffea.modules.remote_environment"] = remote_env_mod
+    sys.modules["topcoffea.modules.dynamic_data_reduction"] = modules_pkg.dynamic_data_reduction
+    sys.modules["topcoffea.modules.HistEFT"] = hist_mod
+    sys.modules["topcoffea.modules.get_param_from_jsons"] = get_param_mod
+    sys.modules["topcoffea.modules.HTMLGenerator"] = html_mod
+    sys.modules["topcoffea.scripts"] = scripts_pkg
+    sys.modules["topcoffea.scripts.make_html"] = make_html_mod
+
+
+def _install_numpy_stub() -> None:
+    if "numpy" in sys.modules:
+        return
+    numpy_stub = ModuleType("numpy")
+    numpy_stub.__version__ = "0.0.0"
+    numpy_stub.array = lambda *args, **kwargs: args
+    numpy_stub.asarray = lambda *args, **kwargs: args
+    numpy_stub.zeros = lambda *args, **kwargs: []
+    numpy_stub.ones = lambda *args, **kwargs: []
+    numpy_stub.dtype = type("DummyDType", (), {})  # type: ignore[misc]
+    numpy_stub.AxisError = type("AxisError", (Exception,), {})
+    numpy_stub.exceptions = type(
+        "NumpyExceptions", (), {"AxisError": numpy_stub.AxisError}
+    )
+    numpy_stub.bool_ = bool
+    numpy_stub.seterr = lambda *args, **kwargs: None
+    sys.modules["numpy"] = numpy_stub
+
+
+_install_topcoffea_stub()
+_install_numpy_stub()
+def _install_matplotlib_stubs() -> None:
+    if "matplotlib" not in sys.modules:
+        matplotlib_mod = ModuleType("matplotlib")
+        matplotlib_mod.use = lambda *args, **kwargs: None
+        sys.modules["matplotlib"] = matplotlib_mod
+    if "matplotlib.pyplot" not in sys.modules:
+        pyplot_mod = ModuleType("matplotlib.pyplot")
+        pyplot_mod.figure = lambda *args, **kwargs: None
+        pyplot_mod.subplots = lambda *args, **kwargs: (None, None)
+        pyplot_mod.savefig = lambda *args, **kwargs: None
+        sys.modules["matplotlib.pyplot"] = pyplot_mod
+    if "mplhep" not in sys.modules:
+        mplhep_mod = ModuleType("mplhep")
+        mplhep_mod.histplot = lambda *args, **kwargs: None
+        sys.modules["mplhep"] = mplhep_mod
+    if "hist" not in sys.modules:
+        hist_mod = ModuleType("hist")
+        hist_mod.Hist = type("DummyHist", (), {})
+        axis_mod = ModuleType("hist.axis")
+        axis_mod.Variable = lambda *args, **kwargs: None
+        hist_mod.axis = axis_mod
+        sys.modules["hist"] = hist_mod
+    if "cycler" not in sys.modules:
+        cycler_mod = ModuleType("cycler")
+        cycler_mod.cycler = lambda *args, **kwargs: None
+        sys.modules["cycler"] = cycler_mod
+
+
+_install_matplotlib_stubs()
+def _install_coffea_stub() -> None:
+    if "coffea" in sys.modules:
+        return
+    coffea_pkg = ModuleType("coffea")
+    nanoevents_mod = ModuleType("coffea.nanoevents")
+    factory_mod = ModuleType("coffea.nanoevents.factory")
+    hist_mod = ModuleType("coffea.hist")
+    class _Bin:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class _Factory:
+        @staticmethod
+        def from_root(*args, **kwargs):
+            return None
+
+    nanoevents_mod.NanoEventsFactory = _Factory
+    factory_mod.NanoEventsFactory = _Factory
+    hist_mod.Bin = _Bin
+
+    coffea_pkg.nanoevents = nanoevents_mod
+    coffea_pkg.hist = hist_mod
+    sys.modules["coffea"] = coffea_pkg
+    sys.modules["coffea.nanoevents"] = nanoevents_mod
+    sys.modules["coffea.nanoevents.factory"] = factory_mod
+    sys.modules["coffea.hist"] = hist_mod
+
+
+_install_coffea_stub()
+
+from analysis.topeft_run2 import metadata_loader
+from analysis.topeft_run2 import datacards_post_processing as dpp
+from analysis.topeft_run2 import make_cr_and_sr_plots as plots
+from analysis.topeft_run2 import comp as comp_module
+from topeft.modules import scenario_groups
+
+
+def test_load_metadata_prefers_custom_file(tmp_path):
+    metadata_file = tmp_path / "custom_meta.yml"
+    metadata_file.write_text(
+        yaml.safe_dump(
+            {
+                "channels": {"groups": {"example": {"categories": []}}},
+                "variables": {"foo": {"variable": [0, 1]}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    bundle = metadata_loader.load_metadata(metadata_file)
+
+    assert bundle.path == metadata_file.resolve()
+    assert "foo" in (bundle.variables or {})
+
+
+def test_run2_scenario_channels_use_provided_metadata(monkeypatch):
+    metadata = {
+        "channels": {
+            "groups": {
+                "TOP22_006_CH_LST_SR": {"categories": []},
+                "CH_LST_CR": {"categories": []},
+            }
+        }
+    }
+
+    def fail_fallback():
+        raise AssertionError("Fallback loader should not be used when metadata is provided")
+
+    monkeypatch.setattr(scenario_groups, "_load_group_metadata", fail_fallback)
+    result = scenario_groups.load_run2_channels_for_scenario(
+        "TOP_22_006", metadata=metadata
+    )
+
+    assert "TOP22_006_CH_LST_SR" in result["groups"]
+    assert "CH_LST_CR" in result["groups"]
+
+
+def test_resolve_scenario_metadata_respects_override(tmp_path, monkeypatch):
+    metadata_file = tmp_path / "custom_override.yml"
+    payload = {
+        "channels": {
+            "groups": {
+                "TOP22_006_CH_LST_SR": {"categories": []},
+                "CH_LST_CR": {"categories": []},
+            }
+        },
+        "variables": {"ptz": {"variable": [0, 1]}},
+    }
+    metadata_file.write_text(yaml.safe_dump(payload), encoding="utf-8")
+
+    captured = {}
+
+    class DummyHelper:
+        def __init__(self, data):
+            captured["data"] = data
+
+    monkeypatch.setattr(dpp, "ChannelMetadataHelper", DummyHelper)
+    scenario_name, bundle, _ = dpp.resolve_scenario_metadata(
+        ["TOP_22_006"],
+        metadata_path=str(metadata_file),
+        require_variables=True,
+    )
+
+    assert scenario_name == "TOP_22_006"
+    assert bundle.path == metadata_file.resolve()
+    assert captured["data"]["groups"]
+
+
+def test_plot_helpers_accept_axes_metadata(monkeypatch):
+    monkeypatch.setattr(plots, "_AXES_INFO", None, raising=False)
+    axes = {
+        "ptz": {"variable": [0, 1]},
+        "lj0pt": {"variable": [0, 1]},
+    }
+
+    plots._set_axes_info(axes)
+
+    assert plots._require_axes_info() == axes
+
+
+def test_comp_helper_uses_metadata_binning(tmp_path, monkeypatch):
+    metadata_file = tmp_path / "comp_meta.yml"
+    metadata_file.write_text(
+        yaml.safe_dump({"channels": {}, "variables": {"test": {"variable": [0, 2, 4]}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(comp_module, "BINNING", {}, raising=False)
+    comp_module._set_binning(str(metadata_file))
+
+    assert comp_module.BINNING["test"] == [0, 2, 4]

--- a/tests/test_metadata_single_source.py
+++ b/tests/test_metadata_single_source.py
@@ -182,7 +182,7 @@ def test_load_metadata_prefers_custom_file(tmp_path):
     assert "foo" in (bundle.variables or {})
 
 
-def test_run2_scenario_channels_use_provided_metadata(monkeypatch):
+def test_scenario_channels_use_provided_metadata(monkeypatch):
     metadata = {
         "channels": {
             "groups": {
@@ -196,7 +196,7 @@ def test_run2_scenario_channels_use_provided_metadata(monkeypatch):
         raise AssertionError("Fallback loader should not be used when metadata is provided")
 
     monkeypatch.setattr(scenario_groups, "_load_group_metadata", fail_fallback)
-    result = scenario_groups.load_run2_channels_for_scenario(
+    result = scenario_groups.load_channels_for_scenario(
         "TOP_22_006", metadata=metadata
     )
 

--- a/tests/test_scenario_registry.py
+++ b/tests/test_scenario_registry.py
@@ -47,7 +47,7 @@ def _tail_components(path: str, depth: int = 3) -> tuple[str, ...]:
     return parts[-depth:]
 
 
-def test_run2_scenarios_resolve_to_canonical_metadata():
+def test_scenarios_resolve_to_canonical_metadata():
     resolution = scenario_registry.resolve_scenario_choice("TOP_22_006")
     assert _tail_components(resolution.metadata_path) == (
         "analysis",
@@ -56,7 +56,7 @@ def test_run2_scenarios_resolve_to_canonical_metadata():
     )
 
 
-def test_run2_channel_groups_cover_canonical_and_derived_sets():
+def test_scenario_channel_groups_cover_canonical_and_derived_sets():
     top_channels = scenario_groups.load_channels_for_scenario("TOP_22_006")
     assert "TOP22_006_CH_LST_SR" in (top_channels.get("groups") or {})
 
@@ -64,7 +64,7 @@ def test_run2_channel_groups_cover_canonical_and_derived_sets():
     assert "ALL_CH_LST_SR" in (derived_channels.get("groups") or {})
 
 
-def test_run2_scenarios_reference_known_metadata_groups(tmp_path=None):
+def test_scenarios_reference_known_metadata_groups(tmp_path=None):
     repo_root = Path(__file__).resolve().parents[1]
     scenarios_path = repo_root / "analysis" / "metadata" / "run2_scenarios.yaml"
     metadata_path = repo_root / "analysis" / "metadata" / "metadata.yml"

--- a/tests/test_scenario_registry.py
+++ b/tests/test_scenario_registry.py
@@ -57,10 +57,10 @@ def test_run2_scenarios_resolve_to_canonical_metadata():
 
 
 def test_run2_channel_groups_cover_canonical_and_derived_sets():
-    top_channels = scenario_groups.load_run2_channels_for_scenario("TOP_22_006")
+    top_channels = scenario_groups.load_channels_for_scenario("TOP_22_006")
     assert "TOP22_006_CH_LST_SR" in (top_channels.get("groups") or {})
 
-    derived_channels = scenario_groups.load_run2_channels_for_scenario("all_analysis")
+    derived_channels = scenario_groups.load_channels_for_scenario("all_analysis")
     assert "ALL_CH_LST_SR" in (derived_channels.get("groups") or {})
 
 

--- a/topeft/modules/datacard_tools.py
+++ b/topeft/modules/datacard_tools.py
@@ -8,9 +8,8 @@ import os
 import re
 import json
 import time
-import yaml
-
 from collections import defaultdict
+from collections.abc import Mapping
 
 import topcoffea
 
@@ -18,10 +17,6 @@ from topeft.modules.paths import topeft_path
 from topeft.modules.compatibility import add_sumw2_stub
 
 regex_match = topcoffea.modules.utils.regex_match
-
-with open(topeft_path("analysis/metadata/metadata.yml"), "r") as f:
-    metadata = yaml.safe_load(f)
-axes_info = metadata["variables"]
 
 PRECISION = 6   # Decimal point precision in the text datacard output
 
@@ -192,12 +187,6 @@ class DatacardMaker():
         "ttlnu_": ["ttlnuJet_"],
     }
 
-    # Controls how we rebin the dense axis of the corresponding distribution
-    BINNING = {}
-    for name, value in axes_info.items():
-        if "variable" in value:
-            BINNING[name] = value["variable"]
-
     YEARS = ["UL16","UL16APV","UL17","UL18"]
 
     SYST_YEARS = ["2016","2016APV","2017","2018"]
@@ -317,6 +306,27 @@ class DatacardMaker():
         return r
 
     def __init__(self,pkl_path,**kwargs):
+        metadata_payload = kwargs.pop("metadata", None)
+        variable_definitions = kwargs.pop("variable_definitions", None)
+        if (
+            metadata_payload is not None
+            and variable_definitions is None
+            and isinstance(metadata_payload, Mapping)
+        ):
+            variable_definitions = metadata_payload.get("variables")
+        if variable_definitions is None:
+            raise ValueError(
+                "DatacardMaker requires histogram variable definitions via 'metadata' or 'variable_definitions'."
+            )
+        if not isinstance(variable_definitions, Mapping):
+            raise TypeError("variable_definitions must be a mapping of variable metadata")
+        self.variable_definitions = dict(variable_definitions)
+        self.variable_binning = {
+            name: value["variable"]
+            for name, value in self.variable_definitions.items()
+            if isinstance(value, dict) and "variable" in value
+        }
+
         self.year_lst        = kwargs.pop("year_lst",[])
         self.do_sm           = kwargs.pop("do_sm",False)
         self.do_nuisance     = kwargs.pop("do_nuisance",False)
@@ -502,7 +512,7 @@ class DatacardMaker():
                 h = h.remove("systematic", list(to_drop))
 
             if h.should_rebin() and km_dist != "njets":
-                edge_arr = self.BINNING[km_dist] + [list(h.axes[km_dist].edges())[-1]]
+                edge_arr = self.variable_binning[km_dist] + [list(h.axes[km_dist].edges())[-1]]
                 h = h.rebin(km_dist, hist.axis.Variable(edge_arr, km_dist, h.axes[km_dist].label))
             else:
                 # TODO: Still need to handle njets case properly

--- a/topeft/modules/datacard_tools.py
+++ b/topeft/modules/datacard_tools.py
@@ -154,6 +154,14 @@ class MissingParton(RateSystematic):
         pass
 
 class DatacardMaker():
+    """Datacard builder that operates on histogram pickles and injected metadata.
+
+    Instances must be constructed with explicit histogram variable definitions
+    (either via ``metadata`` or ``variable_definitions``). No built-in fallback
+    to the canonical ``analysis/metadata/metadata.yml`` exists—callers are
+    responsible for loading and passing the metadata they used during histogram
+    production.
+    """
     # TODO:
     #   We are abusing the grouping mechanism to also handle renaming processes, but might want to
     #   separate into two distinct actions to make things easier to follow for the reader

--- a/topeft/modules/scenario_groups.py
+++ b/topeft/modules/scenario_groups.py
@@ -37,16 +37,16 @@ class ScenarioDefinition:
         return self.group_names
 
 
-def load_run2_scenarios() -> Dict[str, ScenarioDefinition]:
-    """Return the scenarios enumerated in ``run2_scenarios.yaml`` keyed by name."""
+def load_scenarios() -> Dict[str, ScenarioDefinition]:
+    """Return the scenarios enumerated in the scenario definition YAML keyed by name."""
 
-    return dict(_load_run2_scenarios())
+    return dict(_load_scenarios())
 
 
 def resolve_scenario_groups(name: str) -> ScenarioDefinition:
     """Return the :class:`ScenarioDefinition` matching ``name``."""
 
-    scenarios = load_run2_scenarios()
+    scenarios = load_scenarios()
     try:
         return scenarios[name]
     except KeyError as exc:
@@ -57,18 +57,18 @@ def resolve_scenario_groups(name: str) -> ScenarioDefinition:
         ) from exc
 
 
-def known_run2_scenarios() -> Tuple[str, ...]:
-    """Return the scenario names enumerated in ``run2_scenarios.yaml``."""
+def known_scenarios() -> Tuple[str, ...]:
+    """Return the scenario names enumerated in the scenario definition YAML."""
 
-    return tuple(_load_run2_scenarios().keys())
+    return tuple(_load_scenarios().keys())
 
 
-def is_run2_scenario(name: str) -> bool:
-    """Return ``True`` when ``name`` is defined in ``run2_scenarios.yaml``."""
+def is_scenario(name: str) -> bool:
+    """Return ``True`` when ``name`` is defined in the scenario definition YAML."""
 
     if not name:
         return False
-    return name in _load_run2_scenarios()
+    return name in _load_scenarios()
 
 
 def load_channels_for_scenario(
@@ -84,9 +84,9 @@ def load_channels_for_scenario(
     included so callers can still rely on ``ChannelMetadataHelper`` helpers that
     need the scenario → group map. Callers should pass either the already-loaded
     metadata mapping or a metadata path; when neither is provided the canonical
-    Run 2 bundle is used as a fallback. This ensures that custom runs which
+    canonical bundle is used as a fallback. This ensures that custom runs which
     inject metadata remain consistent—only users who omit both inputs pay the
-    price of the legacy fallback to the canonical bundle.
+    price of the legacy fallback to the bundled metadata.
     """
 
     scenario = resolve_scenario_groups(name)
@@ -141,7 +141,7 @@ def load_channels_for_scenario(
 
 
 @lru_cache(maxsize=1)
-def _load_run2_scenarios() -> Mapping[str, ScenarioDefinition]:
+def _load_scenarios() -> Mapping[str, ScenarioDefinition]:
     payload = _read_yaml_mapping(SCENARIO_DEFINITIONS_PATH)
     scenarios_section = payload.get("scenarios") or {}
     if not isinstance(scenarios_section, Mapping):

--- a/topeft/modules/scenario_groups.py
+++ b/topeft/modules/scenario_groups.py
@@ -71,7 +71,7 @@ def is_run2_scenario(name: str) -> bool:
     return name in _load_run2_scenarios()
 
 
-def load_run2_channels_for_scenario(
+def load_channels_for_scenario(
     name: str,
     *,
     metadata: Mapping[str, object] | None = None,

--- a/topeft/modules/scenario_groups.py
+++ b/topeft/modules/scenario_groups.py
@@ -84,7 +84,9 @@ def load_run2_channels_for_scenario(
     included so callers can still rely on ``ChannelMetadataHelper`` helpers that
     need the scenario → group map. Callers should pass either the already-loaded
     metadata mapping or a metadata path; when neither is provided the canonical
-    Run 2 bundle is used as a fallback.
+    Run 2 bundle is used as a fallback. This ensures that custom runs which
+    inject metadata remain consistent—only users who omit both inputs pay the
+    price of the legacy fallback to the canonical bundle.
     """
 
     scenario = resolve_scenario_groups(name)

--- a/topeft/modules/scenario_groups.py
+++ b/topeft/modules/scenario_groups.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
-from typing import Dict, Mapping, MutableMapping, Sequence, Tuple
+from typing import Dict, Mapping, MutableMapping, Sequence, Tuple, Union
 
 import yaml
 
 from topeft.modules.paths import topeft_path
+
+logger = logging.getLogger(__name__)
 
 SCENARIO_DEFINITIONS_PATH = Path(
     topeft_path("../analysis/metadata/run2_scenarios.yaml")
@@ -68,17 +71,50 @@ def is_run2_scenario(name: str) -> bool:
     return name in _load_run2_scenarios()
 
 
-def load_run2_channels_for_scenario(name: str) -> Mapping[str, object]:
+def load_run2_channels_for_scenario(
+    name: str,
+    *,
+    metadata: Mapping[str, object] | None = None,
+    metadata_path: Union[str, Path, None] = None,
+) -> Mapping[str, object]:
     """Return metadata suitable for :class:`ChannelMetadataHelper`.
 
     The returned mapping follows the ``metadata['channels']`` structure and
     contains only the groups requested by ``name``.  Scenario information is
     included so callers can still rely on ``ChannelMetadataHelper`` helpers that
-    need the scenario → group map.
+    need the scenario → group map. Callers should pass either the already-loaded
+    metadata mapping or a metadata path; when neither is provided the canonical
+    Run 2 bundle is used as a fallback.
     """
 
     scenario = resolve_scenario_groups(name)
-    available_groups = _load_group_metadata()
+    available_groups = None
+    source_label = None
+
+    if metadata is not None:
+        available_groups = _extract_groups_from_payload(metadata, "<in-memory metadata>")
+        source_label = "provided metadata payload"
+    elif metadata_path is not None:
+        candidate = Path(metadata_path).expanduser()
+        if not candidate.is_absolute():
+            candidate = Path.cwd() / candidate
+        payload = _read_yaml_mapping(candidate.resolve())
+        available_groups = _extract_groups_from_payload(payload, str(candidate))
+        source_label = str(candidate)
+    else:
+        logger.warning(
+            "No metadata supplied when resolving scenario '%s'. Falling back to canonical %s; "
+            "custom runs may diverge if metadata differs.",
+            name,
+            ", ".join(str(path) for path in GROUP_METADATA_PATHS),
+        )
+        available_groups = _load_group_metadata()
+        source_label = "canonical metadata"
+
+    if not available_groups:
+        raise ValueError(
+            f"No channel groups available for scenario '{name}' (metadata source: {source_label})."
+        )
 
     selected_groups: Dict[str, Mapping[str, object]] = {}
     for group_name in scenario.groups:
@@ -159,31 +195,10 @@ def _load_group_metadata() -> Dict[str, Mapping[str, object]]:
     groups: Dict[str, Mapping[str, object]] = {}
     for metadata_path in GROUP_METADATA_PATHS:
         payload = _read_yaml_mapping(metadata_path)
-        channels = payload.get("channels") or {}
-        if not isinstance(channels, Mapping):
-            raise TypeError(
-                f"'channels' in {metadata_path} must be a mapping with 'groups'"
-            )
-        available = channels.get("groups") or {}
-        if not isinstance(available, Mapping):
-            raise TypeError(
-                f"'channels.groups' in {metadata_path} must be a mapping of group definitions"
-            )
-        for group_name, metadata in available.items():
-            if not isinstance(group_name, str):
-                raise TypeError(
-                    f"Channel group names in {metadata_path} must be strings"
-                )
-            if not isinstance(metadata, Mapping):
-                raise TypeError(
-                    f"Channel group {group_name!r} in {metadata_path} must be a mapping"
-                )
-            if group_name in groups:
-                # Some groups (e.g. shared control regions) appear in multiple
-                # metadata bundles with cosmetic differences. Retain the first
-                # encounter to provide deterministic behaviour.
-                continue
-            groups[group_name] = metadata
+        for group_name, metadata in _extract_groups_from_payload(
+            payload, str(metadata_path)
+        ).items():
+            groups.setdefault(group_name, metadata)
     return groups
 
 
@@ -195,3 +210,26 @@ def _read_yaml_mapping(path: Path) -> Mapping[str, object]:
     if not isinstance(payload, Mapping):
         raise TypeError(f"{path} must contain a YAML mapping at the top level")
     return payload
+
+
+def _extract_groups_from_payload(
+    payload: Mapping[str, object], source: str
+) -> Dict[str, Mapping[str, object]]:
+    channels = payload.get("channels") or {}
+    if not isinstance(channels, Mapping):
+        raise TypeError(f"'channels' in {source} must be a mapping with 'groups'")
+    available = channels.get("groups") or {}
+    if not isinstance(available, Mapping):
+        raise TypeError(
+            f"'channels.groups' in {source} must be a mapping of group definitions"
+        )
+    groups: Dict[str, Mapping[str, object]] = {}
+    for group_name, metadata in available.items():
+        if not isinstance(group_name, str):
+            raise TypeError(f"Channel group names in {source} must be strings")
+        if not isinstance(metadata, Mapping):
+            raise TypeError(
+                f"Channel group {group_name!r} in {source} must be a mapping"
+            )
+        groups[group_name] = metadata
+    return groups


### PR DESCRIPTION
## Summary

This PR wires the Run-2 workflow and tooling to treat the YAML metadata bundle as the single source of truth, and neutralizes the “run2”-specific helper APIs around scenarios and channels.

**Key changes:**

- Introduce `analysis/topeft_run2/metadata_loader.py` as the canonical entry point for loading metadata:
  - Provides `MetadataBundle` (path, payload, channels, systematics, variables).
  - Centralizes YAML parsing, path resolution, and section validation (`required_sections`).
- Replace ad-hoc `yaml.safe_load` calls with `load_metadata` in:
  - `analysis/topeft_run2/quickstart.py`
  - `analysis/topeft_run2/workflow.py`
  - `analysis/topeft_run2/comp.py` (histogram binning)
  - `analysis/topeft_run2/make_cr_and_sr_plots.py` (axes / binning)
  - `analysis/topeft_run2/datacards_post_processing.py` (scenario metadata)
- Extend CLIs to accept explicit metadata overrides:
  - `comp.py --metadata`
  - `make_cr_and_sr_plots.py --metadata`
  - `datacards_post_processing.py --metadata`
  - `make_cards.py --metadata`
- Rework `DatacardMaker` to **require** injected metadata:
  - No implicit read of `analysis/metadata/metadata.yml`.
  - Accepts `metadata=` or `variable_definitions=`.
  - Builds `self.variable_binning` from the injected variable definitions and uses that for rebinning.

**Scenario helpers:**

- Rename scenario APIs to remove “run2” from the public surface:
  - `load_run2_scenarios` → `load_scenarios`
  - `known_run2_scenarios` → `known_scenarios`
  - `is_run2_scenario` → `is_scenario`
  - `load_run2_channels_for_scenario` → `load_channels_for_scenario`
- Extend `load_channels_for_scenario` to prefer the already-loaded metadata:
  - `metadata` (mapping) → extract groups directly from the in-memory payload.
  - `metadata_path` → load once from the provided path and extract groups.
  - Only when neither is provided, fall back to the canonical `GROUP_METADATA_PATHS`, with a warning.
- Factor out `_extract_groups_from_payload` to validate and extract `channels.groups` from any metadata bundle.

**Scenario registry integration:**

- Add `select_metadata_path` in `scenario_registry` to choose between:
  - An explicit `--metadata` path (CLI) and
  - The registry’s default for the selected scenario.
- `resolve_scenario_metadata()` now returns `(scenario_name, MetadataBundle, ChannelMetadataHelper)` so downstream tools (datacards, plotting, etc.) reuse the same metadata bundle instead of reopening canonical paths.

**Plotting & comparison helpers:**

- `comp.py`:
  - Replace global `BINNING` from a hard-coded YAML load with `_set_binning`/`_require_binning` backed by `load_metadata`.
  - Add `--metadata` CLI option with a canonical default and a clear message when the default is used.
- `make_cr_and_sr_plots.py`:
  - Introduce `_AXES_INFO` with `_set_axes_info`/`_require_axes_info`.
  - Wire metadata loading through `load_metadata` and a `--metadata` CLI option.

## Tests

- `python -m pytest tests/test_metadata_single_source.py`
- `python -m pytest tests/test_metadata_datacards_integration.py`
- Existing `tests/test_scenario_registry.py` updated to:
  - Call `load_channels_for_scenario` instead of the legacy `load_run2_channels_for_scenario`.
  - Use the renamed scenario test names (no “run2” suffix).

All of these pass in the `coffea2025` environment used for development.