### PR TITLE
Bump NumPy to 2.3 and add dynamic_data_reduction to topeft

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,4 +13,4 @@ dependencies:
   - xrootd
   - git
   - pyyaml
-  - numpy=2.0.*
+  - "numpy>=2.3,<2.4"

--- a/environment.yml
+++ b/environment.yml
@@ -14,3 +14,6 @@ dependencies:
   - git
   - pyyaml
   - "numpy>=2.3,<2.4"
+  - pip
+  - pip:
+      - dynamic_data_reduction>=2025.12.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "pyyaml",
     "pandas>=2.2,<2.3",
     "numpy>=2.3,<2.4",
+    "dynamic_data_reduction>=2025.12.1",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "dill",
     "pyyaml",
     "pandas>=2.2,<2.3",
-    "numpy>=2.0,<2.1",
+    "numpy>=2.3,<2.4",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

Align the Run 2 `topeft` environment with the shared `coffea2025` stack by:
- Bumping NumPy to `>=2.3,<2.4`, and
- Adding an explicit dependency on `dynamic_data_reduction` so DDR support is available both in conda-based and pip-based installs.

This keeps the packaged dependencies in sync with the environment spec and prepares `topeft` for TaskVine + DDR workflows.

## Changes

- **environment.yml**
  - Replace the old NumPy pin:
    - `numpy=2.0.*`
  - With a version range compatible with the updated coffea stack:
    - `"numpy>=2.3,<2.4"`
  - Ensure `pip` is present in the environment and install DDR from PyPI:
    - `pip`
    - `pip:`
      - `dynamic_data_reduction>=2025.12.1`

- **pyproject.toml**
  - Update the NumPy requirement to match the environment spec:
    - From: `numpy>=2.0,<2.1`
    - To:   `numpy>=2.3,<2.4`
  - Add `dynamic_data_reduction>=2025.12.1` to the core `dependencies` so pip installs get DDR as well.

## Testing

- `PYTHON_ENV="/users/apiccine/work/miniconda3/envs/coffea2025/bin/python" \`
  `"$PYTHON_ENV" -m pytest tests/test_logging_cli.py tests/test_variation_planner.py` ✅

## Follow-up

- After merging:
  - Refresh the `coffea2025` environment from `environment.yml`:
    - `conda env update -n coffea2025 -f environment.yml --prune`
  - Rebuild the TaskVine environment tarball (from the corresponding `topcoffea` branch) so workers see the updated NumPy + DDR stack.
