### PR TITLE
Custom metadata channel groups + logging / CLI debug cleanup

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -699,12 +699,11 @@ class AnalysisProcessor(processor.ProcessorABC):
         )
         # ``allowed_jerc_variations`` gates only shifted JES/JER/UES branches.
         # Central jet/MET corrections always run regardless of this payload.
-        if self._debug_logging:
-            logger.info(
-                "Resolved allowed JERC variations for %s: %s",
-                self._sample.get("histAxisName"),
-                self._allowed_jerc_variations,
-            )
+        logger.info(
+            "Resolved allowed JERC variations for %s: %s",
+            self._sample.get("histAxisName"),
+            self._allowed_jerc_variations,
+        )
 
     @staticmethod
     def _ensure_ak_array(values, dtype=None):
@@ -945,18 +944,17 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         if arr is None:
             sanitized = ak.Array([[] for _ in range(n_events)])
-            if self._debug_logging:
-                logger.info(
-                    "%s layout sanitized: None -> %s",
-                    name,
-                    ak.type(sanitized),
-                )
+            logger.info(
+                "%s layout sanitized: None -> %s",
+                name,
+                ak.type(sanitized),
+            )
             return sanitized
 
         original_type = ak.type(arr)
         arr = ak.Array(arr)
 
-        if name == "goodJets" and self._debug_logging:
+        if name == "goodJets":
             logger.info("goodJets input layout: %s", original_type)
 
         def _is_list_like(value: Any) -> bool:
@@ -999,12 +997,11 @@ class AnalysisProcessor(processor.ProcessorABC):
                 collection = list_like_candidates[0][1]
             elif zipped_collection is not None:
                 collection = ak.Array(zipped_collection)
-                if self._debug_logging:
-                    logger.info(
-                        "%s canonical jets record zipped to %s",
-                        name,
-                        ak.type(collection),
-                    )
+                logger.info(
+                    "%s canonical jets record zipped to %s",
+                    name,
+                    ak.type(collection),
+                )
             else:
                 raise ValueError(
                     f"{name}: ambiguous record layout with fields {fields}; "
@@ -1049,13 +1046,12 @@ class AnalysisProcessor(processor.ProcessorABC):
                 f"but got {ak.type(collection)}"
             )
 
-        if self._debug_logging:
-            logger.info(
-                "%s layout sanitized: %s -> %s",
-                name,
-                original_type,
-                ak.type(collection),
-            )
+        logger.info(
+            "%s layout sanitized: %s -> %s",
+            name,
+            original_type,
+            ak.type(collection),
+        )
 
         return ak.Array(collection)
 
@@ -1578,8 +1574,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         cleaned_jets = jets[~ak.any(jet_indices == veto_indices, axis=-1)]
 
         jetptname = "pt"
-        if self._debug_logging:
-            logger.info("jetptname: %s", jetptname)
+        logger.info("jetptname: %s", jetptname)
 
         cleaned_jets["pt_raw"] = (1 - cleaned_jets.rawFactor) * cleaned_jets.pt
         cleaned_jets["mass_raw"] = (1 - cleaned_jets.rawFactor) * cleaned_jets.mass
@@ -1629,16 +1624,15 @@ class AnalysisProcessor(processor.ProcessorABC):
                 "Jet systematic variations must preserve the central jet multiplicities"
             )
 
-        if self._debug_logging:
-            logger.info(
-                "Building MET for variation '%s': object_variation=%s request_variation=%r dataset_year=%s is_data=%s corrected_jets_fields=%s",
-                variation_state.name,
-                variation_state.object_variation,
-                variation_state.request.variation,
-                dataset.year,
-                dataset.is_data,
-                tuple(ak.fields(corrected_jets)),
-            )
+        logger.info(
+            "Building MET for variation '%s': object_variation=%s request_variation=%r dataset_year=%s is_data=%s corrected_jets_fields=%s",
+            variation_state.name,
+            variation_state.object_variation,
+            variation_state.request.variation,
+            dataset.year,
+            dataset.is_data,
+            tuple(ak.fields(corrected_jets)),
+        )
 
         # Same semantics apply to MET: central recomputation always runs, and
         # ``allowed_variations`` just restricts auxiliary systematic branches.
@@ -1785,30 +1779,29 @@ class AnalysisProcessor(processor.ProcessorABC):
             )
         variation_state = self._derive_lepton_features(variation_state, events, dataset)
 
-        if self._debug_logging:
-            try:
-                total_good_jets = (
-                    int(ak.sum(variation_state.njets))
-                    if variation_state.njets is not None
-                    else 0
-                )
-            except Exception:
-                total_good_jets = 0
-            try:
-                total_fwd_jets = (
-                    int(ak.sum(variation_state.nfwdj))
-                    if variation_state.nfwdj is not None
-                    else 0
-                )
-            except Exception:
-                total_fwd_jets = 0
-            logger.info(
-                "Prepared objects for variation '%s': object_variation=%s total_good_jets=%d total_fwd_jets=%d",
-                variation_state.name,
-                variation_state.object_variation,
-                total_good_jets,
-                total_fwd_jets,
+        try:
+            total_good_jets = (
+                int(ak.sum(variation_state.njets))
+                if variation_state.njets is not None
+                else 0
             )
+        except Exception:
+            total_good_jets = 0
+        try:
+            total_fwd_jets = (
+                int(ak.sum(variation_state.nfwdj))
+                if variation_state.nfwdj is not None
+                else 0
+            )
+        except Exception:
+            total_fwd_jets = 0
+        logger.info(
+            "Prepared objects for variation '%s': object_variation=%s total_good_jets=%d total_fwd_jets=%d",
+            variation_state.name,
+            variation_state.object_variation,
+            total_good_jets,
+            total_fwd_jets,
+        )
 
         return variation_state
 
@@ -2247,19 +2240,18 @@ class AnalysisProcessor(processor.ProcessorABC):
                 variation_name,
             )
 
-        if self._debug_logging:
-            weight_summary = (
-                variation_state.weight_variations
-                if variation_state.weight_variations
-                else ["nominal"]
-            )
-            logger.info(
-                "Registered weight configuration for '%s': weights=%s data_weight=%s sow_labels=%s",
-                variation_state.name,
-                weight_summary,
-                variation_state.requested_data_weight_label,
-                sorted(variation_state.sow_variations.keys()),
-            )
+        weight_summary = (
+            variation_state.weight_variations
+            if variation_state.weight_variations
+            else ["nominal"]
+        )
+        logger.info(
+            "Registered weight configuration for '%s': weights=%s data_weight=%s sow_labels=%s",
+            variation_state.name,
+            weight_summary,
+            variation_state.requested_data_weight_label,
+            sorted(variation_state.sow_variations.keys()),
+        )
 
         return weights_object
 
@@ -2724,10 +2716,9 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         channel_entries: List[Tuple[str, str, ak.Array, np.ndarray]] = []
         for lep_flav in lep_flav_iter:
-            if self._debug_logging:
-                logger.info("Selection keys: %s", selections.names)
-                logger.info("Channel def list: %r", self._channel_dict["chan_def_lst"])
-                logger.info("Channel bit '%s' present? %s", lep_chan, lep_chan in selections.names)
+            logger.info("Selection keys: %s", selections.names)
+            logger.info("Channel def list: %r", self._channel_dict["chan_def_lst"])
+            logger.info("Channel bit '%s' present? %s", lep_chan, lep_chan in selections.names)
             cuts_lst = [self.appregion, lep_chan]
             flav_ch = None
             njet_ch = None
@@ -2747,14 +2738,13 @@ class AnalysisProcessor(processor.ProcessorABC):
                 if not str(self.channel).startswith(str(base_ch_name)):
                     continue
 
-            if self._debug_logging:
-                cut_pass_info = {cut: selections.all(cut) for cut in cuts_lst}
-                logger.info(
-                    "Filling histograms for channel '%s' (base '%s') with cuts %s",
-                    ch_name,
-                    base_ch_name,
-                    cut_pass_info,
-                )
+            cut_pass_info = {cut: selections.all(cut) for cut in cuts_lst}
+            logger.info(
+                "Filling histograms for channel '%s' (base '%s') with cuts %s",
+                ch_name,
+                base_ch_name,
+                cut_pass_info,
+            )
 
             all_cuts_mask = selections.all(*cuts_lst)
             if ecut_mask is not None:
@@ -2857,13 +2847,12 @@ class AnalysisProcessor(processor.ProcessorABC):
 
                 hout[histkey].fill(**axes_fill_info_dict)
 
-                if self._debug_logging:
-                    filled_count = int(np.count_nonzero(np.asarray(all_cuts_mask)))
-                    logger.info(
-                        "Filled histkey %s with %d selected events",
-                        histkey,
-                        filled_count,
-                    )
+                filled_count = int(np.count_nonzero(np.asarray(all_cuts_mask)))
+                logger.info(
+                    "Filled histkey %s with %d selected events",
+                    histkey,
+                    filled_count,
+                )
 
                 axes_fill_info_dict = {
                     dense_axis_name + "_sumw2": dense_axis_vals[all_cuts_mask],

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -69,6 +69,56 @@ get_te_param = GetParam(topeft_path("params/params.json"))
 np.seterr(divide="ignore", invalid="ignore", over="ignore")
 
 
+def _log_region_yields(
+    dataset: str,
+    clean_channel: str,
+    application: str,
+    region_key: str,
+    region_mask: ak.Array,
+    weight_tot: ak.Array,
+) -> None:
+    """
+    Log unweighted and weighted yields for a given region.
+
+    Parameters
+    ----------
+    dataset : str
+        Name of the sample (e.g. NanoAOD dataset name).
+    clean_channel : str
+        Name of the analysis channel, without application/region.
+    application : str
+        Application/region label (e.g. isSR_2lSS).
+    region_key : str
+        Region identifier; typically matches ``application``.
+    region_mask : awkward.Array
+        Boolean mask selecting events in this region.
+    weight_tot : awkward.Array
+        Total event weights aligned with events.
+    """
+
+    n_events = int(ak.sum(region_mask))
+    if n_events == 0:
+        logger.info(
+            "Region empty: dataset=%s clean_channel=%s application=%s region=%s n_events=0",
+            dataset,
+            clean_channel,
+            application,
+            region_key,
+        )
+        return
+
+    sumw = float(ak.sum(weight_tot[region_mask]))
+    logger.info(
+        "Region yields: dataset=%s clean_channel=%s application=%s region=%s n_events=%d sumw=%.6f",
+        dataset,
+        clean_channel,
+        application,
+        region_key,
+        n_events,
+        sumw,
+    )
+
+
 # Takes strings as inputs, constructs a string for the full channel name
 # Try to construct a channel name like this: [n leptons]_[lepton flavors]_[p or m charge]_[on or off Z]_[n b jets]_[n jets]
 # chan_str should look something like "3l_p_offZ_1b", NOTE: This function assumes nlep comes first
@@ -1007,44 +1057,6 @@ class AnalysisProcessor(processor.ProcessorABC):
             )
 
         return ak.Array(collection)
-
-    def _log_region_yield(
-        self,
-        *,
-        mask: Any,
-        dataset: str,
-        base_channel: str,
-        channel: str,
-        appl_region: str,
-        lep_chan: str,
-    ) -> None:
-        """Log the number of events passing the final region mask for a chunk."""
-
-        if not getattr(self, "_debug_logging", False) and not logger.isEnabledFor(
-            logging.INFO
-        ):
-            return
-
-        if mask is None:
-            n_total = 0
-            n_selected = 0
-        else:
-            mask_array = np.asarray(mask)
-            n_total = int(mask_array.size)
-            n_selected = int(np.count_nonzero(mask_array)) if n_total else 0
-
-        frac = float(n_selected) / float(n_total) if n_total else 0.0
-        logger.info(
-            "Region yield: dataset=%s base_channel=%s channel=%s appl_region=%s lep_chan=%s selected=%d total=%d frac=%.6f",
-            dataset,
-            base_channel,
-            channel,
-            appl_region,
-            lep_chan,
-            n_selected,
-            n_total,
-            frac,
-        )
 
     def _build_histogram_key(
         self,
@@ -2752,16 +2764,6 @@ class AnalysisProcessor(processor.ProcessorABC):
                 all_cuts_mask = selections.all(*cuts_lst)
                 if ecut_mask is not None:
                     all_cuts_mask = all_cuts_mask & ecut_mask
-                if wgt_fluct == "nominal":
-                    self._log_region_yield(
-                        mask=all_cuts_mask,
-                        dataset=dataset.dataset,
-                        base_channel=base_ch_name,
-                        channel=ch_name,
-                        appl_region=self.appregion,
-                        lep_chan=lep_chan,
-                    )
-
                 if isinstance(all_cuts_mask, ak.Array):
                     mask_numpy = (
                         ak.to_numpy(all_cuts_mask)
@@ -2770,6 +2772,16 @@ class AnalysisProcessor(processor.ProcessorABC):
                     )
                 else:
                     mask_numpy = np.asarray(all_cuts_mask)
+
+                if wgt_fluct == "nominal":
+                    _log_region_yields(
+                        dataset=dataset.dataset,
+                        clean_channel=base_ch_name,
+                        application=self.appregion,
+                        region_key=self.appregion,
+                        region_mask=all_cuts_mask,
+                        weight_tot=weight,
+                    )
                 weights_flat = np.asarray(weight)[mask_numpy]
                 eft_coeffs = dataset.eft_coeffs
                 eft_coeffs_cut = (

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -1008,6 +1008,44 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         return ak.Array(collection)
 
+    def _log_region_yield(
+        self,
+        *,
+        mask: Any,
+        dataset: str,
+        base_channel: str,
+        channel: str,
+        appl_region: str,
+        lep_chan: str,
+    ) -> None:
+        """Log the number of events passing the final region mask for a chunk."""
+
+        if not getattr(self, "_debug_logging", False) and not logger.isEnabledFor(
+            logging.INFO
+        ):
+            return
+
+        if mask is None:
+            n_total = 0
+            n_selected = 0
+        else:
+            mask_array = np.asarray(mask)
+            n_total = int(mask_array.size)
+            n_selected = int(np.count_nonzero(mask_array)) if n_total else 0
+
+        frac = float(n_selected) / float(n_total) if n_total else 0.0
+        logger.info(
+            "Region yield: dataset=%s base_channel=%s channel=%s appl_region=%s lep_chan=%s selected=%d total=%d frac=%.6f",
+            dataset,
+            base_channel,
+            channel,
+            appl_region,
+            lep_chan,
+            n_selected,
+            n_total,
+            frac,
+        )
+
     def _build_histogram_key(
         self,
         variable: str,
@@ -2714,6 +2752,16 @@ class AnalysisProcessor(processor.ProcessorABC):
                 all_cuts_mask = selections.all(*cuts_lst)
                 if ecut_mask is not None:
                     all_cuts_mask = all_cuts_mask & ecut_mask
+                if wgt_fluct == "nominal":
+                    self._log_region_yield(
+                        mask=all_cuts_mask,
+                        dataset=dataset.dataset,
+                        base_channel=base_ch_name,
+                        channel=ch_name,
+                        appl_region=self.appregion,
+                        lep_chan=lep_chan,
+                    )
+
                 if isinstance(all_cuts_mask, ak.Array):
                     mask_numpy = (
                         ak.to_numpy(all_cuts_mask)

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -2720,6 +2720,9 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         channel_entries: List[Tuple[str, str, ak.Array, np.ndarray]] = []
         for lep_flav in lep_flav_iter:
+            logger.info("Selection keys: %s", selections.names)
+            logger.info("Channel def list: %r", self._channel_dict["chan_def_lst"])
+            logger.info("Channel bit '%s' present? %s", lep_chan, lep_chan in selections.names)
             cuts_lst = [self.appregion, lep_chan]
             flav_ch = None
             njet_ch = None
@@ -2926,7 +2929,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         if not self._debug_logging:
             return
 
-        logger.debug(message, *args)
+        logger.info(message, *args)
 
         if self._suppress_debug_prints:
             return

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -700,7 +700,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         # ``allowed_jerc_variations`` gates only shifted JES/JER/UES branches.
         # Central jet/MET corrections always run regardless of this payload.
         if self._debug_logging:
-            self._debug(
+            logger.info(
                 "Resolved allowed JERC variations for %s: %s",
                 self._sample.get("histAxisName"),
                 self._allowed_jerc_variations,
@@ -946,7 +946,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         if arr is None:
             sanitized = ak.Array([[] for _ in range(n_events)])
             if self._debug_logging:
-                self._debug(
+                logger.info(
                     "%s layout sanitized: None -> %s",
                     name,
                     ak.type(sanitized),
@@ -957,7 +957,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         arr = ak.Array(arr)
 
         if name == "goodJets" and self._debug_logging:
-            self._debug("goodJets input layout: %s", original_type)
+            logger.info("goodJets input layout: %s", original_type)
 
         def _is_list_like(value: Any) -> bool:
             return ak.to_layout(value, allow_record=True).is_list
@@ -1000,7 +1000,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             elif zipped_collection is not None:
                 collection = ak.Array(zipped_collection)
                 if self._debug_logging:
-                    self._debug(
+                    logger.info(
                         "%s canonical jets record zipped to %s",
                         name,
                         ak.type(collection),
@@ -1050,7 +1050,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             )
 
         if self._debug_logging:
-            self._debug(
+            logger.info(
                 "%s layout sanitized: %s -> %s",
                 name,
                 original_type,
@@ -1420,7 +1420,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             group_info = group_mapping.get(group_key, {})
 
             if group_mapping:
-                self._debug(
+                logger.info(
                     "Variation group mapping for '%s': mapping=%s key=%s info=%s",
                     variation_name,
                     group_mapping,
@@ -1578,7 +1578,8 @@ class AnalysisProcessor(processor.ProcessorABC):
         cleaned_jets = jets[~ak.any(jet_indices == veto_indices, axis=-1)]
 
         jetptname = "pt"
-        logger.info("jetptname: %s", jetptname)
+        if self._debug_logging:
+            logger.info("jetptname: %s", jetptname)
 
         cleaned_jets["pt_raw"] = (1 - cleaned_jets.rawFactor) * cleaned_jets.pt
         cleaned_jets["mass_raw"] = (1 - cleaned_jets.rawFactor) * cleaned_jets.mass
@@ -1611,13 +1612,15 @@ class AnalysisProcessor(processor.ProcessorABC):
             ),
             cleaned_jets,
         )
-        logger.info("Corrected jets pt: %s", ak.to_list(corrected_jets.pt))
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("Corrected jets pt: %s", ak.to_list(corrected_jets.pt))
 
         cleaned_jets = ApplyJetSystematics(
             dataset.year, corrected_jets, variation_state.object_variation
         )
 
-        logger.info("Cleaned jets pt: %s", ak.to_list(cleaned_jets.pt))
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("Cleaned jets pt: %s", ak.to_list(cleaned_jets.pt))
 
         central_jet_counts = ak.num(corrected_jets.pt, axis=-1)
         variation_jet_counts = ak.num(cleaned_jets.pt, axis=-1)
@@ -1627,7 +1630,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             )
 
         if self._debug_logging:
-            self._debug(
+            logger.info(
                 "Building MET for variation '%s': object_variation=%s request_variation=%r dataset_year=%s is_data=%s corrected_jets_fields=%s",
                 variation_state.name,
                 variation_state.object_variation,
@@ -1799,7 +1802,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                 )
             except Exception:
                 total_fwd_jets = 0
-            self._debug(
+            logger.info(
                 "Prepared objects for variation '%s': object_variation=%s total_good_jets=%d total_fwd_jets=%d",
                 variation_state.name,
                 variation_state.object_variation,
@@ -2250,7 +2253,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                 if variation_state.weight_variations
                 else ["nominal"]
             )
-            self._debug(
+            logger.info(
                 "Registered weight configuration for '%s': weights=%s data_weight=%s sow_labels=%s",
                 variation_state.name,
                 weight_summary,
@@ -2691,7 +2694,8 @@ class AnalysisProcessor(processor.ProcessorABC):
         dense_axis_vals = self._check_dense_axis_invariants(
             dense_axis_name, dense_axis_vals, n_events
         )
-        logger.info("Variable values: %s", ak.to_list(dense_axis_vals))
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("Variable values: %s", ak.to_list(dense_axis_vals))
 
         weight_variations_to_run = list(variation_state.weight_variations)
         if weight_variations_to_run:
@@ -2720,9 +2724,10 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         channel_entries: List[Tuple[str, str, ak.Array, np.ndarray]] = []
         for lep_flav in lep_flav_iter:
-            logger.info("Selection keys: %s", selections.names)
-            logger.info("Channel def list: %r", self._channel_dict["chan_def_lst"])
-            logger.info("Channel bit '%s' present? %s", lep_chan, lep_chan in selections.names)
+            if self._debug_logging:
+                logger.info("Selection keys: %s", selections.names)
+                logger.info("Channel def list: %r", self._channel_dict["chan_def_lst"])
+                logger.info("Channel bit '%s' present? %s", lep_chan, lep_chan in selections.names)
             cuts_lst = [self.appregion, lep_chan]
             flav_ch = None
             njet_ch = None
@@ -2744,7 +2749,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
             if self._debug_logging:
                 cut_pass_info = {cut: selections.all(cut) for cut in cuts_lst}
-                self._debug(
+                logger.info(
                     "Filling histograms for channel '%s' (base '%s') with cuts %s",
                     ch_name,
                     base_ch_name,
@@ -2854,7 +2859,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
                 if self._debug_logging:
                     filled_count = int(np.count_nonzero(np.asarray(all_cuts_mask)))
-                    self._debug(
+                    logger.info(
                         "Filled histkey %s with %d selected events",
                         histkey,
                         filled_count,
@@ -2924,21 +2929,6 @@ class AnalysisProcessor(processor.ProcessorABC):
                 break
 
         return dataset_for_histograms, dataset_for_triggers
-
-    def _debug(self, message: str, *args) -> None:
-        if not self._debug_logging:
-            return
-
-        logger.info(message, *args)
-
-        if self._suppress_debug_prints:
-            return
-
-        try:
-            formatted = message % args if args else message
-        except Exception:
-            formatted = " ".join([message, *(str(arg) for arg in args)])
-        print(formatted, flush=True)
 
     # Main function: run on a given dataset
 

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -665,6 +665,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         self._histogram_key_map = histogram_key_map
 
         histogram[self.VARIATION_SUMMARY_KEY] = []
+        histogram["region_yields"] = processor.dict_accumulator()
         self._accumulator = histogram
 
         # Set the energy threshold to cut on
@@ -2691,7 +2692,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             dense_axis_name, dense_axis_vals, n_events
         )
         logger.info("Variable values: %s", ak.to_list(dense_axis_vals))
-        
+
         weight_variations_to_run = list(variation_state.weight_variations)
         if weight_variations_to_run:
             wgt_var_lst = []
@@ -2702,6 +2703,12 @@ class AnalysisProcessor(processor.ProcessorABC):
                 wgt_var_lst.append(name)
 
         executed_weight_variations: List[str] = []
+        is_nominal_variation = (
+            variation_state.request.variation is None
+            or variation_state.variation_type == "nominal"
+            or variation_state.name == "nominal"
+        )
+        nominal_weight = weights_object.weight(None)
 
         lep_chan = self._channel_dict["chan_def_lst"][0]
         jet_req = self._channel_dict["jet_selection"]
@@ -2711,77 +2718,103 @@ class AnalysisProcessor(processor.ProcessorABC):
             else [None]
         )
 
-        for wgt_fluct in wgt_var_lst:
-            if wgt_fluct == "nominal":
-                weight = weights_object.weight(None)
-            elif wgt_fluct in weights_object.variations:
-                weight = weights_object.weight(wgt_fluct)
-            else:
-                continue
+        channel_entries: List[Tuple[str, str, ak.Array, np.ndarray]] = []
+        for lep_flav in lep_flav_iter:
+            cuts_lst = [self.appregion, lep_chan]
+            flav_ch = None
+            njet_ch = None
+            if isData:
+                cuts_lst.append("is_good_lumi")
+            if self._split_by_lepton_flavor:
+                flav_ch = lep_flav
+                cuts_lst.append(lep_flav)
+            if dense_axis_name != "njets":
+                njet_ch = jet_req
+                cuts_lst.append(jet_req)
 
-            if (
-                self.appregion.startswith("isSR")
-                and wgt_fluct in data_weight_systematics_set
-            ):
-                continue
-            executed_weight_variations.append(wgt_fluct)
-
-            if wgt_fluct == "nominal":
-                hist_variation_label = hist_label
-            else:
-                hist_variation_label = self._histogram_label_lookup.get(
-                    wgt_fluct, wgt_fluct
-                )
-
-            for lep_flav in lep_flav_iter:
-                cuts_lst = [self.appregion, lep_chan]
-                flav_ch = None
-                njet_ch = None
-                if isData:
-                    cuts_lst.append("is_good_lumi")
-                if self._split_by_lepton_flavor:
-                    flav_ch = lep_flav
-                    cuts_lst.append(lep_flav)
-                if dense_axis_name != "njets":
-                    njet_ch = jet_req
-                    cuts_lst.append(jet_req)
-
-                ch_name, base_ch_name = self._build_channel_names(
-                    lep_chan, njet_ch, flav_ch
-                )
-                if base_ch_name != self.channel:
+            ch_name, base_ch_name = self._build_channel_names(
+                lep_chan, njet_ch, flav_ch
+            )
+            if base_ch_name != self.channel:
+                if not str(self.channel).startswith(str(base_ch_name)):
                     continue
 
-                if self._debug_logging:
-                    cut_pass_info = {cut: selections.all(cut) for cut in cuts_lst}
-                    self._debug(
-                        "Filling histograms for channel '%s' (base '%s') with cuts %s",
-                        ch_name,
+            if self._debug_logging:
+                cut_pass_info = {cut: selections.all(cut) for cut in cuts_lst}
+                self._debug(
+                    "Filling histograms for channel '%s' (base '%s') with cuts %s",
+                    ch_name,
+                    base_ch_name,
+                    cut_pass_info,
+                )
+
+            all_cuts_mask = selections.all(*cuts_lst)
+            if ecut_mask is not None:
+                all_cuts_mask = all_cuts_mask & ecut_mask
+            if isinstance(all_cuts_mask, ak.Array):
+                mask_numpy = (
+                    ak.to_numpy(all_cuts_mask)
+                    if hasattr(ak, "to_numpy")
+                    else np.asarray(all_cuts_mask)
+                )
+            else:
+                mask_numpy = np.asarray(all_cuts_mask)
+
+            channel_entries.append((ch_name, base_ch_name, all_cuts_mask, mask_numpy))
+
+        if is_nominal_variation and channel_entries:
+            region_store = self._accumulator.get("region_yields")
+            for ch_name, base_ch_name, all_cuts_mask, mask_numpy in channel_entries:
+                _log_region_yields(
+                    dataset=dataset.dataset,
+                    clean_channel=base_ch_name,
+                    application=self.appregion,
+                    region_key=self.appregion,
+                    region_mask=all_cuts_mask,
+                    weight_tot=nominal_weight,
+                )
+                if region_store is not None:
+                    region_key = (
+                        dataset.dataset,
                         base_ch_name,
-                        cut_pass_info,
+                        self.appregion,
+                        "nominal",
+                    )
+                    current = region_store.get(region_key, np.zeros(2, dtype=float))
+                    n_events = int(np.count_nonzero(mask_numpy))
+                    sumw_nominal = (
+                        float(np.sum(np.asarray(nominal_weight)[mask_numpy]))
+                        if n_events
+                        else 0.0
+                    )
+                    region_store[region_key] = current + np.array(
+                        [float(n_events), sumw_nominal], dtype=float
                     )
 
-                all_cuts_mask = selections.all(*cuts_lst)
-                if ecut_mask is not None:
-                    all_cuts_mask = all_cuts_mask & ecut_mask
-                if isinstance(all_cuts_mask, ak.Array):
-                    mask_numpy = (
-                        ak.to_numpy(all_cuts_mask)
-                        if hasattr(ak, "to_numpy")
-                        else np.asarray(all_cuts_mask)
-                    )
+        for ch_name, base_ch_name, all_cuts_mask, mask_numpy in channel_entries:
+            for wgt_fluct in wgt_var_lst:
+                if wgt_fluct == "nominal":
+                    weight = weights_object.weight(None)
+                elif wgt_fluct in weights_object.variations:
+                    weight = weights_object.weight(wgt_fluct)
                 else:
-                    mask_numpy = np.asarray(all_cuts_mask)
+                    continue
+
+                if (
+                    self.appregion.startswith("isSR")
+                    and wgt_fluct in data_weight_systematics_set
+                ):
+                    continue
+                if wgt_fluct not in executed_weight_variations:
+                    executed_weight_variations.append(wgt_fluct)
 
                 if wgt_fluct == "nominal":
-                    _log_region_yields(
-                        dataset=dataset.dataset,
-                        clean_channel=base_ch_name,
-                        application=self.appregion,
-                        region_key=self.appregion,
-                        region_mask=all_cuts_mask,
-                        weight_tot=weight,
+                    hist_variation_label = hist_label
+                else:
+                    hist_variation_label = self._histogram_label_lookup.get(
+                        wgt_fluct, wgt_fluct
                     )
+
                 weights_flat = np.asarray(weight)[mask_numpy]
                 eft_coeffs = dataset.eft_coeffs
                 eft_coeffs_cut = (

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -944,7 +944,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         if arr is None:
             sanitized = ak.Array([[] for _ in range(n_events)])
-            logger.info(
+            logger.debug(
                 "%s layout sanitized: None -> %s",
                 name,
                 ak.type(sanitized),
@@ -953,9 +953,6 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         original_type = ak.type(arr)
         arr = ak.Array(arr)
-
-        if name == "goodJets":
-            logger.info("goodJets input layout: %s", original_type)
 
         def _is_list_like(value: Any) -> bool:
             return ak.to_layout(value, allow_record=True).is_list
@@ -997,7 +994,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                 collection = list_like_candidates[0][1]
             elif zipped_collection is not None:
                 collection = ak.Array(zipped_collection)
-                logger.info(
+                logger.debug(
                     "%s canonical jets record zipped to %s",
                     name,
                     ak.type(collection),
@@ -1045,13 +1042,6 @@ class AnalysisProcessor(processor.ProcessorABC):
                 f"{name}: expected at least a [events][objects] jagged layout for axis=1 concatenation, "
                 f"but got {ak.type(collection)}"
             )
-
-        logger.info(
-            "%s layout sanitized: %s -> %s",
-            name,
-            original_type,
-            ak.type(collection),
-        )
 
         return ak.Array(collection)
 
@@ -1574,7 +1564,6 @@ class AnalysisProcessor(processor.ProcessorABC):
         cleaned_jets = jets[~ak.any(jet_indices == veto_indices, axis=-1)]
 
         jetptname = "pt"
-        logger.info("jetptname: %s", jetptname)
 
         cleaned_jets["pt_raw"] = (1 - cleaned_jets.rawFactor) * cleaned_jets.pt
         cleaned_jets["mass_raw"] = (1 - cleaned_jets.rawFactor) * cleaned_jets.mass
@@ -1624,7 +1613,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                 "Jet systematic variations must preserve the central jet multiplicities"
             )
 
-        logger.info(
+        logger.debug(
             "Building MET for variation '%s': object_variation=%s request_variation=%r dataset_year=%s is_data=%s corrected_jets_fields=%s",
             variation_state.name,
             variation_state.object_variation,
@@ -2739,7 +2728,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                     continue
 
             cut_pass_info = {cut: selections.all(cut) for cut in cuts_lst}
-            logger.info(
+            logger.debug(
                 "Filling histograms for channel '%s' (base '%s') with cuts %s",
                 ch_name,
                 base_ch_name,

--- a/analysis/topeft_run2/logging_utils.py
+++ b/analysis/topeft_run2/logging_utils.py
@@ -15,11 +15,21 @@ from .run_analysis_helpers import VALID_LOG_LEVELS, VALID_LOG_LEVELS_DISPLAY
 
 logger = logging.getLogger(__name__)
 _configured = False
+_project_handler: Optional[logging.Handler] = None
+
+LOG_LEVEL_MAP = {
+    "NONE": logging.CRITICAL + 10,
+    "CRITICAL": logging.CRITICAL,
+    "ERROR": logging.ERROR,
+    "WARNING": logging.WARNING,
+    "INFO": logging.INFO,
+    "DEBUG": logging.DEBUG,
+}
 
 
 def _level_name_to_numeric(level_name: str) -> int:
-    resolved = getattr(logging, level_name.upper(), None)
-    if not isinstance(resolved, int):
+    resolved = LOG_LEVEL_MAP.get(level_name.strip().upper())
+    if resolved is None:
         raise ValueError(f"Unknown logging level '{level_name}'.")
     return resolved
 
@@ -65,12 +75,14 @@ def configure_logging(
 
     effective_level_name = "DEBUG" if dev_debug_enabled else normalized_level
     project_level = (
-        logging.CRITICAL + 10 if mute_project_loggers else _level_name_to_numeric(effective_level_name)
+        _level_name_to_numeric(effective_level_name)
+        if not mute_project_loggers
+        else _level_name_to_numeric("NONE")
     )
     root_level = (
-        _level_name_to_numeric("WARNING")
+        _level_name_to_numeric("NONE")
         if mute_project_loggers
-        else _level_name_to_numeric(effective_level_name)
+        else _level_name_to_numeric("INFO")
     )
 
     root = logging.getLogger()
@@ -78,6 +90,7 @@ def configure_logging(
     # Avoid stacking multiple handlers when run_analysis.py is imported or invoked
     # repeatedly; reuse existing root handlers whenever they are present.
     attach_handler = not root.handlers
+    format_string = formatter or "%(asctime)s %(levelname)s %(name)s: %(message)s"
     if attach_handler:
         # Prefer tqdm-aware logging so progress bars and INFO lines do not stomp
         # on each other; fall back to a plain stream handler if tqdm is missing.
@@ -85,11 +98,7 @@ def configure_logging(
             handler: logging.Handler = TqdmLoggingHandler()
         else:
             handler = logging.StreamHandler()
-        handler.setFormatter(
-            logging.Formatter(
-                formatter or "%(asctime)s %(levelname)s %(name)s: %(message)s"
-            )
-        )
+        handler.setFormatter(logging.Formatter(format_string))
         root.addHandler(handler)
         logger.debug(
             "configure_logging applied (effective_level=%s)", effective_level_name
@@ -100,6 +109,16 @@ def configure_logging(
     # their levels to follow the latest CLI request.
     for handler in root.handlers:
         handler.setLevel(root_level)
+        handler.setFormatter(logging.Formatter(format_string))
+
+    global _project_handler
+    if _project_handler is None:
+        if TqdmLoggingHandler is not None:
+            _project_handler = TqdmLoggingHandler()
+        else:
+            _project_handler = logging.StreamHandler()
+    _project_handler.setFormatter(logging.Formatter(format_string))
+    _project_handler.setLevel(project_level)
 
     project_logger_names = (
         "topeft",
@@ -111,7 +130,9 @@ def configure_logging(
         project_logger = logging.getLogger(name)
         project_logger.setLevel(project_level)
         project_logger.disabled = mute_project_loggers and not dev_debug_enabled
-        project_logger.propagate = True
+        project_logger.propagate = False
+        if _project_handler not in project_logger.handlers:
+            project_logger.addHandler(_project_handler)
 
     root.setLevel(root_level)
     _configured = True

--- a/analysis/topeft_run2/logging_utils.py
+++ b/analysis/topeft_run2/logging_utils.py
@@ -71,9 +71,10 @@ def configure_logging(
     dev_debug_enabled = allow_dev_debug and _is_truthy_env(
         os.environ.get("TOPEFT_DEV_DEBUG"),
     )
-    mute_project_loggers = normalized_level == "NONE" and not dev_debug_enabled
-
-    effective_level_name = "DEBUG" if dev_debug_enabled else normalized_level
+    effective_level_name = (
+        "DEBUG" if (normalized_level == "DEBUG" or dev_debug_enabled) else normalized_level
+    )
+    mute_project_loggers = normalized_level == "NONE"
     project_level = (
         _level_name_to_numeric(effective_level_name)
         if not mute_project_loggers
@@ -135,4 +136,8 @@ def configure_logging(
             project_logger.addHandler(_project_handler)
 
     root.setLevel(root_level)
+    if dev_debug_enabled and not mute_project_loggers:
+        logger.info(
+            "TOPEFT_DEV_DEBUG detected: forcing project loggers to DEBUG (root remains INFO)."
+        )
     _configured = True

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -242,6 +242,14 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--allow-partial-channel-groups",
+        action="store_true",
+        help=(
+            "Allow runs to proceed when a scenario is missing some channel groups"
+            " in the provided metadata. By default a missing group raises an error."
+        ),
+    )
+    parser.add_argument(
         "--skip-sr",
         action="store_true",
         help="Skip all signal region categories",

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -220,7 +220,7 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help=(
             "Set the Python logging level to control topeft/topcoffea output. "
-            "Allowed values: none, info, warning, error. Defaults to info when unset."
+            "Allowed values: none, info, warning, error, debug. Defaults to info when unset."
         ),
     )
     parser.add_argument(

--- a/analysis/topeft_run2/run_analysis_helpers.py
+++ b/analysis/topeft_run2/run_analysis_helpers.py
@@ -423,6 +423,7 @@ class RunConfig:
     futures_prefetch: Optional[int] = 1
     futures_retries: int = 0
     futures_retry_wait: float = 5.0
+    channel_groups_strict: bool = True
 
 
 class RunConfigBuilder:
@@ -470,6 +471,11 @@ class RunConfigBuilder:
             "skip_cr": ("skip_cr", coerce_bool),
             "do_np": ("do_np", coerce_bool),
             "do_renormfact_envelope": ("do_renormfact_envelope", coerce_bool),
+            "channel_groups_strict": ("channel_groups_strict", coerce_bool),
+            "allow_partial_channel_groups": (
+                "channel_groups_strict",
+                lambda v: not coerce_bool(v),
+            ),
             "log_level": ("log_level", coerce_log_level),
             "wc_list": ("wc_list", normalize_sequence),
             "ecut": ("ecut", coerce_optional_float),

--- a/analysis/topeft_run2/run_analysis_helpers.py
+++ b/analysis/topeft_run2/run_analysis_helpers.py
@@ -424,6 +424,8 @@ class RunConfig:
     futures_retries: int = 0
     futures_retry_wait: float = 5.0
     channel_groups_strict: bool = True
+    options_profile: Optional[str] = None
+    options_path: Optional[str] = None
 
 
 class RunConfigBuilder:
@@ -599,6 +601,9 @@ class RunConfigBuilder:
 
             for section in yaml_sections:
                 _apply_source(section)
+
+        config.options_profile = selected_profile
+        config.options_path = options_path
 
         if options_path is None:
             cli_attr_map = {

--- a/analysis/topeft_run2/run_analysis_helpers.py
+++ b/analysis/topeft_run2/run_analysis_helpers.py
@@ -40,8 +40,8 @@ DEFAULT_WEIGHT_VARIATIONS = [
     "nSumOfWeights_renormfactDown",
 ]
 
-VALID_LOG_LEVELS = {"NONE", "INFO", "WARNING", "ERROR"}
-VALID_LOG_LEVELS_DISPLAY = "none, info, warning, error"
+VALID_LOG_LEVELS = {"NONE", "INFO", "WARNING", "ERROR", "DEBUG"}
+VALID_LOG_LEVELS_DISPLAY = "none, info, warning, error, debug"
 
 def normalize_sequence(value: Any) -> List[str]:
     """Flatten ``value`` into a list of strings."""
@@ -210,13 +210,7 @@ def coerce_log_level(value: Any) -> Optional[str]:
         normalized = value.strip()
         if not normalized:
             return None
-        lowered = normalized.lower()
-        if lowered == "debug":
-            raise ValueError(
-                "DEBUG log level is reserved for internal development and cannot be set via --log-level. "
-                f"Use one of: {VALID_LOG_LEVELS_DISPLAY}."
-            )
-        upper_normalized = lowered.upper()
+        upper_normalized = normalized.upper()
         if upper_normalized in VALID_LOG_LEVELS:
             return upper_normalized
     raise ValueError(f"log_level must be one of: {VALID_LOG_LEVELS_DISPLAY}")

--- a/analysis/topeft_run2/workflow.py
+++ b/analysis/topeft_run2/workflow.py
@@ -95,6 +95,7 @@ from .run_analysis_helpers import (
     unique_preserving_order,
     weight_variations_from_metadata,
 )
+from . import scenario_registry
 from .metadata_loader import load_metadata
 from .nanoevents_helpers import nanoevents_factory_from_root
 from .systematics_validation import (
@@ -1680,15 +1681,32 @@ def run_workflow(config: RunConfig) -> None:
                 ", ".join(config.scenario_names[1:]),
             )
             config.scenario_names = [primary_scenario]
+        canonical_path = Path(
+            scenario_registry.resolve_scenario_path(primary_scenario)
+        ).resolve()
+        metadata_is_custom = Path(metadata_file).resolve() != canonical_path
         try:
-            channels_data = scenario_groups.load_channels_for_scenario(
-                primary_scenario
-            )
-            logger.info(
-                "Loaded %d canonical channel groups for scenario '%s'.",
-                len((channels_data or {}).get("groups", {})),
-                primary_scenario,
-            )
+            if metadata_is_custom:
+                channels_data = scenario_groups.load_channels_for_scenario(
+                    primary_scenario,
+                    metadata=metadata,
+                    metadata_path=str(metadata_file),
+                )
+                logger.info(
+                    "Loaded %d channel groups for scenario '%s' from metadata '%s'.",
+                    len((channels_data or {}).get("groups", {})),
+                    primary_scenario,
+                    metadata_file,
+                )
+            else:
+                channels_data = scenario_groups.load_channels_for_scenario(
+                    primary_scenario
+                )
+                logger.info(
+                    "Loaded %d canonical channel groups for scenario '%s'.",
+                    len((channels_data or {}).get("groups", {})),
+                    primary_scenario,
+                )
         except Exception as exc:  # pragma: no cover - defensive guard
             logger.warning(
                 "Falling back to inline channel metadata for scenario '%s': %s",

--- a/analysis/topeft_run2/workflow.py
+++ b/analysis/topeft_run2/workflow.py
@@ -136,11 +136,15 @@ class ChannelPlanner:
         skip_sr: bool = False,
         skip_cr: bool = False,
         scenario_names: Optional[Sequence[str]] = None,
+        channel_groups_strict: bool = True,
+        warn_on_partial_groups: bool = True,
     ) -> None:
         self._channel_helper = channel_helper
         self._skip_sr = bool(skip_sr)
         self._skip_cr = bool(skip_cr)
         self._scenario_names = list(scenario_names or [])
+        self._channel_groups_strict = bool(channel_groups_strict)
+        self._warn_on_partial_groups = bool(warn_on_partial_groups)
 
         self._sr_groups = None
         self._cr_groups = None
@@ -316,7 +320,11 @@ class ChannelPlanner:
                 if not self._skip_sr and group not in sr_groups:
                     sr_groups.append(group)
 
-        group_names = channel_helper.selected_group_names(self._scenario_names)
+        group_names = channel_helper.selected_group_names(
+            self._scenario_names,
+            strict=self._channel_groups_strict,
+            warn_on_partial=self._warn_on_partial_groups,
+        )
         for group_name in group_names:
             _register_group(group_name)
 
@@ -1685,12 +1693,15 @@ def run_workflow(config: RunConfig) -> None:
             scenario_registry.resolve_scenario_path(primary_scenario)
         ).resolve()
         metadata_is_custom = Path(metadata_file).resolve() != canonical_path
+        strict_mode = bool(config.channel_groups_strict)
         try:
+            scenario_kwargs = {"strict": strict_mode}
             if metadata_is_custom:
                 channels_data = scenario_groups.load_channels_for_scenario(
                     primary_scenario,
                     metadata=metadata,
                     metadata_path=str(metadata_file),
+                    **scenario_kwargs,
                 )
                 logger.info(
                     "Loaded %d channel groups for scenario '%s' from metadata '%s'.",
@@ -1700,7 +1711,7 @@ def run_workflow(config: RunConfig) -> None:
                 )
             else:
                 channels_data = scenario_groups.load_channels_for_scenario(
-                    primary_scenario
+                    primary_scenario, **scenario_kwargs
                 )
                 logger.info(
                     "Loaded %d canonical channel groups for scenario '%s'.",
@@ -1728,6 +1739,8 @@ def run_workflow(config: RunConfig) -> None:
         skip_sr=config.skip_sr,
         skip_cr=config.skip_cr,
         scenario_names=config.scenario_names,
+        channel_groups_strict=strict_mode,
+        warn_on_partial_groups=not (metadata_is_custom and not strict_mode),
     )
 
     var_defs = metadata.get("variables")

--- a/analysis/topeft_run2/workflow.py
+++ b/analysis/topeft_run2/workflow.py
@@ -29,14 +29,12 @@ import gzip
 import json
 import logging
 import os
-import subprocess
 import numpy as np
 import tempfile
 import time
 import warnings
 from functools import partial
 from pathlib import Path
-from datetime import datetime
 from dataclasses import asdict, dataclass, field
 from typing import (
     Any,
@@ -102,90 +100,6 @@ def _merge_region_yields(
             target[key] = arr
         else:
             target[key] = np.asarray(current, dtype=float) + arr
-
-
-def _write_region_yields_report(
-    region_yields: Mapping[Tuple[str, str, str, str], Any],
-    *,
-    config: "RunConfig",
-    metadata_path: str,
-    scenario_names: Sequence[str],
-) -> None:
-    """Persist a per-region yields report under reports/ following AGENTS.md conventions."""
-
-    if not region_yields:
-        return
-
-    repo_root = Path(__file__).resolve().parents[2]
-    reports_dir = repo_root / "reports"
-    reports_dir.mkdir(parents=True, exist_ok=True)
-
-    try:
-        branch = (
-            subprocess.check_output(
-                ["git", "rev-parse", "--abbrev-ref", "HEAD"], text=True
-            ).strip()
-        )
-    except Exception:
-        branch = "unknown-branch"
-
-    timestamp = datetime.now().strftime("%Y%m%d-%H%M")
-    report_path = reports_dir / f"topeft-{branch}-{timestamp}-region-yields.md"
-
-    entries: List[Tuple[str, str, str, str, float, float]] = []
-    per_dataset_totals: Dict[str, np.ndarray] = {}
-    overall = np.zeros(2, dtype=float)
-
-    for key, value in sorted(region_yields.items()):
-        dataset, channel, application, variation = key
-        arr = np.asarray(value, dtype=float)
-        n_events = float(arr[0]) if arr.size > 0 else 0.0
-        sumw = float(arr[1]) if arr.size > 1 else 0.0
-        entries.append(
-            (str(dataset), str(channel), str(application), str(variation), n_events, sumw)
-        )
-        per_dataset_totals.setdefault(dataset, np.zeros(2, dtype=float))[:] += arr[:2]
-        overall += arr[:2]
-
-    lines: List[str] = []
-    lines.append("# Per-region yields report (Run-2 TopEFT)")
-    lines.append("")
-    lines.append("## Summary")
-    lines.append(
-        f"- Options profile: {getattr(config, 'options_profile', None) or 'unspecified'}"
-    )
-    scenario_label = ", ".join(str(s) for s in scenario_names) if scenario_names else "unspecified"
-    lines.append(f"- Scenarios: {scenario_label}")
-    lines.append(f"- Metadata: {metadata_path}")
-    lines.append(f"- Output tag: {getattr(config, 'outname', '<unknown>')}")
-    lines.append(f"- Branch: {branch}")
-    lines.append(f"- Timestamp: {timestamp}")
-    lines.append("")
-    lines.append("## Per-region yields (nominal)")
-    lines.append("")
-    lines.append("| dataset | channel | application | variation | n_events | sumw_nominal |")
-    lines.append("|---|---|---|---|---|---|")
-    for dataset, channel, application, variation, n_events, sumw in entries:
-        lines.append(
-            f"| {dataset} | {channel} | {application} | {variation} | {n_events:.0f} | {sumw:.6f} |"
-        )
-    if not entries:
-        lines.append("| _none_ | _none_ | _none_ | _none_ | 0 | 0.000000 |")
-
-    lines.append("")
-    lines.append("## Totals")
-    lines.append("")
-    lines.append("| dataset | n_events | sumw_nominal |")
-    lines.append("|---|---|---|")
-    for dataset, arr in sorted(per_dataset_totals.items()):
-        lines.append(f"| {dataset} | {arr[0]:.0f} | {arr[1]:.6f} |")
-    lines.append(f"| **overall** | {overall[0]:.0f} | {overall[1]:.6f} |")
-    lines.append("")
-    lines.append("## Testing")
-    lines.append("")
-    lines.append("- Not run as part of this write-out; run a small profile such as `python analysis/topeft_run2/run_analysis.py --options ./configs/fullR2_run_local.yml:sr_it_test` to regenerate histograms and this report.")
-
-    report_path.write_text("\n".join(lines))
 
 
 _topcoffea_paths = _import_topcoffea_submodule("paths")
@@ -1694,8 +1608,6 @@ class RunWorkflow:
             os.system("mkdir -p %s" % self._config.outpath)
         out_pkl_file = os.path.join(self._config.outpath, self._config.outname + ".pkl.gz")
 
-        region_yields = output.get("region_yields", {})
-
         serialised_output = normalise_runner_output(output)
         if isinstance(serialised_output, Mapping):
             total_bins, filled_bins = tuple_dict_stats(serialised_output)
@@ -1709,16 +1621,6 @@ class RunWorkflow:
 
             cloudpickle.dump(serialised_output, fout)
         logger.info("Finished writing %s", out_pkl_file)
-
-        try:
-            _write_region_yields_report(
-                region_yields,
-                config=self._config,
-                metadata_path=self._config.metadata_path or "",
-                scenario_names=self._config.scenario_names or [],
-            )
-        except Exception:
-            logger.warning("Failed to write region yields report", exc_info=True)
 
         if self._config.do_np:
             logger.info("Starting nonprompt estimation")

--- a/analysis/topeft_run2/workflow.py
+++ b/analysis/topeft_run2/workflow.py
@@ -29,11 +29,14 @@ import gzip
 import json
 import logging
 import os
+import subprocess
+import numpy as np
 import tempfile
 import time
 import warnings
 from functools import partial
 from pathlib import Path
+from datetime import datetime
 from dataclasses import asdict, dataclass, field
 from typing import (
     Any,
@@ -82,6 +85,107 @@ def _import_topcoffea_submodule(submodule: str):
             )
             % module_name
         ) from exc
+
+
+def _merge_region_yields(
+    target: Dict[Tuple[str, str, str, str], np.ndarray],
+    incoming: Mapping[Tuple[str, str, str, str], Any],
+) -> None:
+    """Accumulate region yield arrays into ``target`` in place."""
+
+    if not incoming:
+        return
+    for key, value in incoming.items():
+        arr = np.asarray(value, dtype=float)
+        current = target.get(key)
+        if current is None:
+            target[key] = arr
+        else:
+            target[key] = np.asarray(current, dtype=float) + arr
+
+
+def _write_region_yields_report(
+    region_yields: Mapping[Tuple[str, str, str, str], Any],
+    *,
+    config: "RunConfig",
+    metadata_path: str,
+    scenario_names: Sequence[str],
+) -> None:
+    """Persist a per-region yields report under reports/ following AGENTS.md conventions."""
+
+    if not region_yields:
+        return
+
+    repo_root = Path(__file__).resolve().parents[2]
+    reports_dir = repo_root / "reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        branch = (
+            subprocess.check_output(
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"], text=True
+            ).strip()
+        )
+    except Exception:
+        branch = "unknown-branch"
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M")
+    report_path = reports_dir / f"topeft-{branch}-{timestamp}-region-yields.md"
+
+    entries: List[Tuple[str, str, str, str, float, float]] = []
+    per_dataset_totals: Dict[str, np.ndarray] = {}
+    overall = np.zeros(2, dtype=float)
+
+    for key, value in sorted(region_yields.items()):
+        dataset, channel, application, variation = key
+        arr = np.asarray(value, dtype=float)
+        n_events = float(arr[0]) if arr.size > 0 else 0.0
+        sumw = float(arr[1]) if arr.size > 1 else 0.0
+        entries.append(
+            (str(dataset), str(channel), str(application), str(variation), n_events, sumw)
+        )
+        per_dataset_totals.setdefault(dataset, np.zeros(2, dtype=float))[:] += arr[:2]
+        overall += arr[:2]
+
+    lines: List[str] = []
+    lines.append("# Per-region yields report (Run-2 TopEFT)")
+    lines.append("")
+    lines.append("## Summary")
+    lines.append(
+        f"- Options profile: {getattr(config, 'options_profile', None) or 'unspecified'}"
+    )
+    scenario_label = ", ".join(str(s) for s in scenario_names) if scenario_names else "unspecified"
+    lines.append(f"- Scenarios: {scenario_label}")
+    lines.append(f"- Metadata: {metadata_path}")
+    lines.append(f"- Output tag: {getattr(config, 'outname', '<unknown>')}")
+    lines.append(f"- Branch: {branch}")
+    lines.append(f"- Timestamp: {timestamp}")
+    lines.append("")
+    lines.append("## Per-region yields (nominal)")
+    lines.append("")
+    lines.append("| dataset | channel | application | variation | n_events | sumw_nominal |")
+    lines.append("|---|---|---|---|---|---|")
+    for dataset, channel, application, variation, n_events, sumw in entries:
+        lines.append(
+            f"| {dataset} | {channel} | {application} | {variation} | {n_events:.0f} | {sumw:.6f} |"
+        )
+    if not entries:
+        lines.append("| _none_ | _none_ | _none_ | _none_ | 0 | 0.000000 |")
+
+    lines.append("")
+    lines.append("## Totals")
+    lines.append("")
+    lines.append("| dataset | n_events | sumw_nominal |")
+    lines.append("|---|---|---|")
+    for dataset, arr in sorted(per_dataset_totals.items()):
+        lines.append(f"| {dataset} | {arr[0]:.0f} | {arr[1]:.6f} |")
+    lines.append(f"| **overall** | {overall[0]:.0f} | {overall[1]:.6f} |")
+    lines.append("")
+    lines.append("## Testing")
+    lines.append("")
+    lines.append("- Not run as part of this write-out; run a small profile such as `python analysis/topeft_run2/run_analysis.py --options ./configs/fullR2_run_local.yml:sr_it_test` to regenerate histograms and this report.")
+
+    report_path.write_text("\n".join(lines))
 
 
 _topcoffea_paths = _import_topcoffea_submodule("paths")
@@ -1324,6 +1428,7 @@ class RunWorkflow:
         runner = self._executor_factory.create_runner()
 
         output: Dict[str, Any] = {}
+        merged_region_yields: Dict[Tuple[str, str, str, str], np.ndarray] = {}
 
         total_tasks = len(histogram_plan.tasks)
         for idt, task in enumerate(histogram_plan.tasks):
@@ -1409,6 +1514,9 @@ class RunWorkflow:
             summary_payload = out.pop(
                 analysis_processor.AnalysisProcessor.VARIATION_SUMMARY_KEY, ()
             )
+            region_yields_payload = out.pop("region_yields", None)
+            if region_yields_payload:
+                _merge_region_yields(merged_region_yields, region_yields_payload)
             self._log_variation_recap(
                 task_index=idt + 1,
                 total_tasks=total_tasks,
@@ -1417,6 +1525,8 @@ class RunWorkflow:
             )
             output.update(out)
 
+        if merged_region_yields:
+            output["region_yields"] = merged_region_yields
         dt = time.time() - tstart
 
         if self._config.executor == "futures":
@@ -1584,6 +1694,8 @@ class RunWorkflow:
             os.system("mkdir -p %s" % self._config.outpath)
         out_pkl_file = os.path.join(self._config.outpath, self._config.outname + ".pkl.gz")
 
+        region_yields = output.get("region_yields", {})
+
         serialised_output = normalise_runner_output(output)
         if isinstance(serialised_output, Mapping):
             total_bins, filled_bins = tuple_dict_stats(serialised_output)
@@ -1597,6 +1709,16 @@ class RunWorkflow:
 
             cloudpickle.dump(serialised_output, fout)
         logger.info("Finished writing %s", out_pkl_file)
+
+        try:
+            _write_region_yields_report(
+                region_yields,
+                config=self._config,
+                metadata_path=self._config.metadata_path or "",
+                scenario_names=self._config.scenario_names or [],
+            )
+        except Exception:
+            logger.warning("Failed to write region yields report", exc_info=True)
 
         if self._config.do_np:
             logger.info("Starting nonprompt estimation")

--- a/topeft/modules/channel_metadata.py
+++ b/topeft/modules/channel_metadata.py
@@ -275,7 +275,11 @@ class ChannelMetadataHelper:
         return tuple(self._groups.keys())
 
     def selected_group_names(
-        self, scenario_names: Optional[Sequence[str]]
+        self,
+        scenario_names: Optional[Sequence[str]],
+        *,
+        strict: bool = True,
+        warn_on_partial: bool = True,
     ) -> Tuple[str, ...]:
         """Return the ordered group names for the requested scenarios.
 
@@ -302,13 +306,16 @@ class ChannelMetadataHelper:
                 requested_groups = tuple(scenario.groups)
                 present = [name for name in requested_groups if name in available_groups]
                 missing = [name for name in requested_groups if name not in available_groups]
-                # Allow partial coverage: intersect scenario groups with metadata contents.
+                if strict and missing:
+                    raise KeyError(
+                        f"Scenario {scenario_name!r} references unknown group(s): {', '.join(missing)}"
+                    )
                 if not present:
                     raise KeyError(
                         f"Scenario {scenario_name!r} references channel groups {requested_groups!r}, "
                         "none of which are present in the loaded metadata."
                     )
-                if missing:
+                if missing and warn_on_partial:
                     logger.warning(
                         "Scenario %r: using subset of channel groups from metadata. "
                         "Requested: %s | Found: %s | Missing: %s",
@@ -317,7 +324,8 @@ class ChannelMetadataHelper:
                         ", ".join(present),
                         ", ".join(missing),
                     )
-                for group_name in present:
+                active_group_names = requested_groups if strict or not missing else tuple(present)
+                for group_name in active_group_names:
                     if group_name not in seen:
                         seen.add(group_name)
                         normalized.append(group_name)

--- a/topeft/modules/channel_metadata.py
+++ b/topeft/modules/channel_metadata.py
@@ -9,8 +9,12 @@ similar set of fields while benefiting from the richer metadata schema.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Dict, Iterable, Iterator, List, Mapping, Optional, Sequence, Tuple
+
+
+logger = logging.getLogger(__name__)
 
 
 def _normalize_histogram_list(
@@ -288,17 +292,32 @@ class ChannelMetadataHelper:
                 )
             normalized: List[str] = []
             seen = set()
+            available_groups = set(self._groups.keys())
             for scenario_name in scenario_names:
                 scenario = self._scenarios.get(scenario_name)
                 if scenario is None:
                     raise KeyError(
                         f"Scenario {scenario_name!r} not found in metadata"
                     )
-                for group_name in scenario.groups:
-                    if group_name not in self._groups:
-                        raise KeyError(
-                            f"Scenario {scenario_name!r} references unknown group {group_name!r}"
-                        )
+                requested_groups = tuple(scenario.groups)
+                present = [name for name in requested_groups if name in available_groups]
+                missing = [name for name in requested_groups if name not in available_groups]
+                # Allow partial coverage: intersect scenario groups with metadata contents.
+                if not present:
+                    raise KeyError(
+                        f"Scenario {scenario_name!r} references channel groups {requested_groups!r}, "
+                        "none of which are present in the loaded metadata."
+                    )
+                if missing:
+                    logger.warning(
+                        "Scenario %r: using subset of channel groups from metadata. "
+                        "Requested: %s | Found: %s | Missing: %s",
+                        scenario_name,
+                        ", ".join(requested_groups),
+                        ", ".join(present),
+                        ", ".join(missing),
+                    )
+                for group_name in present:
                     if group_name not in seen:
                         seen.add(group_name)
                         normalized.append(group_name)

--- a/topeft/modules/runner_output.py
+++ b/topeft/modules/runner_output.py
@@ -11,6 +11,7 @@ analysis scripts as well as the training utilities.
 
 from __future__ import annotations
 
+import logging
 from collections import OrderedDict
 from typing import Any, Dict, Mapping, Optional, Tuple
 
@@ -26,6 +27,8 @@ try:  # pragma: no cover - topcoffea is optional for a subset of the tests
     import topcoffea
 except ModuleNotFoundError:
     topcoffea = None  # type: ignore[assignment]
+
+_logger = logging.getLogger(__name__)
 
 
 def _load_hist_eft():  # pragma: no cover - import shim exercised in dedicated tests
@@ -100,25 +103,37 @@ def _summarise_histogram(histogram: Any) -> Dict[str, Any]:
     variances: Optional[np.ndarray] = None
 
     if HistEFT is not None and isinstance(histogram, HistEFT):
-        entries = histogram.values() #sumw2=True)
-        for payload in entries: #.values():
-            if isinstance(payload, tuple):
-                current_values = _ensure_numpy(payload[0])
-                raw_variances = payload[1]
-                current_variances = None if raw_variances is None else _ensure_numpy(raw_variances)
-            else:
-                current_values = _ensure_numpy(payload)
-                current_variances = None
-
-            values = current_values if values is None else values + current_values
-            if current_variances is None:
-                variances = None if variances is None else None
-            else:
-                variances = (
-                    current_variances
-                    if variances is None
-                    else variances + current_variances
+        dense_hists = getattr(histogram, "_dense_hists", None)
+        if isinstance(dense_hists, Mapping) and len(dense_hists) == 0:
+            _logger.info(
+                "runner_output: encountered empty sparse histogram in summary; treating as empty."
+            )
+        else:
+            try:
+                entries = histogram.values() #sumw2=True)
+            except (KeyError, IndexError):
+                _logger.info(
+                    "runner_output: sparse histogram missing base dense entry; treating as empty.",
                 )
+            else:
+                for payload in entries: #.values():
+                    if isinstance(payload, tuple):
+                        current_values = _ensure_numpy(payload[0])
+                        raw_variances = payload[1]
+                        current_variances = None if raw_variances is None else _ensure_numpy(raw_variances)
+                    else:
+                        current_values = _ensure_numpy(payload)
+                        current_variances = None
+
+                    values = current_values if values is None else values + current_values
+                    if current_variances is None:
+                        variances = None if variances is None else None
+                    else:
+                        variances = (
+                            current_variances
+                            if variances is None
+                            else variances + current_variances
+                        )
     elif Hist is not None and isinstance(histogram, Hist):
         if axis is not None:
             for axis_obj in histogram.axes:
@@ -244,4 +259,3 @@ __all__ = [
     "normalise_runner_output",
     "tuple_dict_stats",
 ]
-

--- a/topeft/modules/scenario_groups.py
+++ b/topeft/modules/scenario_groups.py
@@ -90,19 +90,21 @@ def load_channels_for_scenario(
     """
 
     scenario = resolve_scenario_groups(name)
-    available_groups = None
-    source_label = None
+    provided_metadata = metadata is not None or metadata_path is not None
 
     if metadata is not None:
-        available_groups = _extract_groups_from_payload(metadata, "<in-memory metadata>")
-        source_label = "provided metadata payload"
+        available_groups = _extract_groups_from_payload(
+            metadata, "<in-memory metadata>"
+        )
+        source_label = metadata_path or "provided metadata payload"
     elif metadata_path is not None:
         candidate = Path(metadata_path).expanduser()
         if not candidate.is_absolute():
             candidate = Path.cwd() / candidate
-        payload = _read_yaml_mapping(candidate.resolve())
-        available_groups = _extract_groups_from_payload(payload, str(candidate))
-        source_label = str(candidate)
+        resolved = candidate.resolve()
+        payload = _read_yaml_mapping(resolved)
+        available_groups = _extract_groups_from_payload(payload, str(resolved))
+        source_label = str(resolved)
     else:
         logger.warning(
             "No metadata supplied when resolving scenario '%s'. Falling back to canonical %s; "
@@ -118,16 +120,41 @@ def load_channels_for_scenario(
             f"No channel groups available for scenario '{name}' (metadata source: {source_label})."
         )
 
+    requested_groups = list(scenario.groups)
     selected_groups: Dict[str, Mapping[str, object]] = {}
-    for group_name in scenario.groups:
-        try:
-            metadata = available_groups[group_name]
-        except KeyError as exc:
-            raise KeyError(
-                f"Scenario {scenario.name!r} references unknown group {group_name!r}."
-            ) from exc
+    missing_groups = []
+
+    for group_name in requested_groups:
+        metadata = available_groups.get(group_name)
+        if metadata is None:
+            missing_groups.append(group_name)
+            continue
         if group_name not in selected_groups:
             selected_groups[group_name] = metadata
+
+    if not selected_groups:
+        raise KeyError(
+            f"No channel groups for scenario '{scenario.name}' found in metadata ({source_label}). "
+            f"Requested groups: {', '.join(requested_groups) or '<none>'}. "
+            f"Available groups: {', '.join(sorted(available_groups)) or '<none>'}."
+        )
+
+    if missing_groups and provided_metadata:
+        logger.warning(
+            "Scenario '%s': using subset of channel groups from metadata (%s). "
+            "Requested: %s | Found: %s | Missing: %s",
+            scenario.name,
+            source_label,
+            ", ".join(requested_groups),
+            ", ".join(selected_groups),
+            ", ".join(missing_groups),
+        )
+    elif missing_groups:
+        missing = ", ".join(missing_groups)
+        raise KeyError(
+            f"Scenario {scenario.name!r} references unknown group(s): {missing} "
+            f"(metadata source: {source_label})."
+        )
 
     return {
         "groups": selected_groups,

--- a/topeft/modules/scenario_groups.py
+++ b/topeft/modules/scenario_groups.py
@@ -76,6 +76,7 @@ def load_channels_for_scenario(
     *,
     metadata: Mapping[str, object] | None = None,
     metadata_path: Union[str, Path, None] = None,
+    strict: bool = True,
 ) -> Mapping[str, object]:
     """Return metadata suitable for :class:`ChannelMetadataHelper`.
 
@@ -90,7 +91,7 @@ def load_channels_for_scenario(
     """
 
     scenario = resolve_scenario_groups(name)
-    provided_metadata = metadata is not None or metadata_path is not None
+    metadata_supplied = metadata is not None or metadata_path is not None
 
     if metadata is not None:
         available_groups = _extract_groups_from_payload(
@@ -121,16 +122,28 @@ def load_channels_for_scenario(
         )
 
     requested_groups = list(scenario.groups)
-    selected_groups: Dict[str, Mapping[str, object]] = {}
-    missing_groups = []
 
-    for group_name in requested_groups:
-        metadata = available_groups.get(group_name)
-        if metadata is None:
-            missing_groups.append(group_name)
-            continue
-        if group_name not in selected_groups:
-            selected_groups[group_name] = metadata
+    if strict:
+        missing_groups = [name for name in requested_groups if name not in available_groups]
+        if missing_groups:
+            raise KeyError(
+                f"Scenario {scenario.name!r} references unknown group(s): {', '.join(missing_groups)} "
+                f"(metadata source: {source_label})."
+            )
+        selected_groups: Dict[str, Mapping[str, object]] = {
+            group_name: available_groups[group_name]
+            for group_name in requested_groups
+        }
+    else:
+        selected_groups = {}
+        missing_groups = []
+        for group_name in requested_groups:
+            metadata_entry = available_groups.get(group_name)
+            if metadata_entry is None:
+                missing_groups.append(group_name)
+                continue
+            if group_name not in selected_groups:
+                selected_groups[group_name] = metadata_entry
 
     if not selected_groups:
         raise KeyError(
@@ -139,7 +152,7 @@ def load_channels_for_scenario(
             f"Available groups: {', '.join(sorted(available_groups)) or '<none>'}."
         )
 
-    if missing_groups and provided_metadata:
+    if not strict and missing_groups and metadata_supplied:
         logger.warning(
             "Scenario '%s': using subset of channel groups from metadata (%s). "
             "Requested: %s | Found: %s | Missing: %s",
@@ -148,12 +161,6 @@ def load_channels_for_scenario(
             ", ".join(requested_groups),
             ", ".join(selected_groups),
             ", ".join(missing_groups),
-        )
-    elif missing_groups:
-        missing = ", ".join(missing_groups)
-        raise KeyError(
-            f"Scenario {scenario.name!r} references unknown group(s): {missing} "
-            f"(metadata source: {source_label})."
         )
 
     return {


### PR DESCRIPTION
## Summary

This PR does two things for the Run-2 workflow:

1. **Custom metadata channel groups**

   The workflow now properly honors user-supplied channel groups when a `metadata_path` is provided, instead of always falling back to the canonical `analysis/metadata/metadata.yml` for known scenarios such as `TOP_22_006`.

   - `run_workflow` passes the loaded metadata payload/path into `scenario_groups.load_channels_for_scenario(...)` whenever a custom `metadata_path` is set.
   - `load_channels_for_scenario`:
     - Uses the provided metadata for channel groups when available.
     - Intersects the scenario’s requested groups with those actually present in the custom metadata.
     - Warns when some requested groups are missing.
     - Raises a clear error if none of the requested groups are found.
   - Canonical metadata is still used as before when no custom `metadata_path` is supplied.

   This allows trimmed metadata bundles (e.g. only `TOP22_006_CH_LST_SR`) to drive the Run-2 channel layout without silently reintroducing the full canonical group set.

2. **Logging and CLI debug level**

   The logging stack is cleaned up so that:
   - `AnalysisProcessor` logs directly with `logger.info` / `logger.debug` (no `debug_logging` flag, no `_debug` helper, no stdout prints).
   - `--log-level debug` is now accepted by the CLI and turns on DEBUG for `topeft` / `topcoffea` **without** enabling DEBUG for third-party dependencies.
   - The root logger stays at INFO for normal runs; `none` fully mutes log output, and `TOPEFT_DEV_DEBUG=1` can be used as an override for development.
   - Region yields are still merged into the in-memory output (`region_yields` in the `.pkl.gz`), but no separate Markdown report is written.

---

## Motivation

### 1. Custom metadata for channel groups

Previously, when running with something like:

- `metadata_path = analysis/metadata/metadata_loc.yml`
- `scenario_names = ["TOP_22_006"]`

the workflow would:

1. Load `metadata_loc.yml` for systematics and variables, **but**
2. Call `scenario_groups.load_channels_for_scenario("TOP_22_006")` **without** passing that metadata.
3. `load_channels_for_scenario` then logged a “No metadata supplied… falling back to canonical …” message.
4. Channel planning used the canonical `analysis/metadata/metadata.yml` to build the full TOP-22-006 SR+CR channel set, ignoring the trimmed groups in `metadata_loc.yml`.

That made it impossible to reduce or customize channel groups via a local metadata file while still using the scenario registry.

### 2. Logging noise and inaccessible DEBUG

On the logging side:

- `AnalysisProcessor` diagnostics were gated behind a `debug_logging` flag and a custom `_debug` helper that sometimes printed to stdout.
- The CLI explicitly rejected `--log-level debug` as “dev-only”, forcing developers to rely on environment hacks to access DEBUG logs.
- Turning on DEBUG globally risked pulling in a lot of noisy third-party logging.

The goal here is to:

- Let `--log-level debug` behave like a normal level for project code.
- Keep third-party modules at INFO unless explicitly muted.
- Make the processor logs predictable and readable without special flags.

---

## Implementation details

### A. `run_workflow` and scenario channel groups

**File:** `analysis/topeft_run2/workflow.py`

- After loading metadata, `run_workflow(...)` now distinguishes between:
  - **Canonical mode:** no `metadata_path` override → use the canonical metadata as before.
  - **Custom mode:** a `metadata_path` override is provided → pass both the in-memory payload and its path into:

    ```python
    channels_data = scenario_groups.load_channels_for_scenario(
        primary_scenario,
        metadata=metadata,
        metadata_path=str(metadata_file),
        strict=strict_mode,
    )
    ```

- `strict_mode` comes from the new `RunConfig.channel_groups_strict`:
  - Default: `True` → missing groups are an error.
  - `--allow-partial-channel-groups` flips this to `False` so you can run with a subset of groups.

- Logging is updated so that:
  - When using canonical metadata, we log that canonical channel groups were loaded.
  - When using custom metadata, we log that channel groups were loaded from the given file.

### B. `scenario_groups.load_channels_for_scenario`

**File:** `topeft/modules/scenario_groups.py`

- Function signature now supports a `strict` flag:

  ```python
  def load_channels_for_scenario(
      name: str,
      *,
      metadata: Mapping[str, object] | None = None,
      metadata_path: Union[str, Path, None] = None,
      strict: bool = True,
  ) -> Mapping[str, object]:
  ```

- Behavior:
  - If `metadata` / `metadata_path` is provided:
    - Load and extract channel groups from that payload/path.
    - Look up the scenario definition (`run2_scenarios.yaml`) to get the list of requested groups.
    - Compute the intersection between requested and available groups.
  - If `strict=True`:
    - Any missing groups → explicit `KeyError` listing which groups are unknown.
    - All requested groups must be present.
  - If `strict=False`:
    - Use only the intersection (subset) of requested vs available.
    - If some requested groups are missing and custom metadata was supplied:
      - Emit a warning including requested, found, missing, and the metadata source.
    - If the intersection is empty:
      - Raise an error that no channel groups for the scenario were found in the supplied metadata.

- Only when both `metadata` and `metadata_path` are `None` do we:
  - Log that no metadata was supplied and fall back to canonical metadata.
  - Preserve the existing behavior for completely canonical runs.

### C. `ChannelMetadataHelper.selected_group_names`

**File:** `topeft/modules/channel_metadata.py`

- The helper now supports partial group coverage and clearer errors:

  ```python
  def selected_group_names(
      self,
      scenario_names: Optional[Sequence[str]],
      *,
      strict: bool = True,
      warn_on_partial: bool = True,
  ) -> Tuple[str, ...]:
  ```

- For each scenario:
  - Compute requested vs available group names.
  - If `strict=True` and any missing → raise.
  - If no overlap at all → raise with a clear message.
  - If there is a subset and `warn_on_partial=True` → log a warning summarizing requested, found, and missing groups.
  - The final ordered list of groups respects scenario definitions while de-duplicating across multiple scenarios.

This ties the scenario registry, custom metadata, and channel planning together in a predictable way.

### D. `RunConfig` and CLI options

**File:** `analysis/topeft_run2/run_analysis_helpers.py`, `analysis/topeft_run2/run_analysis.py`

- `RunConfig` gains:
  - `channel_groups_strict: bool = True`
  - `options_profile: Optional[str] = None`
  - `options_path: Optional[str] = None`  
    (for bookkeeping of the selected options profile and YAML path).

- CLI:
  - `--log-level` now accepts `none, info, warning, error, debug` and is documented as such.
  - `--allow-partial-channel-groups` sets `channel_groups_strict=False` via the builder mapping.

- `coerce_log_level`:
  - Simply uppercases input and validates against `VALID_LOG_LEVELS = {"NONE","INFO","WARNING","ERROR","DEBUG"}`.
  - No special-casing of `debug` as “dev only”.

### E. Logging configuration and runtime behavior

**File:** `analysis/topeft_run2/logging_utils.py`

- Introduced a small map for level names:

  ```python
  LOG_LEVEL_MAP = {
      "NONE": logging.CRITICAL + 10,
      "CRITICAL": logging.CRITICAL,
      "ERROR": logging.ERROR,
      "WARNING": logging.WARNING,
      "INFO": logging.INFO,
      "DEBUG": logging.DEBUG,
  }
  ```

- `configure_logging` behavior:
  - Normalizes the CLI `log_level` and checks `TOPEFT_DEV_DEBUG` (when `allow_dev_debug=True`).
  - Chooses `effective_level_name`:
    - `DEBUG` if `log_level == "DEBUG"` or `TOPEFT_DEV_DEBUG=1`.
    - Otherwise the chosen level (`NONE`, `INFO`, `WARNING`, `ERROR`).
  - Mutes project loggers only when `log_level == "NONE"`.
  - Keeps the root logger at:
    - `INFO` for all non-`none` levels (including debug).
    - Effectively off (`NONE`) when `log_level == "NONE"`.

- Project logger handler:
  - A dedicated `_project_handler` is attached to `topeft`, `topcoffea`, and other project namespaces.
  - `propagate=False` so project DEBUG logs do not turn on DEBUG for dependencies.
  - Formatter is synchronized with the root handler.

- If `TOPEFT_DEV_DEBUG=1` and `log_level != "none"`:
  - Project loggers are forced to DEBUG.
  - An INFO message is emitted once:

    ```text
    TOPEFT_DEV_DEBUG detected: forcing project loggers to DEBUG (root remains INFO).
    ```

### F. AnalysisProcessor logging and region yields

**File:** `analysis/topeft_run2/analysis_processor.py`

- Removed `_debug` and stopped using `self._debug_logging` for processor logs; all diagnostics now go directly through `logger.info` or `logger.debug`.
- Key changes:
  - Variation mapping, object layout sanitation, MET building, jet counts, weight registration, and histogram fill counts are always logged at INFO.
  - Heavy dumps:
    - Corrected jet `pt`
    - Cleaned jet `pt`
    - Dense variable values
    are logged at DEBUG and only computed when DEBUG is enabled via `logger.isEnabledFor(logging.DEBUG)`.

- Region yields:
  - `_log_region_yields(...)` logs per-region event counts and sumw at INFO for nominal variations.
  - `AnalysisProcessor` accumulates these into a `region_yields` dict accumulator.
  - `RunWorkflow` merges per-task `region_yields` into the top-level output mapping; no additional file is written.

---

## Behavior changes

### 1. Custom metadata vs canonical metadata

- **No custom metadata (`metadata_path` unset)**  
  Behavior is unchanged:
  - Canonical `analysis/metadata/metadata.yml` + scenario registry drive channel group selection.
  - The same canonical SR+CR layout for scenarios such as `TOP_22_006` is preserved.

- **Custom metadata with a subset of groups (`metadata_path` set)**  
  Example: a `metadata_loc.yml` that defines only `TOP22_006_CH_LST_SR`.

  - Channel groups are resolved from `metadata_loc.yml`.
  - For `TOP_22_006`, the scenario’s requested groups (e.g. `TOP22_006_CH_LST_SR`, `CH_LST_CR`) are intersected with the groups available in `metadata_loc.yml`.
  - If only `TOP22_006_CH_LST_SR` is present:
    - That group is used.
    - A warning is logged that `CH_LST_CR` is missing (unless `channel_groups_strict=True`, in which case it becomes an error).
  - The histogram plan includes only the channels defined in the surviving groups from the custom metadata file.

### 2. Logging and debug level

- `--log-level info`:
  - Project loggers at INFO.
  - Third-party loggers at INFO.
  - Structural AnalysisProcessor logs visible; heavy arrays suppressed.

- `--log-level debug`:
  - Project loggers at DEBUG (including heavy arrays).
  - Root/dependency loggers still at INFO, avoiding framework noise.

- `--log-level none`:
  - Both project and root loggers effectively muted.

- `TOPEFT_DEV_DEBUG=1`:
  - Acts as an override to force project loggers to DEBUG for any non-`none` level.
  - Root remains at INFO, dependencies remain at INFO.

---

## Logging messages (metadata side)

When using a custom metadata file, new/adjusted messages include:

- Info:

  ```text
  Loaded <N> channel groups for scenario '<SCENARIO>' from metadata '<PATH>'.
  ```

- Warning (partial overlap):

  ```text
  Scenario '<SCENARIO>' requested channel groups <requested> but only found <found> in metadata '<PATH>'; missing: <missing>.
  ```

- Error (no overlap):

  ```text
  No channel groups for scenario '<SCENARIO>' were found in metadata '<PATH>'.
  ```

When no metadata is supplied, the original canonical fallback message is preserved.

---

## How to verify

1. **Custom metadata, subset of groups**

   - Run with:
     - `metadata_path=analysis/metadata/metadata_loc.yml`
     - `scenario_names=["TOP_22_006"]`
   - Confirm:
     - You do **not** see a “falling back to canonical metadata” message.
     - You **do** see a message indicating channel groups were loaded from the custom metadata.
     - If some groups from the scenario are missing in `metadata_loc.yml`, you see a warning (unless strict mode turns this into an error).
   - Check the “Planned histogram summary”:
     - Only channels under the surviving groups from `metadata_loc.yml` appear.

2. **Canonical behavior**

   - Run without `metadata_path`:
     - Confirm that the canonical TOP-22-006 SR+CR layout is restored.
     - Confirm that canonical metadata is reported in the logs.

3. **Logging levels**

   - Run a small slice with:
     - `--log-level info`: expect clean, structural logs; no heavy arrays.
     - `--log-level debug`: expect additional DEBUG entries (corrected / cleaned jet `pt`, dense variable values) while third-party modules stay at INFO.
     - `--log-level none`: expect minimal/no logging.
     - Optionally, `TOPEFT_DEV_DEBUG=1` combined with `--log-level info` and verify that project DEBUG logs are emitted while root remains at INFO.

4. **Sanity checks**

   - Confirm that `region_yields` is present in the serialized `.pkl.gz` output and that no additional Markdown report is produced.
   - Check that `run_analysis.py --help` shows `debug` in the allowed `--log-level` values.

---

## Potential pitfalls

- Typos or outdated group names in custom metadata will either:
  - Trigger warnings and drop those groups (in non-strict mode), or
  - Raise explicit errors (in strict mode).
- If scenario definitions change (e.g. groups added in `run2_scenarios.yaml`) but custom metadata is not updated, the workflow will run on the intersection, and you’ll see warnings about missing groups.
- If all requested groups for a scenario are missing from the supplied metadata, the workflow will now fail explicitly instead of silently reverting to canonical metadata.