### PR TITLE
unify logging CLI, enforce TaskVine policy, and remove debug flags

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -1527,7 +1527,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         cleaned_jets = jets[~ak.any(jet_indices == veto_indices, axis=-1)]
 
         jetptname = "pt"
-        logging.info("jetptname: %s", jetptname)
+        logger.info("jetptname: %s", jetptname)
 
         cleaned_jets["pt_raw"] = (1 - cleaned_jets.rawFactor) * cleaned_jets.pt
         cleaned_jets["mass_raw"] = (1 - cleaned_jets.rawFactor) * cleaned_jets.mass
@@ -1560,13 +1560,13 @@ class AnalysisProcessor(processor.ProcessorABC):
             ),
             cleaned_jets,
         )
-        logging.info("Corrected jets pt: %s", ak.to_list(corrected_jets.pt))
+        logger.info("Corrected jets pt: %s", ak.to_list(corrected_jets.pt))
 
         cleaned_jets = ApplyJetSystematics(
             dataset.year, corrected_jets, variation_state.object_variation
         )
 
-        logging.info("Cleaned jets pt: %s", ak.to_list(cleaned_jets.pt))
+        logger.info("Cleaned jets pt: %s", ak.to_list(cleaned_jets.pt))
 
         central_jet_counts = ak.num(corrected_jets.pt, axis=-1)
         variation_jet_counts = ak.num(cleaned_jets.pt, axis=-1)
@@ -2633,14 +2633,14 @@ class AnalysisProcessor(processor.ProcessorABC):
         else:
             ecut_mask = None
 
-        logging.info("Variable name: %s", self._var)
-        logging.info("Variable definition: %s", self._var_def)
+        logger.info("Variable name: %s", self._var)
+        logger.info("Variable definition: %s", self._var_def)
         dense_axis_name = self._var
         dense_axis_vals = eval(self._var_def, {"ak": ak, "np": np}, locals())
         dense_axis_vals = self._check_dense_axis_invariants(
             dense_axis_name, dense_axis_vals, n_events
         )
-        logging.info("Variable values: %s", ak.to_list(dense_axis_vals))
+        logger.info("Variable values: %s", ak.to_list(dense_axis_vals))
         
         weight_variations_to_run = list(variation_state.weight_variations)
         if weight_variations_to_run:

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -425,7 +425,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         systematic_variations=None,
         available_systematics=None,
         metadata_path: Optional[str] = None,
-        debug_logging: bool = True,
+        debug_logging: bool = False,
         executor_mode: Optional[str] = None,
         suppress_debug_prints: Optional[bool] = None,
     ):

--- a/analysis/topeft_run2/full_run.sh
+++ b/analysis/topeft_run2/full_run.sh
@@ -27,7 +27,7 @@ PrintUsage() {
 Usage: full_run.sh [-y YEAR [YEAR ...]] [-t TAG] [--cr | --sr] \
                    [--executor {taskvine,futures,iterative}] [--outdir PATH] [--manager NAME] \
                    [--samples PATH [PATH ...]] [--scenario NAME] [--log-level LEVEL] \
-                   [--debug-logging] [--dry-run] [extra run_analysis args]
+                   [--dry-run] [extra run_analysis args]
 
 Examples:
   # Control-region TaskVine run over Run-3 bundles using defaults defined in the
@@ -60,9 +60,8 @@ Notes:
   * The default output name is <YEARS>_(CRs|SRs)_<TAG>, saved to the specified
     output directory with the 5-tuple histogram schema used throughout this
     branch.  Use --dry-run to print the resolved command without launching
-    Python.  Pass --debug-logging to forward the instrumentation flag (always
-    DEBUG) or --log-level LEVEL to tweak the Python logging verbosity seen in
-    run_analysis.py.
+    Python.  Use --log-level LEVEL to tweak the Python logging verbosity seen in
+    run_analysis.py (allowed: none, info, warning, error).
 USAGE
 }
 
@@ -110,8 +109,6 @@ main() {
   local futures_retries=0
   local futures_retry_wait=5.0
   local dry_run=false
-  local debug_logging=false
-  local processor_debug=false
   local log_level=""
   local auto_options_spec=""
 
@@ -226,34 +223,12 @@ main() {
         dry_run=true
         shift
         ;;
-      --debug-logging)
-        debug_logging=true
-        shift
-        ;;
-      --processor-debug)
-        processor_debug=true
-        shift
-        ;;
       --log-level)
         log_level="$2"
         shift 2
         ;;
       --log-level=*)
         log_level="${1#*=}"
-        shift
-        ;;
-      --debug-logging=*)
-        local value="${1#*=}"
-        if [[ "${value,,}" != "0" && "${value,,}" != "false" && -n "$value" ]]; then
-          debug_logging=true
-        fi
-        shift
-        ;;
-      --processor-debug=*)
-        local value="${1#*=}"
-        if [[ "${value,,}" != "0" && "${value,,}" != "false" && -n "$value" ]]; then
-          processor_debug=true
-        fi
         shift
         ;;
       --options)
@@ -630,10 +605,6 @@ main() {
     esac
   fi
 
-  if [[ "$debug_logging" == true && "$processor_debug" == false ]]; then
-    processor_debug=true
-  fi
-
   local -a options=(
     --outname "$out_name"
     --outpath "$outdir"
@@ -662,12 +633,6 @@ main() {
     options+=(--skip-cr --do-systs)
   fi
 
-  if [[ "$debug_logging" == true ]]; then
-    options+=(--debug-logging)
-  fi
-  if [[ "$processor_debug" == true ]]; then
-    options+=(--processor-debug)
-  fi
   if [[ -n "$log_level" ]]; then
     options+=(--log-level "$log_level")
   fi

--- a/analysis/topeft_run2/logging_utils.py
+++ b/analysis/topeft_run2/logging_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import Optional
 
 try:  # pragma: no cover - tqdm is bundled with coffea
@@ -10,7 +11,7 @@ try:  # pragma: no cover - tqdm is bundled with coffea
 except Exception:  # pragma: no cover - fallback when tqdm is unavailable
     TqdmLoggingHandler = None  # type: ignore[assignment]
 
-from .run_analysis_helpers import VALID_LOG_LEVELS
+from .run_analysis_helpers import VALID_LOG_LEVELS, VALID_LOG_LEVELS_DISPLAY
 
 logger = logging.getLogger(__name__)
 _configured = False
@@ -23,23 +24,55 @@ def _level_name_to_numeric(level_name: str) -> int:
     return resolved
 
 
-def configure_logging(level_name: str, *, formatter: Optional[str] = None) -> None:
+def _is_truthy_env(value: Optional[str]) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def configure_logging(
+    level_name: str,
+    *,
+    formatter: Optional[str] = None,
+    allow_dev_debug: bool = True,
+) -> None:
     """Configure root logging handlers with a consistent format.
 
     The helper intentionally keeps the configuration minimal: a single stream
     handler with timestamps and module names. In multi-process futures runs
     the configuration only applies to the main process for now—workers inherit
     coffea's defaults until we plumb per-process hooks.
+
+    Args:
+        level_name: Normalized log level string (NONE/INFO/WARNING/ERROR).
+        formatter: Optional format string for the handler.
+        allow_dev_debug: When True, TOPEFT_DEV_DEBUG=1 forces DEBUG on project
+            loggers even if the requested level is higher. Ignored when False.
     """
 
     global _configured
 
-    if level_name.upper() not in VALID_LOG_LEVELS:
+    normalized_level = (level_name or "").strip().upper()
+    if normalized_level not in VALID_LOG_LEVELS:
         raise ValueError(
-            f"log level '{level_name}' is not in {', '.join(sorted(VALID_LOG_LEVELS))}"
+            f"log level '{level_name}' is not in {VALID_LOG_LEVELS_DISPLAY}"
         )
 
-    numeric_level = _level_name_to_numeric(level_name)
+    dev_debug_enabled = allow_dev_debug and _is_truthy_env(
+        os.environ.get("TOPEFT_DEV_DEBUG"),
+    )
+    mute_project_loggers = normalized_level == "NONE" and not dev_debug_enabled
+
+    effective_level_name = "DEBUG" if dev_debug_enabled else normalized_level
+    project_level = (
+        logging.CRITICAL + 10 if mute_project_loggers else _level_name_to_numeric(effective_level_name)
+    )
+    root_level = (
+        _level_name_to_numeric("WARNING")
+        if mute_project_loggers
+        else _level_name_to_numeric(effective_level_name)
+    )
+
     root = logging.getLogger()
 
     # Avoid stacking multiple handlers when run_analysis.py is imported or invoked
@@ -59,14 +92,26 @@ def configure_logging(level_name: str, *, formatter: Optional[str] = None) -> No
         )
         root.addHandler(handler)
         logger.debug(
-            "configure_logging applied (effective_level=%s)", level_name.upper()
+            "configure_logging applied (effective_level=%s)", effective_level_name
         )
 
     # Root already had handlers (for example when run_analysis.py is imported in a
     # larger application); reuse them instead of stacking duplicates and update
     # their levels to follow the latest CLI request.
     for handler in root.handlers:
-        handler.setLevel(numeric_level)
+        handler.setLevel(root_level)
 
-    root.setLevel(numeric_level)
+    project_logger_names = (
+        "topeft",
+        "topcoffea",
+        "analysis",
+        "analysis.topeft_run2",
+    )
+    for name in project_logger_names:
+        project_logger = logging.getLogger(name)
+        project_logger.setLevel(project_level)
+        project_logger.disabled = mute_project_loggers and not dev_debug_enabled
+        project_logger.propagate = True
+
+    root.setLevel(root_level)
     _configured = True

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -58,7 +58,14 @@ def _verify_numpy_pandas_abi() -> None:
             "refreshed environment for both futures and TaskVine runs."
         ) from exc
 
-from run_analysis_helpers import RunConfig, RunConfigBuilder
+from run_analysis_helpers import (
+    RunConfig,
+    RunConfigBuilder,
+    _enforce_taskvine_logging_policy,
+    _normalize_executor_name,
+    _reject_legacy_debug_flags,
+    _resolve_effective_log_level,
+)
 from topeft.modules.executor_cli import (
     ExecutorCLIHelper,
     FuturesArgumentSpec,
@@ -214,8 +221,8 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         default=False,
         help=(
-            "Enable verbose AnalysisProcessor debugging/instrumentation. "
-            "Leave unset to suppress debug logs during normal production runs."
+            "Deprecated flag; no longer supported. Using this flag will raise an error. "
+            "Use --log-level (none, info, warning, error); DEBUG is reserved for internal development."
         ),
     )
     parser.add_argument(
@@ -223,15 +230,16 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         default=False,
         help=(
-            "Enable AnalysisProcessor-specific debug instrumentation without raising the global log level."
+            "Deprecated flag; no longer supported. Using this flag will raise an error. "
+            "Processor instrumentation is no longer controlled via the CLI."
         ),
     )
     parser.add_argument(
         "--log-level",
         default=None,
         help=(
-            "Set the Python logging level "
-            "(DEBUG, INFO, WARNING, ERROR, CRITICAL). Defaults to INFO when unset."
+            "Set the Python logging level to control topeft/topcoffea output. "
+            "Allowed values: none, info, warning, error. Defaults to info when unset."
         ),
     )
     parser.add_argument(
@@ -313,12 +321,6 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _normalize_executor_name(value: str | None) -> str:
-    """Return a canonical executor identifier without applying aliases."""
-
-    return (value or "").strip().lower()
-
-
 def _ensure_supported_executor(value: str) -> None:
     """Raise an error when ``value`` is not a supported executor."""
 
@@ -327,17 +329,6 @@ def _ensure_supported_executor(value: str) -> None:
             f"Unsupported executor '{value}'. "
             f"Valid options are: {', '.join(SUPPORTED_EXECUTORS)}."
         )
-
-
-def _resolve_logging_controls(config: RunConfig) -> tuple[str, bool]:
-    """Return the log level and processor-debug flag based on CLI inputs."""
-
-    if config.debug_logging:
-        return "DEBUG", True
-    if config.log_level:
-        normalized = config.log_level.upper()
-        return normalized, normalized == "DEBUG"
-    return "INFO", False
 
 
 def _apply_scenario_metadata_defaults(config: RunConfig) -> tuple[str, str, bool]:
@@ -397,6 +388,11 @@ def main(argv: Sequence[str] | None = None) -> None:
         argv_list = list(argv)
     args = parser.parse_args(argv_list)
 
+    try:
+        _reject_legacy_debug_flags(args)
+    except ValueError as exc:
+        parser.error(str(exc))
+
     if getattr(args, "options", None) and getattr(args, "scenarios", None):
         parser.error(
             "Scenario selection must come from either --scenario or --options. "
@@ -409,22 +405,24 @@ def main(argv: Sequence[str] | None = None) -> None:
     executor_default = _normalize_executor_name(getattr(parser_defaults, "executor", ""))
     if not executor_default:
         executor_default = "taskvine"
-    logger.info(
-        "[DEBUG CHECK] args.log_level=%r, args.debug_logging=%r, args.processor_debug=%r",
-        getattr(args, "log_level", None),
-        getattr(args, "debug_logging", None),
-        getattr(args, "processor_debug", None),
-    )
     executor_choice = _normalize_executor_name(getattr(args, "executor", ""))
     if not executor_choice:
         executor_choice = executor_default
     setattr(args, "executor", executor_choice)
 
     config_builder = RunConfigBuilder(parser_defaults)
-    config = config_builder.build(
-        args,
-        getattr(args, "options", None),
-    )
+    try:
+        config = config_builder.build(
+            args,
+            getattr(args, "options", None),
+        )
+    except (ValueError, TypeError, KeyError) as exc:
+        parser.error(str(exc))
+
+    try:
+        _reject_legacy_debug_flags(config)
+    except ValueError as exc:
+        parser.error(str(exc))
 
     try:
         scenario_name, metadata_path, metadata_from_options = _apply_scenario_metadata_defaults(config)
@@ -436,24 +434,35 @@ def main(argv: Sequence[str] | None = None) -> None:
             logger.error("Failed to resolve metadata scenario")
         sys.exit(1)
 
-    run_cfg = config
-    logger.info(
-        "[DEBUG CHECK] builder input: log_level from args=%r",
-        getattr(args, "log_level", None),
-    )
-    logger.info(
-        "[DEBUG CHECK] builder output: run_cfg.log_level=%r, run_cfg.debug_logging=%r, run_cfg.processor_debug=%r",
-        run_cfg.log_level,
-        run_cfg.debug_logging,
-        getattr(run_cfg, "processor_debug", None),
-    )
+    try:
+        effective_log_level = _resolve_effective_log_level(config)
+    except ValueError as exc:
+        parser.error(str(exc))
 
-    effective_log_level, driver_debug = _resolve_logging_controls(config)
+    if chunksize_from_cli:
+        config.chunksize = getattr(args, "chunksize", config.chunksize)
+    if nchunks_from_cli:
+        config.nchunks = getattr(args, "nchunks", config.nchunks)
+
+    current_executor = _normalize_executor_name(getattr(config, "executor", ""))
+    if executor_from_cli:
+        current_executor = executor_choice
+    elif not current_executor:
+        current_executor = executor_choice
+    _ensure_supported_executor(current_executor)
+    config.executor = current_executor
+
+    try:
+        _enforce_taskvine_logging_policy(config.executor, effective_log_level)
+    except ValueError as exc:
+        parser.error(str(exc))
+
     # Currently configures logging for the driver process; futures workers keep
     # their default handlers until we plumb a per-worker hook.
-    configure_logging(effective_log_level)
-
-    logger.info("[DEBUG CHECK] effective_log_level=%r", effective_log_level)
+    configure_logging(
+        effective_log_level,
+        allow_dev_debug=(config.executor != "taskvine"),
+    )
 
     if metadata_from_options:
         logger.info(
@@ -468,23 +477,9 @@ def main(argv: Sequence[str] | None = None) -> None:
             metadata_path,
         )
 
-    processor_debug = bool(getattr(config, "processor_debug", False) or driver_debug)
     config.log_level = effective_log_level
-    config.debug_logging = driver_debug
-    config.processor_debug = processor_debug
-
-    if chunksize_from_cli:
-        config.chunksize = getattr(args, "chunksize", config.chunksize)
-    if nchunks_from_cli:
-        config.nchunks = getattr(args, "nchunks", config.nchunks)
-
-    current_executor = _normalize_executor_name(getattr(config, "executor", ""))
-    if executor_from_cli:
-        current_executor = executor_choice
-    elif not current_executor:
-        current_executor = executor_choice
-    _ensure_supported_executor(current_executor)
-    config.executor = current_executor
+    config.debug_logging = False
+    config.processor_debug = False
     logger.info(
         "Using executor: %s | chunksize=%s | maxchunks=%s",
         config.executor,

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -63,7 +63,6 @@ from run_analysis_helpers import (
     RunConfigBuilder,
     _enforce_taskvine_logging_policy,
     _normalize_executor_name,
-    _reject_legacy_debug_flags,
     _resolve_effective_log_level,
 )
 from topeft.modules.executor_cli import (
@@ -214,24 +213,6 @@ def build_parser() -> argparse.ArgumentParser:
             "systematics, and 'full' prepends those lists to the per-combination "
             "table plus the structured dump (including a note when "
             "--split-lep-flavor is active)."
-        ),
-    )
-    parser.add_argument(
-        "--debug-logging",
-        action="store_true",
-        default=False,
-        help=(
-            "Deprecated flag; no longer supported. Using this flag will raise an error. "
-            "Use --log-level (none, info, warning, error); DEBUG is reserved for internal development."
-        ),
-    )
-    parser.add_argument(
-        "--processor-debug",
-        action="store_true",
-        default=False,
-        help=(
-            "Deprecated flag; no longer supported. Using this flag will raise an error. "
-            "Processor instrumentation is no longer controlled via the CLI."
         ),
     )
     parser.add_argument(
@@ -388,11 +369,6 @@ def main(argv: Sequence[str] | None = None) -> None:
         argv_list = list(argv)
     args = parser.parse_args(argv_list)
 
-    try:
-        _reject_legacy_debug_flags(args)
-    except ValueError as exc:
-        parser.error(str(exc))
-
     if getattr(args, "options", None) and getattr(args, "scenarios", None):
         parser.error(
             "Scenario selection must come from either --scenario or --options. "
@@ -417,11 +393,6 @@ def main(argv: Sequence[str] | None = None) -> None:
             getattr(args, "options", None),
         )
     except (ValueError, TypeError, KeyError) as exc:
-        parser.error(str(exc))
-
-    try:
-        _reject_legacy_debug_flags(config)
-    except ValueError as exc:
         parser.error(str(exc))
 
     try:
@@ -478,8 +449,6 @@ def main(argv: Sequence[str] | None = None) -> None:
         )
 
     config.log_level = effective_log_level
-    config.debug_logging = False
-    config.processor_debug = False
     logger.info(
         "Using executor: %s | chunksize=%s | maxchunks=%s",
         config.executor,

--- a/analysis/topeft_run2/run_analysis_helpers.py
+++ b/analysis/topeft_run2/run_analysis_helpers.py
@@ -40,7 +40,8 @@ DEFAULT_WEIGHT_VARIATIONS = [
     "nSumOfWeights_renormfactDown",
 ]
 
-VALID_LOG_LEVELS = {"CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"}
+VALID_LOG_LEVELS = {"NONE", "INFO", "WARNING", "ERROR"}
+VALID_LOG_LEVELS_DISPLAY = "none, info, warning, error"
 
 def normalize_sequence(value: Any) -> List[str]:
     """Flatten ``value`` into a list of strings."""
@@ -206,14 +207,63 @@ def coerce_log_level(value: Any) -> Optional[str]:
     if value is None:
         return None
     if isinstance(value, str):
-        normalized = value.strip().upper()
+        normalized = value.strip()
         if not normalized:
             return None
-        if normalized in VALID_LOG_LEVELS:
-            return normalized
-    raise ValueError(
-        f"log_level must be one of {', '.join(sorted(VALID_LOG_LEVELS))}"
-    )
+        lowered = normalized.lower()
+        if lowered == "debug":
+            raise ValueError(
+                "DEBUG log level is reserved for internal development and cannot be set via --log-level. "
+                f"Use one of: {VALID_LOG_LEVELS_DISPLAY}."
+            )
+        upper_normalized = lowered.upper()
+        if upper_normalized in VALID_LOG_LEVELS:
+            return upper_normalized
+    raise ValueError(f"log_level must be one of: {VALID_LOG_LEVELS_DISPLAY}")
+
+
+def _normalize_executor_name(value: str | None) -> str:
+    """Return a canonical executor identifier without applying aliases."""
+
+    return (value or "").strip().lower()
+
+
+def _resolve_effective_log_level(config: "RunConfig") -> str:
+    """Return the effective log level after applying CLI defaults."""
+
+    normalized = (config.log_level or "INFO").upper()
+    if normalized not in VALID_LOG_LEVELS:
+        raise ValueError(
+            f"log level '{normalized}' is not supported. Use one of: {VALID_LOG_LEVELS_DISPLAY}."
+        )
+    return normalized
+
+
+def _reject_legacy_debug_flags(obj: Any) -> None:
+    """Raise when legacy debug flags are supplied via CLI or options."""
+
+    if getattr(obj, "debug_logging", False):
+        raise ValueError(
+            "The --debug-logging flag has been removed. Use --log-level (none, info, warning, error). "
+            "DEBUG-level logging is reserved for internal development."
+        )
+    if getattr(obj, "processor_debug", False):
+        raise ValueError(
+            "The --processor-debug flag has been removed. Processor instrumentation is no longer controlled via the CLI. "
+            "Use --log-level for user-facing logs."
+        )
+
+
+def _enforce_taskvine_logging_policy(executor: str, log_level: str) -> None:
+    """Ensure TaskVine only runs with log-level 'none'."""
+
+    normalized_executor = _normalize_executor_name(executor)
+    normalized_level = (log_level or "").strip().upper()
+    if normalized_executor == "taskvine" and normalized_level != "NONE":
+        raise ValueError(
+            "TaskVine runs require '--log-level none' to avoid worker log spam. "
+            "Either set --log-level none or use a non-TaskVine executor."
+        )
 
 
 class SampleLoader:

--- a/analysis/topeft_run2/run_analysis_helpers.py
+++ b/analysis/topeft_run2/run_analysis_helpers.py
@@ -239,21 +239,6 @@ def _resolve_effective_log_level(config: "RunConfig") -> str:
     return normalized
 
 
-def _reject_legacy_debug_flags(obj: Any) -> None:
-    """Raise when legacy debug flags are supplied via CLI or options."""
-
-    if getattr(obj, "debug_logging", False):
-        raise ValueError(
-            "The --debug-logging flag has been removed. Use --log-level (none, info, warning, error). "
-            "DEBUG-level logging is reserved for internal development."
-        )
-    if getattr(obj, "processor_debug", False):
-        raise ValueError(
-            "The --processor-debug flag has been removed. Processor instrumentation is no longer controlled via the CLI. "
-            "Use --log-level for user-facing logs."
-        )
-
-
 def _enforce_taskvine_logging_policy(executor: str, log_level: str) -> None:
     """Ensure TaskVine only runs with log-level 'none'."""
 
@@ -429,8 +414,6 @@ class RunConfig:
     taskvine_print_stdout: bool = True
     ecut: Optional[float] = None
     summary_verbosity: str = "brief"
-    debug_logging: bool = False
-    processor_debug: bool = False
     log_level: Optional[str] = None
     log_tasks: bool = False
     environment_file: Optional[str] = "cached"
@@ -506,8 +489,6 @@ class RunConfigBuilder:
             "resources_mode": ("resources_mode", _coerce_optional_string),
             "taskvine_print_stdout": ("taskvine_print_stdout", coerce_bool),
             "summary_verbosity": ("summary_verbosity", coerce_summary_verbosity),
-            "debug_logging": ("debug_logging", coerce_bool),
-            "processor_debug": ("processor_debug", coerce_bool),
             "log_tasks": ("log_tasks", coerce_bool),
             "environment_file": ("environment_file", coerce_environment_file),
             "futures_status": ("futures_status", coerce_bool),
@@ -647,7 +628,6 @@ class RunConfigBuilder:
                 "taskvine_print_stdout": "taskvine_print_stdout",
                 "environment_file": "environment_file",
                 "log_level": "log_level",
-                "debug_logging": "debug_logging",
                 "futures_status": "futures_status",
                 "futures_tail_timeout": "futures_tail_timeout",
                 "futures_memory": "futures_memory",

--- a/analysis/topeft_run2/workflow.py
+++ b/analysis/topeft_run2/workflow.py
@@ -66,6 +66,7 @@ from topeft.modules.executor import (
 from topeft.modules.runner_output import normalise_runner_output, tuple_dict_stats
 
 logger = logging.getLogger(__name__)
+_DEV_DEBUG = os.environ.get("TOPEFT_DEV_DEBUG", "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _import_topcoffea_submodule(submodule: str):
@@ -991,7 +992,7 @@ class RunWorkflow:
             available_systematics=task.available_systematics,
             metadata_path=self._metadata_path,
             executor_mode=self._config.executor,
-            debug_logging=bool(getattr(self._config, "processor_debug", self._config.debug_logging)),
+            debug_logging=_DEV_DEBUG,
         )
         if not isinstance(processor_instance, coffea_processor_module.ProcessorABC):
             raise TypeError(
@@ -1342,7 +1343,7 @@ class RunWorkflow:
             if not channel_dict:
                 continue
 
-            if self._config.debug_logging:
+            if _DEV_DEBUG:
                 logger.info("Channel %s metadata: %s", task.clean_channel, channel_dict)
                 logger.info("Task detail: %s", task)
 

--- a/tests/test_logging_cli.py
+++ b/tests/test_logging_cli.py
@@ -1,0 +1,50 @@
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_HELPERS_PATH = Path(__file__).resolve().parents[1] / "analysis" / "topeft_run2" / "run_analysis_helpers.py"
+_HELPERS_SPEC = importlib.util.spec_from_file_location(
+    "analysis.topeft_run2.run_analysis_helpers",
+    _HELPERS_PATH,
+)
+assert _HELPERS_SPEC and _HELPERS_SPEC.loader
+run_analysis_helpers = importlib.util.module_from_spec(_HELPERS_SPEC)
+sys.modules[_HELPERS_SPEC.name] = run_analysis_helpers
+_HELPERS_SPEC.loader.exec_module(run_analysis_helpers)
+
+
+def test_taskvine_requires_silent_log_level():
+    with pytest.raises(
+        ValueError,
+        match="TaskVine runs require '--log-level none'",
+    ):
+        run_analysis_helpers._enforce_taskvine_logging_policy("taskvine", "INFO")
+
+
+def test_debug_log_level_rejected():
+    with pytest.raises(
+        ValueError,
+        match="DEBUG log level is reserved for internal development",
+    ):
+        run_analysis_helpers.coerce_log_level("debug")
+
+
+def test_legacy_debug_flags_fail():
+    with pytest.raises(
+        ValueError,
+        match="--debug-logging flag has been removed",
+    ):
+        run_analysis_helpers._reject_legacy_debug_flags(
+            argparse.Namespace(debug_logging=True, processor_debug=False),
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="--processor-debug flag has been removed",
+    ):
+        run_analysis_helpers._reject_legacy_debug_flags(
+            argparse.Namespace(debug_logging=False, processor_debug=True),
+        )

--- a/tests/test_logging_cli.py
+++ b/tests/test_logging_cli.py
@@ -1,4 +1,3 @@
-import argparse
 import importlib.util
 import sys
 from pathlib import Path
@@ -32,19 +31,26 @@ def test_debug_log_level_rejected():
         run_analysis_helpers.coerce_log_level("debug")
 
 
-def test_legacy_debug_flags_fail():
-    with pytest.raises(
-        ValueError,
-        match="--debug-logging flag has been removed",
-    ):
-        run_analysis_helpers._reject_legacy_debug_flags(
-            argparse.Namespace(debug_logging=True, processor_debug=False),
-        )
+def test_coerce_log_level_none_normalized():
+    result = run_analysis_helpers.coerce_log_level("none")
+    assert result == "NONE"
 
-    with pytest.raises(
-        ValueError,
-        match="--processor-debug flag has been removed",
-    ):
-        run_analysis_helpers._reject_legacy_debug_flags(
-            argparse.Namespace(debug_logging=False, processor_debug=True),
-        )
+
+class DummyConfig:
+    def __init__(self, log_level):
+        self.log_level = log_level
+
+
+def test_resolve_effective_log_level_defaults_to_info():
+    cfg = DummyConfig(log_level=None)
+    assert run_analysis_helpers._resolve_effective_log_level(cfg) == "INFO"
+
+
+def test_resolve_effective_log_level_accepts_warning():
+    cfg = DummyConfig(log_level="WARNING")
+    assert run_analysis_helpers._resolve_effective_log_level(cfg) == "WARNING"
+
+
+def test_non_taskvine_executor_allows_any_level():
+    run_analysis_helpers._enforce_taskvine_logging_policy("futures", "INFO")
+    run_analysis_helpers._enforce_taskvine_logging_policy("futures", "NONE")


### PR DESCRIPTION
## Summary

This PR cleans up the logging/CLI surface for Run-2 topeft, enforces a strict TaskVine logging policy, and removes legacy debug flags. It also introduces a private environment-based debug override for developers.

Concretely:

- `--log-level` is now the **only** logging-related CLI flag.
- Allowed log levels: `none`, `info`, `warning`, `error` (case-insensitive).
- TaskVine runs now **require** `--log-level none`.
- Legacy `--debug-logging` and `--processor-debug` flags are removed.
- Logging configuration is centralized via `logging_utils.configure_logging`, with an optional internal `TOPEFT_DEV_DEBUG=1` override.
- Processor/debug instrumentation now hangs off the env override instead of CLI flags.
- New tests cover log-level normalization and the TaskVine guard.

## Motivation

- The previous CLI surface exposed multiple partially overlapping logging controls:
  - `--log-level`
  - `--debug-logging`
  - `--processor-debug`
  - plus various print-based scripts.
- For TaskVine, we explicitly want *no* topeft/topcoffea logging from workers (only TaskVine’s own logs), to avoid log spam and confusing output.
- We also want a simple, documented policy:
  - Users pick from a small set of levels.
  - DEBUG-level logging is reserved for internal development and not exposed via CLI.
  - A single configuration function manages handlers and project logger levels.

## Changes

### CLI & RunConfig

- **analysis/topeft_run2/run_analysis.py**
  - Removes `--debug-logging` and `--processor-debug` from the parser.
  - `--log-level` help text now clearly states allowed values: `none`, `info`, `warning`, `error` (default: `info`).
  - Uses helper functions from `run_analysis_helpers` to:
    - Normalize the executor name.
    - Resolve the effective log level (with default).
    - Enforce the TaskVine + `none` policy.
  - Wraps `RunConfigBuilder.build(...)` and the log-level resolution in `try/except` and surfaces user-friendly errors via `parser.error(...)`.
  - Calls `configure_logging(effective_log_level, allow_dev_debug=(executor != "taskvine"))`.

- **analysis/topeft_run2/run_analysis_helpers.py**
  - Defines `VALID_LOG_LEVELS = {"NONE", "INFO", "WARNING", "ERROR"}` and `VALID_LOG_LEVELS_DISPLAY = "none, info, warning, error"`.
  - `coerce_log_level`:
    - Normalizes strings.
    - Explicitly rejects `"debug"` with an error explaining that DEBUG is reserved and listing the allowed values.
  - `_normalize_executor_name` returns a canonical lower-case executor identifier.
  - `_resolve_effective_log_level(config)`:
    - Defaults to `"INFO"` when `config.log_level` is `None`.
    - Validates that the result is one of the supported levels.
  - `_enforce_taskvine_logging_policy(executor, log_level)`:
    - Raises if executor is `taskvine` and `log_level != "NONE"` (message explains why and how to fix).
  - `RunConfig`:
    - Drops `debug_logging` and `processor_debug` fields.
  - `RunConfigBuilder`:
    - No longer maps or copies debug-related fields.

- **analysis/topeft_run2/full_run.sh**
  - Usage text no longer mentions debug flags; just `--log-level`.
  - Removes all parsing/forwarding of `--debug-logging` and `--processor-debug`.
  - Only forwards `--log-level` (if set) into the `run_analysis.py` invocation.

### Logging configuration

- **analysis/topeft_run2/logging_utils.py**
  - `configure_logging(level_name, formatter=None, allow_dev_debug=True)`:
    - Validates against `VALID_LOG_LEVELS`.
    - Reads `TOPEFT_DEV_DEBUG` from the environment when `allow_dev_debug` is `True`.
    - For non-TaskVine runs with `TOPEFT_DEV_DEBUG=1`, forces an internal DEBUG mode for project loggers (without exposing a CLI knob).
    - Implements `log-level none` by:
      - Muting project loggers (`topeft`, `topcoffea`, `analysis`, `analysis.topeft_run2`) via a level above `CRITICAL` and `logger.disabled = True`.
      - Keeping root at WARNING so external warnings/errors are still visible.
    - Ensures only one stream handler is attached to root, and updates handler levels on reconfiguration.

### Processor / workflow wiring

- **analysis/topeft_run2/analysis_processor.py**
  - Constructor default: `debug_logging=False` (so no debug instrumentation unless explicitly requested from the workflow).
  - Existing direct `logging.info` calls replaced by `logger.info` in the module:
    - jet correction/debug prints.
    - dense-axis variable debugging (name, definition, evaluated values).

- **analysis/topeft_run2/workflow.py**
  - Introduces `_DEV_DEBUG` as a module-level boolean:
    ```python
    _DEV_DEBUG = os.environ.get("TOPEFT_DEV_DEBUG", "").strip().lower() in {"1", "true", "yes", "on"}
    ```
  - Uses `_DEV_DEBUG` to:
    - Pass `debug_logging=_DEV_DEBUG` into `AnalysisProcessor`.
    - Gate extra debug logs in the workflow itself (e.g. channel metadata dumps).
  - For TaskVine runs, `run_analysis` passes `allow_dev_debug=False` into `configure_logging`, so even if `_DEV_DEBUG` is True, project loggers remain muted at configuration time (no user-visible log spam from TaskVine workers).

### Tests

- **tests/test_logging_cli.py** (new)
  - Loads `run_analysis_helpers` directly via `importlib` to avoid package import side effects.
  - Coverage:
    - `test_taskvine_requires_silent_log_level`:
      - Asserts that `_enforce_taskvine_logging_policy("taskvine", "INFO")` raises with the TaskVine message.
    - `test_debug_log_level_rejected`:
      - Asserts that `coerce_log_level("debug")` raises with the “DEBUG reserved” message.
    - `test_coerce_log_level_none_normalized`:
      - Asserts that `"none"` is normalized to `"NONE"`.
    - `test_resolve_effective_log_level_defaults_to_info`:
      - `log_level=None` → `"INFO"`.
    - `test_resolve_effective_log_level_accepts_warning`:
      - `"WARNING"` passes through unchanged.
    - `test_non_taskvine_executor_allows_any_level`:
      - `_enforce_taskvine_logging_policy("futures", "INFO")` and `"NONE"` both succeed.

## Backwards compatibility & behavior changes

- Users:
  - **Must** now use `--log-level` for logging control.
  - Can no longer use `--debug-logging` or `--processor-debug`; these flags are removed, not deprecated.
  - For normal runs, valid log levels: `none`, `info`, `warning`, `error`.
  - For TaskVine runs, the CLI must use `--log-level none`.
- Developers:
  - Can use `TOPEFT_DEV_DEBUG=1` in non-TaskVine runs to enable deeper debug instrumentation and logging without changing the CLI surface.
- TaskVine:
  - Becomes strictly “silent” with respect to topeft/topcoffea logging, as intended, while still allowing TaskVine’s own logs.

## Testing

- New test slice:
  - `$PYTHON_ENV -m pytest tests/test_logging_cli.py` ✅
- Known outstanding issue (unchanged by this PR):
  - `$PYTHON_ENV -m pytest tests/test_scenario_registry.py` still fails due to a NumPy C-extension import/ABI mismatch in the current environment. This predates the logging changes; once the environment is fixed, we can rerun broader tests.