### PR TITLE
Canonical channel labels (jet-bin + flavor) + add `quick_check` validator for tuple-keyed outputs

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -2777,9 +2777,10 @@ class AnalysisProcessor(processor.ProcessorABC):
         if is_nominal_variation and channel_entries:
             region_store = self._accumulator.get("region_yields")
             for ch_name, base_ch_name, all_cuts_mask, mask_numpy in channel_entries:
+                region_channel_label = ch_name
                 _log_region_yields(
                     dataset=dataset.dataset,
-                    clean_channel=base_ch_name,
+                    clean_channel=region_channel_label,
                     application=self.appregion,
                     region_key=self.appregion,
                     region_mask=all_cuts_mask,
@@ -2788,7 +2789,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                 if region_store is not None:
                     region_key = (
                         dataset.dataset,
-                        base_ch_name,
+                        region_channel_label,
                         self.appregion,
                         "nominal",
                     )

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -26,6 +26,7 @@ from coffea.lumi_tools import LumiMask
 from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 from topeft.modules.paths import topeft_path
+from topeft.modules.channel_metadata import build_channel_label
 from topeft.modules.corrections import (
     ApplyJetCorrections,
     build_corrected_jets,
@@ -492,6 +493,20 @@ class AnalysisProcessor(processor.ProcessorABC):
         # nested structure with several loops in ``process``.  The new logic
         # operates directly on the flat dictionary, so simply store it.
         self._channel_dict = channel_dict
+        chan_def_lst = channel_dict.get("chan_def_lst") or ()
+        jet_selection = channel_dict.get("jet_selection")
+        channel_label = channel_dict.get("channel_label")
+        if channel_label:
+            self._channel_label = str(channel_label)
+        else:
+            try:
+                self._channel_label = build_channel_label(
+                    chan_def_lst,
+                    jet_selection=jet_selection,
+                )
+            except Exception:
+                self._channel_label = None
+        self._jet_selection = jet_selection
         channel_features = channel_dict.get("features", ())
         if channel_features is None:
             channel_features = ()
@@ -579,6 +594,8 @@ class AnalysisProcessor(processor.ProcessorABC):
         self._var = var
         self._channel = ch
         self._appregion = appl
+        if not self._channel_label:
+            self._channel_label = self._channel
         self._syst = first_label
         self._var_def = info.get("definition")
         if self._var_def is None:
@@ -799,11 +816,6 @@ class AnalysisProcessor(processor.ProcessorABC):
     @property
     def var_def(self):
         return self._var_def
-
-    def _build_channel_names(self, lep_chan, njet_ch, flav_ch):
-        ch_name = construct_cat_name(lep_chan, njet_str=njet_ch, flav_str=flav_ch)
-        base_ch_name = construct_cat_name(lep_chan, njet_str=njet_ch, flav_str=None)
-        return ch_name, base_ch_name
 
     def _compute_ptbl(
         self,
@@ -2695,8 +2707,13 @@ class AnalysisProcessor(processor.ProcessorABC):
         )
         nominal_weight = weights_object.weight(None)
 
-        lep_chan = self._channel_dict["chan_def_lst"][0]
-        jet_req = self._channel_dict["jet_selection"]
+        chan_def_lst = self._channel_dict["chan_def_lst"]
+        lep_chan = chan_def_lst[0]
+        jet_req = self._jet_selection
+        base_channel_label = self._channel_label or build_channel_label(
+            chan_def_lst,
+            jet_selection=jet_req,
+        )
         lep_flav_iter = (
             self._channel_dict["lep_flav_lst"]
             if self._split_by_lepton_flavor
@@ -2706,33 +2723,41 @@ class AnalysisProcessor(processor.ProcessorABC):
         channel_entries: List[Tuple[str, str, ak.Array, np.ndarray]] = []
         for lep_flav in lep_flav_iter:
             logger.info("Selection keys: %s", selections.names)
-            logger.info("Channel def list: %r", self._channel_dict["chan_def_lst"])
+            logger.info("Channel def list: %r", chan_def_lst)
             logger.info("Channel bit '%s' present? %s", lep_chan, lep_chan in selections.names)
             cuts_lst = [self.appregion, lep_chan]
-            flav_ch = None
-            njet_ch = None
             if isData:
                 cuts_lst.append("is_good_lumi")
             if self._split_by_lepton_flavor:
-                flav_ch = lep_flav
                 cuts_lst.append(lep_flav)
-            if dense_axis_name != "njets":
-                njet_ch = jet_req
+            if jet_req:
                 cuts_lst.append(jet_req)
 
-            ch_name, base_ch_name = self._build_channel_names(
-                lep_chan, njet_ch, flav_ch
-            )
-            if base_ch_name != self.channel:
-                if not str(self.channel).startswith(str(base_ch_name)):
+            ch_name = base_channel_label
+            if self._split_by_lepton_flavor and lep_flav:
+                ch_name = build_channel_label(
+                    chan_def_lst,
+                    jet_selection=jet_req,
+                    lep_flav=lep_flav,
+                )
+
+            if base_channel_label != self.channel:
+                if not str(self.channel).startswith(str(base_channel_label)):
                     continue
 
             cut_pass_info = {cut: selections.all(cut) for cut in cuts_lst}
             logger.debug(
                 "Filling histograms for channel '%s' (base '%s') with cuts %s",
                 ch_name,
-                base_ch_name,
+                base_channel_label,
                 cut_pass_info,
+            )
+            logger.info(
+                "Filling histograms for canonical channel '%s' (base '%s', jet_selection=%r, app=%s)",
+                ch_name,
+                base_channel_label,
+                jet_req,
+                self.appregion,
             )
 
             all_cuts_mask = selections.all(*cuts_lst)
@@ -2747,7 +2772,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             else:
                 mask_numpy = np.asarray(all_cuts_mask)
 
-            channel_entries.append((ch_name, base_ch_name, all_cuts_mask, mask_numpy))
+            channel_entries.append((ch_name, base_channel_label, all_cuts_mask, mask_numpy))
 
         if is_nominal_variation and channel_entries:
             region_store = self._accumulator.get("region_yields")

--- a/analysis/topeft_run2/quick_check.py
+++ b/analysis/topeft_run2/quick_check.py
@@ -25,7 +25,8 @@ import argparse
 import gzip
 import sys
 from collections import Counter, defaultdict
-from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+from collections.abc import Mapping as ABCMapping, MutableMapping as ABCMutableMapping
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 import cloudpickle
 
@@ -33,6 +34,9 @@ DEFAULT_MAX_EMPTY_PRINT = 10
 DEFAULT_SMALL_LIMIT = 50
 DEFAULT_MAX_KEYS_PRINT = 200
 DEFAULT_TOTALS_GROUP = "none"
+
+WARN_NUMPY_IMPORT = False
+_WARNED_NUMPY_IMPORT = False
 
 
 # -----------------------------
@@ -76,7 +80,8 @@ def _infer_expected_sidecars() -> List[str]:
 
 
 def _is_mapping(obj: Any) -> bool:
-    return isinstance(obj, MutableMapping) or isinstance(obj, Mapping)
+    # Use runtime ABCs (collections.abc), not typing.Mapping, for isinstance checks.
+    return isinstance(obj, (ABCMutableMapping, ABCMapping))
 
 
 # -----------------------------
@@ -133,8 +138,16 @@ def _parse_region_value(value: Any) -> Tuple[Optional[float], Optional[float]]:
         try:
             import numpy as np  # type: ignore
         except Exception:
+            global _WARNED_NUMPY_IMPORT
             np = None  # type: ignore
+            if WARN_NUMPY_IMPORT and not _WARNED_NUMPY_IMPORT:
+                print(
+                    "WARNING: numpy import failed; using duck-typed region_yields parsing (totals may be incomplete).",
+                    file=sys.stderr,
+                )
+                _WARNED_NUMPY_IMPORT = True
 
+        # Numpy-native handling
         if np is not None and isinstance(value, np.ndarray):
             flat = value.ravel()
             if flat.size >= 2:
@@ -146,25 +159,74 @@ def _parse_region_value(value: Any) -> Tuple[Optional[float], Optional[float]]:
         if np is not None and isinstance(value, np.generic):
             return None, float(value)
 
+        # Plain python numeric
         if isinstance(value, (int, float)):
             return None, float(value)
+
+        # Plain python sequences
         if isinstance(value, (list, tuple)):
             if len(value) >= 2:
                 return float(value[0]), float(value[1])
             if len(value) == 1:
                 return float(value[0]), None
+
+        # Duck-typed fallbacks when numpy is unavailable or types differ
+        for attr in ("ravel", "flatten"):
+            try:
+                if hasattr(value, attr):
+                    flat = getattr(value, attr)()
+                    # Prefer .size if present
+                    if hasattr(flat, "size"):
+                        size = flat.size  # type: ignore[attr-defined]
+                        if size >= 2:
+                            return float(flat[0]), float(flat[1])
+                        if size == 1:
+                            return float(flat[0]), None
+                    else:
+                        try:
+                            size = len(flat)  # type: ignore[arg-type]
+                        except Exception:
+                            size = None
+                        if size is not None:
+                            if size >= 2:
+                                return float(flat[0]), float(flat[1])
+                            if size == 1:
+                                return float(flat[0]), None
+            except Exception:
+                continue
+
+        # Scalar-like with .item()
+        try:
+            if hasattr(value, "item"):
+                scalar = value.item()
+                return None, float(scalar)
+        except Exception:
+            pass
+
+        # Generic indexable sequence (exclude mappings)
+        try:
+            if not _is_mapping(value) and hasattr(value, "__len__") and hasattr(value, "__getitem__"):
+                size = len(value)  # type: ignore[arg-type]
+                if size >= 2:
+                    return float(value[0]), float(value[1])
+                if size == 1:
+                    return float(value[0]), None
+        except Exception:
+            pass
+
     except Exception:
         return None, None
+
     return None, None
 
 
 def _compute_region_totals(region_obj: Any, by: str) -> Dict[str, Any]:
-    totals = {
+    totals: Dict[str, Any] = {
         "entries": 0,
         "skipped": 0,
-        "total_n_events": None,  # type: Optional[float]
-        "total_sumw": None,      # type: Optional[float]
-        "grouped": {},           # type: Dict[Any, Dict[str, Optional[float]]]
+        "total_n_events": None,  # Optional[float]
+        "total_sumw": None,      # Optional[float]
+        "grouped": {},           # Dict[Any, Dict[str, Optional[float]]]
     }
     if not _is_mapping(region_obj):
         return totals
@@ -298,7 +360,7 @@ def classify_histogram_empty(hist_obj: Any) -> Tuple[str, str]:
     if callable(values_fn):
         try:
             vals = values_fn()
-            if isinstance(vals, Mapping):
+            if isinstance(vals, ABCMapping):
                 if not vals:
                     return "empty", "values_mapping_empty"
 
@@ -318,18 +380,19 @@ def classify_histogram_empty(hist_obj: Any) -> Tuple[str, str]:
                         continue
 
                 return "empty", "values_mapping_checked_all_empty"
-            else:
-                size = getattr(vals, "size", None)
-                if size is not None:
-                    return ("non-empty" if size > 0 else "empty", "values_size_checked")
-                try:
-                    return ("non-empty" if len(vals) > 0 else "empty", "values_len_checked")  # type: ignore[arg-type]
-                except Exception as exc:
-                    msg = str(exc)
-                    # Some HistEFT values() calls may raise with empty-tuple-like messages
-                    if msg.strip() in {"()", "( )"}:
-                        return "empty", "values_raised_empty_tuple"
-                    return "unknown", f"values_uninterpretable:{exc}"
+
+            size = getattr(vals, "size", None)
+            if size is not None:
+                return ("non-empty" if size > 0 else "empty", "values_size_checked")
+
+            try:
+                return ("non-empty" if len(vals) > 0 else "empty", "values_len_checked")  # type: ignore[arg-type]
+            except Exception as exc:
+                msg = str(exc)
+                if msg.strip() in {"()", "( )"}:
+                    return "empty", "values_raised_empty_tuple"
+                return "unknown", f"values_uninterpretable:{exc}"
+
         except Exception as exc:
             msg = str(exc)
             if msg.strip() in {"()", "( )"}:
@@ -390,8 +453,8 @@ def _type_name(obj: Any) -> str:
 
 
 def _summarize_value_types(payload: Mapping[Any, Any], tuple_keys: List[TupleKey]) -> None:
-    overall = Counter()
-    by_var: Dict[str, Counter] = defaultdict(Counter)
+    overall: Counter[str] = Counter()
+    by_var: Dict[str, Counter[str]] = defaultdict(Counter)
 
     for k in tuple_keys:
         v = payload.get(k)
@@ -440,7 +503,7 @@ def _has_hist_for(
     dataset: Any,
     syst: Any,
 ) -> bool:
-    for var, ch, ap, ds, sy in tuple_keys:
+    for _, ch, ap, ds, sy in tuple_keys:
         if ch == channel and ap == app and ds == dataset and sy == syst:
             return True
     return False
@@ -575,6 +638,11 @@ def main() -> None:
         default=DEFAULT_TOTALS_GROUP,
         help="Group totals by this key when printing region_yields summaries.",
     )
+    parser.add_argument(
+        "--warn-numpy-import",
+        action="store_true",
+        help="Emit a warning if numpy import fails; parsing will fall back to duck-typing.",
+    )
 
     # Partner checks
     parser.add_argument(
@@ -590,6 +658,9 @@ def main() -> None:
     )
 
     args = parser.parse_args()
+
+    global WARN_NUMPY_IMPORT
+    WARN_NUMPY_IMPORT = bool(args.warn_numpy_import)
 
     out = smart_load_output(args.path)
 

--- a/analysis/topeft_run2/quick_check.py
+++ b/analysis/topeft_run2/quick_check.py
@@ -130,6 +130,22 @@ def _parse_region_value(value: Any) -> Tuple[Optional[float], Optional[float]]:
     """Return (n_events, sumw) parsed from a region_yields entry."""
 
     try:
+        try:
+            import numpy as np  # type: ignore
+        except Exception:
+            np = None  # type: ignore
+
+        if np is not None and isinstance(value, np.ndarray):
+            flat = value.ravel()
+            if flat.size >= 2:
+                return float(flat[0]), float(flat[1])
+            if flat.size == 1:
+                return float(flat[0]), None
+            return None, None
+
+        if np is not None and isinstance(value, np.generic):
+            return None, float(value)
+
         if isinstance(value, (int, float)):
             return None, float(value)
         if isinstance(value, (list, tuple)):
@@ -309,8 +325,15 @@ def classify_histogram_empty(hist_obj: Any) -> Tuple[str, str]:
                 try:
                     return ("non-empty" if len(vals) > 0 else "empty", "values_len_checked")  # type: ignore[arg-type]
                 except Exception as exc:
+                    msg = str(exc)
+                    # Some HistEFT values() calls may raise with empty-tuple-like messages
+                    if msg.strip() in {"()", "( )"}:
+                        return "empty", "values_raised_empty_tuple"
                     return "unknown", f"values_uninterpretable:{exc}"
         except Exception as exc:
+            msg = str(exc)
+            if msg.strip() in {"()", "( )"}:
+                return "empty", "values_raised_empty_tuple"
             return "unknown", f"values_failed:{exc}"
 
     return "unknown", "no_dense_or_values"
@@ -433,12 +456,8 @@ def _check_region_yields(payload: Mapping[Any, Any], tuple_keys: List[TupleKey])
     print(f"[region_yields] detected schema: {schema}")
 
     for key, value in _region_yields_entries(region_obj):
-        try:
-            n_events = float(value[0]) if isinstance(value, (list, tuple)) else float(value)
-        except Exception:
-            n_events = 0.0
-
-        if n_events <= 0:
+        n_events, _ = _parse_region_value(value)
+        if n_events is None or n_events <= 0:
             continue
 
         if isinstance(key, tuple) and len(key) >= 4:

--- a/analysis/topeft_run2/quick_check.py
+++ b/analysis/topeft_run2/quick_check.py
@@ -2,11 +2,21 @@
 """
 quick_check.py
 
-Validate Run-2 output pickle/gzip artifacts by inspecting tuple-keyed histograms
-and region_yields using the conventions encoded in the workflow/processor.
+Validate Run-2 output artifacts by inspecting tuple-keyed histogram entries and
+sidecars like region_yields.
+
+Key behaviors:
+- Smart-loads gzip+cloudpickle or lz4+coffea.util.load outputs.
+- Inventories tuple keys of the form (variable, channel, application, dataset, systematic).
+- Optionally prints all tuple keys (auto when small; or --print-keys).
+- Classifies hist emptiness with conservative heuristics (dense map / values()).
+- Summarizes value-object types (overall + per variable).
+- Checks region_yields coverage: nonzero yields should have at least one histogram key
+  for the same (channel, application, dataset, systematic).
+- Optional partner check: enforce existence of *_sumw2 partner histograms.
 
 Usage:
-  python quick_check.py path/to/output.pkl.gz [--max-empty-print N] [--strict-unknown]
+  python quick_check.py path/to/output.pkl.gz [options]
 """
 
 from __future__ import annotations
@@ -14,24 +24,31 @@ from __future__ import annotations
 import argparse
 import gzip
 import sys
-from collections import OrderedDict
+from collections import Counter, defaultdict
 from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
 
 import cloudpickle
 
 DEFAULT_MAX_EMPTY_PRINT = 10
+DEFAULT_SMALL_LIMIT = 50
+DEFAULT_MAX_KEYS_PRINT = 200
+DEFAULT_TOTALS_GROUP = "none"
 
 
+# -----------------------------
+# Loading / basic helpers
+# -----------------------------
 def smart_load_output(path: str) -> Any:
     """Load an output file by sniffing its magic bytes."""
-
     with open(path, "rb") as f:
         magic4 = f.read(4)
 
+    # gzip
     if magic4[:2] == b"\x1f\x8b":
         with gzip.open(path, "rb") as fin:
             return cloudpickle.load(fin)
 
+    # lz4 frame magic
     if magic4 == b"\x04\x22\x4d\x18":
         from coffea.util import load
 
@@ -45,7 +62,6 @@ def smart_load_output(path: str) -> Any:
 
 def _infer_expected_sidecars() -> List[str]:
     """Best-effort inference of non-histogram keys from workflow/processor code."""
-
     candidates: List[str] = []
     try:
         from analysis.topeft_run2 import analysis_processor
@@ -63,9 +79,15 @@ def _is_mapping(obj: Any) -> bool:
     return isinstance(obj, MutableMapping) or isinstance(obj, Mapping)
 
 
-def _inventory_tuple_keys(payload: Mapping[Any, Any]) -> Tuple[List[Tuple[Any, ...]], Dict[str, set]]:
-    tuple_keys: List[Tuple[Any, ...]] = []
-    uniques = {
+# -----------------------------
+# Key inventory
+# -----------------------------
+TupleKey = Tuple[Any, Any, Any, Any, Any]
+
+
+def _inventory_tuple_keys(payload: Mapping[Any, Any]) -> Tuple[List[TupleKey], Dict[str, set]]:
+    tuple_keys: List[TupleKey] = []
+    uniques: Dict[str, set] = {
         "variable": set(),
         "channel": set(),
         "application": set(),
@@ -75,49 +97,180 @@ def _inventory_tuple_keys(payload: Mapping[Any, Any]) -> Tuple[List[Tuple[Any, .
 
     for key in payload.keys():
         if isinstance(key, tuple) and len(key) == 5:
-            tuple_keys.append(key)
-            uniques["variable"].add(key[0])
-            uniques["channel"].add(key[1])
-            uniques["application"].add(key[2])
-            uniques["dataset"].add(key[3])
-            uniques["systematic"].add(key[4])
+            tkey: TupleKey = key  # type: ignore[assignment]
+            tuple_keys.append(tkey)
+            uniques["variable"].add(tkey[0])
+            uniques["channel"].add(tkey[1])
+            uniques["application"].add(tkey[2])
+            uniques["dataset"].add(tkey[3])
+            uniques["systematic"].add(tkey[4])
+
+    # Deterministic ordering helps diffing outputs
+    tuple_keys.sort(key=lambda k: tuple(str(x) for x in k))
     return tuple_keys, uniques
 
 
+def _describe_sidecars(payload: Mapping[Any, Any]) -> List[Tuple[Any, str]]:
+    results: List[Tuple[Any, str]] = []
+    expected = set(_infer_expected_sidecars())
+    for key, value in payload.items():
+        if not isinstance(key, tuple):
+            label = type(value).__name__
+            if key in expected:
+                label = f"{label} (expected sidecar)"
+            results.append((key, label))
+    results.sort(key=lambda kv: str(kv[0]))
+    return results
+
+
+# -----------------------------
+# Region totals helpers
+# -----------------------------
+def _parse_region_value(value: Any) -> Tuple[Optional[float], Optional[float]]:
+    """Return (n_events, sumw) parsed from a region_yields entry."""
+
+    try:
+        if isinstance(value, (int, float)):
+            return None, float(value)
+        if isinstance(value, (list, tuple)):
+            if len(value) >= 2:
+                return float(value[0]), float(value[1])
+            if len(value) == 1:
+                return float(value[0]), None
+    except Exception:
+        return None, None
+    return None, None
+
+
+def _compute_region_totals(region_obj: Any, by: str) -> Dict[str, Any]:
+    totals = {
+        "entries": 0,
+        "skipped": 0,
+        "total_n_events": None,  # type: Optional[float]
+        "total_sumw": None,      # type: Optional[float]
+        "grouped": {},           # type: Dict[Any, Dict[str, Optional[float]]]
+    }
+    if not _is_mapping(region_obj):
+        return totals
+
+    total_n: Optional[float] = None
+    total_w: Optional[float] = None
+    grouped: Dict[Any, Dict[str, Optional[float]]] = {}
+
+    for key, value in region_obj.items():
+        totals["entries"] += 1
+        n_events, sumw = _parse_region_value(value)
+        if n_events is None and sumw is None:
+            totals["skipped"] += 1
+            continue
+
+        if n_events is not None:
+            total_n = (total_n or 0.0) + n_events
+        if sumw is not None:
+            total_w = (total_w or 0.0) + sumw
+
+        if by != "none":
+            if isinstance(key, tuple) and len(key) >= 4:
+                dataset, channel, app, syst = key[0], key[1], key[2], key[3]
+            else:
+                dataset = channel = app = syst = None
+
+            if by == "dataset":
+                grp_key = dataset
+            elif by == "channel":
+                grp_key = channel
+            elif by == "application":
+                grp_key = app
+            elif by == "systematic":
+                grp_key = syst
+            elif by == "all":
+                grp_key = (dataset, channel, app, syst)
+            else:
+                grp_key = None
+
+            if grp_key is not None:
+                info = grouped.setdefault(grp_key, {"n_events": None, "sumw": None})
+                if n_events is not None:
+                    info["n_events"] = (info["n_events"] or 0.0) + n_events
+                if sumw is not None:
+                    info["sumw"] = (info["sumw"] or 0.0) + sumw
+
+    totals["total_n_events"] = total_n
+    totals["total_sumw"] = total_w
+    totals["grouped"] = grouped
+    return totals
+
+
+def _print_totals(totals: Dict[str, Any], by: str) -> None:
+    print(f"[totals] region_yields entries: {totals['entries']} (skipped: {totals['skipped']})")
+    n_events = totals.get("total_n_events")
+    sumw = totals.get("total_sumw")
+    n_str = "unknown" if n_events is None else f"{n_events}"
+    w_str = "unknown" if sumw is None else f"{sumw}"
+    print(f"[totals] total_n_events={n_str} total_sumw={w_str}")
+
+    if by != "none":
+        grouped = totals.get("grouped") or {}
+        for key in sorted(grouped, key=lambda k: str(k)):
+            info = grouped[key]
+            n = info.get("n_events")
+            w = info.get("sumw")
+            n_val = "unknown" if n is None else f"{n}"
+            w_val = "unknown" if w is None else f"{w}"
+            print(f"[totals:{by}] {key}: n_events={n_val} sumw={w_val}")
+
+
+# -----------------------------
+# Histogram emptiness heuristics
+# -----------------------------
 def _dense_empty_info(hist_obj: Any) -> Tuple[Optional[str], Optional[int]]:
     dense = getattr(hist_obj, "_dense_hists", None)
     if isinstance(dense, dict):
         if len(dense) == 0:
             return "dense_map_empty", 0
+
         nonzero = 0
-        total = 0
+        observed = 0
         for val in dense.values():
             try:
                 arr = getattr(val, "values", lambda: val)()
             except Exception:
                 arr = val
+
+            # Try to decide if this payload is "empty"
             try:
                 arr_len = len(arr)  # type: ignore[arg-type]
             except Exception:
                 arr_len = None
-            total += 1 if arr_len is not None else 0
-            if arr_len:
-                try:
-                    if getattr(arr, "sum", lambda: 0)() != 0:
-                        nonzero += 1
-                except Exception:
+
+            if arr_len is None:
+                continue
+
+            observed += 1
+            if arr_len == 0:
+                continue
+
+            # Non-empty length; check sum() if available
+            try:
+                if getattr(arr, "sum", lambda: 0)() != 0:
                     nonzero += 1
-        if total == 0:
+                else:
+                    # length nonzero but sum zero is ambiguous; still count as "has content"
+                    nonzero += 1
+            except Exception:
+                nonzero += 1
+
+        if observed == 0:
             return "dense_map_no_lengths", len(dense)
         if nonzero == 0:
             return "dense_map_all_zero", len(dense)
         return None, len(dense)
+
     return None, None
 
 
 def classify_histogram_empty(hist_obj: Any) -> Tuple[str, str]:
-    """Return (status, reason) where status is empty/non-empty/unknown."""
-
+    """Return (status, reason) where status is 'empty'/'non-empty'/'unknown'."""
     dense_reason, dense_len = _dense_empty_info(hist_obj)
     if dense_reason:
         return "empty", dense_reason
@@ -132,39 +285,115 @@ def classify_histogram_empty(hist_obj: Any) -> Tuple[str, str]:
             if isinstance(vals, Mapping):
                 if not vals:
                     return "empty", "values_mapping_empty"
-                has_nonzero = False
+
+                # Try to find any non-empty payload
                 for payload in vals.values():
                     try:
                         arr = payload[0] if isinstance(payload, tuple) else payload
-                        if getattr(arr, "size", None) not in (None, 0):
-                            has_nonzero = True
-                            break
+                        size = getattr(arr, "size", None)
+                        if size is not None:
+                            if size > 0:
+                                return "non-empty", "values_mapping_has_size>0"
+                            continue
+                        # If size is missing, try len()
+                        if len(arr) > 0:  # type: ignore[arg-type]
+                            return "non-empty", "values_mapping_has_len>0"
                     except Exception:
                         continue
-                return ("non-empty" if has_nonzero else "empty", "values_mapping_checked")
+
+                return "empty", "values_mapping_checked_all_empty"
             else:
                 size = getattr(vals, "size", None)
-                if size is not None and size > 0:
-                    return "non-empty", "values_size>0"
-                return "empty", "values_size==0"
+                if size is not None:
+                    return ("non-empty" if size > 0 else "empty", "values_size_checked")
+                try:
+                    return ("non-empty" if len(vals) > 0 else "empty", "values_len_checked")  # type: ignore[arg-type]
+                except Exception as exc:
+                    return "unknown", f"values_uninterpretable:{exc}"
         except Exception as exc:
             return "unknown", f"values_failed:{exc}"
 
     return "unknown", "no_dense_or_values"
 
 
-def _describe_sidecars(payload: Mapping[Any, Any]) -> List[Tuple[Any, str]]:
-    results: List[Tuple[Any, str]] = []
-    expected = set(_infer_expected_sidecars())
-    for key, value in payload.items():
-        if not isinstance(key, tuple):
-            label = type(value).__name__
-            if key in expected:
-                label = f"{label} (expected sidecar)"
-            results.append((key, label))
-    return results
+# -----------------------------
+# Diagnostics / summaries
+# -----------------------------
+def _print_inventory(
+    tuple_keys: List[TupleKey],
+    uniques: Dict[str, set],
+    sidecars: List[Tuple[Any, str]],
+) -> None:
+    print(f"Histogram entries: {len(tuple_keys)}")
+    for name in ("variable", "channel", "application", "dataset", "systematic"):
+        vals = sorted(str(v) for v in uniques[name])
+        preview = ", ".join(vals[:30])
+        if len(vals) > 30:
+            preview += " ..."
+        print(f"  {name}s ({len(vals)}): {preview}")
+
+    if sidecars:
+        print("Sidecar keys (non-tuple):")
+        for key, desc in sidecars:
+            print(f"  {key!r}: {desc}")
+    else:
+        print("No sidecar keys detected.")
 
 
+def _maybe_print_keys(
+    tuple_keys: List[TupleKey],
+    *,
+    print_keys: bool,
+    small_limit: int,
+    max_keys_print: int,
+) -> None:
+    should_print = print_keys or (len(tuple_keys) <= small_limit)
+    if not should_print:
+        return
+
+    n = min(len(tuple_keys), max_keys_print)
+    print(f"Tuple keys ({n}/{len(tuple_keys)} shown):")
+    for k in tuple_keys[:n]:
+        print(f"  {k}")
+    if n < len(tuple_keys):
+        print(f"  ... (use --max-keys-print {len(tuple_keys)} to show all)")
+
+
+def _type_name(obj: Any) -> str:
+    try:
+        return f"{obj.__class__.__module__}.{obj.__class__.__name__}"
+    except Exception:
+        return type(obj).__name__
+
+
+def _summarize_value_types(payload: Mapping[Any, Any], tuple_keys: List[TupleKey]) -> None:
+    overall = Counter()
+    by_var: Dict[str, Counter] = defaultdict(Counter)
+
+    for k in tuple_keys:
+        v = payload.get(k)
+        tn = _type_name(v)
+        overall[tn] += 1
+        by_var[str(k[0])][tn] += 1
+
+    if not overall:
+        print("No histogram values to summarize.")
+        return
+
+    print("Histogram value types (overall):")
+    for t, c in overall.most_common():
+        print(f"  {t}: {c}")
+
+    print("Histogram value types (by variable):")
+    for var in sorted(by_var.keys()):
+        cnt = by_var[var]
+        parts = ", ".join(f"{t}={c}" for t, c in cnt.most_common())
+        print(f"  {var}: {parts}")
+
+
+# -----------------------------
+# region_yields checks
+# -----------------------------
 def _infer_region_schema(region_obj: Any) -> str:
     if not _is_mapping(region_obj) or not region_obj:
         return "unknown"
@@ -180,14 +409,21 @@ def _region_yields_entries(region_obj: Any) -> Iterable[Tuple[Any, Any]]:
     return ()
 
 
-def _has_hist_for(tuple_keys: List[Tuple[Any, ...]], channel: Any, app: Any, dataset: Any, syst: Any) -> bool:
+def _has_hist_for(
+    tuple_keys: Sequence[TupleKey],
+    *,
+    channel: Any,
+    app: Any,
+    dataset: Any,
+    syst: Any,
+) -> bool:
     for var, ch, ap, ds, sy in tuple_keys:
         if ch == channel and ap == app and ds == dataset and sy == syst:
             return True
     return False
 
 
-def _check_region_yields(payload: Mapping[Any, Any], tuple_keys: List[Tuple[Any, ...]]) -> List[str]:
+def _check_region_yields(payload: Mapping[Any, Any], tuple_keys: List[TupleKey]) -> List[str]:
     missing: List[str] = []
     region_obj = payload.get("region_yields")
     if region_obj is None:
@@ -201,6 +437,7 @@ def _check_region_yields(payload: Mapping[Any, Any], tuple_keys: List[Tuple[Any,
             n_events = float(value[0]) if isinstance(value, (list, tuple)) else float(value)
         except Exception:
             n_events = 0.0
+
         if n_events <= 0:
             continue
 
@@ -210,25 +447,64 @@ def _check_region_yields(payload: Mapping[Any, Any], tuple_keys: List[Tuple[Any,
             # Cannot interpret; skip reporting to avoid false positives
             continue
 
-        if not _has_hist_for(tuple_keys, channel, app, dataset, syst):
+        if not _has_hist_for(tuple_keys, channel=channel, app=app, dataset=dataset, syst=syst):
             missing.append(f"Missing histogram for region_yield key={key!r}")
 
     return missing
 
 
-def _print_inventory(tuple_keys: List[Tuple[Any, ...]], uniques: Dict[str, set], sidecars: List[Tuple[Any, str]]) -> None:
-    print(f"Histogram entries: {len(tuple_keys)}")
-    for name in ("variable", "channel", "application", "dataset", "systematic"):
-        vals = sorted(str(v) for v in uniques[name])
-        print(f"  {name}s ({len(vals)}): {', '.join(vals[:30])}" + (" ..." if len(vals) > 30 else ""))
-    if sidecars:
-        print("Sidecar keys (non-tuple):")
-        for key, desc in sidecars:
-            print(f"  {key!r}: {desc}")
-    else:
-        print("No sidecar keys detected.")
+# -----------------------------
+# Partner checks: *_sumw2
+# -----------------------------
+def _build_key_set(tuple_keys: Sequence[TupleKey]) -> set:
+    return set(tuple_keys)
 
 
+def _check_sumw2_partners(
+    tuple_keys: List[TupleKey],
+    *,
+    require_all: bool,
+    require_for_vars: Optional[Sequence[str]],
+) -> List[str]:
+    """
+    Partner rule:
+      For a base variable "x", expect "x_sumw2" with identical (ch, app, ds, syst).
+      For a variable already ending in "_sumw2", expect the base partner as well.
+    """
+    if not require_all and not require_for_vars:
+        return []
+
+    keyset = _build_key_set(tuple_keys)
+    missing: List[str] = []
+
+    def want_var(var: str) -> bool:
+        if require_all:
+            return True
+        if not require_for_vars:
+            return False
+        return var in set(require_for_vars)
+
+    for var, ch, app, ds, syst in tuple_keys:
+        var_s = str(var)
+
+        if var_s.endswith("_sumw2"):
+            base = var_s[: -len("_sumw2")]
+            if want_var(base) and (base, ch, app, ds, syst) not in keyset:
+                missing.append(
+                    f"Missing base partner for sumw2 variable: ({base!r}, {ch!r}, {app!r}, {ds!r}, {syst!r})"
+                )
+        else:
+            if want_var(var_s) and (f"{var_s}_sumw2", ch, app, ds, syst) not in keyset:
+                missing.append(
+                    f"Missing sumw2 partner: ({(var_s + '_sumw2')!r}, {ch!r}, {app!r}, {ds!r}, {syst!r})"
+                )
+
+    return missing
+
+
+# -----------------------------
+# Main
+# -----------------------------
 def main() -> None:
     parser = argparse.ArgumentParser(description="Validate a topeft Run-2 output pickle.")
     parser.add_argument(
@@ -237,17 +513,63 @@ def main() -> None:
         default="histos/refact_250901_c1_it_test_cr.pkl.gz",
         help="Path to the output file (default: %(default)s).",
     )
+
+    # Printing / verbosity knobs
+    parser.add_argument(
+        "--print-keys",
+        action="store_true",
+        help="Print tuple histogram keys (also auto-prints when entries <= --small-limit).",
+    )
+    parser.add_argument(
+        "--small-limit",
+        type=int,
+        default=DEFAULT_SMALL_LIMIT,
+        help="Auto-print tuple keys when the number of entries is <= N.",
+    )
+    parser.add_argument(
+        "--max-keys-print",
+        type=int,
+        default=DEFAULT_MAX_KEYS_PRINT,
+        help="Maximum number of tuple keys to print when printing keys.",
+    )
+
+    # Diagnostics knobs
     parser.add_argument(
         "--max-empty-print",
         type=int,
         default=DEFAULT_MAX_EMPTY_PRINT,
-        help="Print at most N empty histogram diagnostics.",
+        help="Print at most N empty/unknown histogram diagnostics.",
     )
     parser.add_argument(
         "--strict-unknown",
         action="store_true",
         help="Treat unknown histogram states as failures.",
     )
+    parser.add_argument(
+        "--no-print-totals",
+        action="store_true",
+        help="Disable totals reporting from region_yields.",
+    )
+    parser.add_argument(
+        "--totals-by",
+        choices=["none", "dataset", "channel", "application", "systematic", "all"],
+        default=DEFAULT_TOTALS_GROUP,
+        help="Group totals by this key when printing region_yields summaries.",
+    )
+
+    # Partner checks
+    parser.add_argument(
+        "--require-sumw2",
+        action="store_true",
+        help="Require *_sumw2 partners for ALL variables (and base partners for *_sumw2 vars).",
+    )
+    parser.add_argument(
+        "--require-sumw2-for",
+        nargs="*",
+        default=None,
+        help="Require *_sumw2 partners only for these base variables (space-separated).",
+    )
+
     args = parser.parse_args()
 
     out = smart_load_output(args.path)
@@ -260,9 +582,18 @@ def main() -> None:
     sidecars = _describe_sidecars(out)
 
     _print_inventory(tuple_keys, uniques, sidecars)
+    _maybe_print_keys(
+        tuple_keys,
+        print_keys=args.print_keys,
+        small_limit=args.small_limit,
+        max_keys_print=args.max_keys_print,
+    )
 
-    empty_entries: List[Tuple[Tuple[Any, ...], str]] = []
-    unknown_entries: List[Tuple[Tuple[Any, ...], str]] = []
+    _summarize_value_types(out, tuple_keys)
+
+    # Emptiness scan
+    empty_entries: List[Tuple[TupleKey, str]] = []
+    unknown_entries: List[Tuple[TupleKey, str]] = []
 
     for key in tuple_keys:
         hist_obj = out.get(key)
@@ -284,6 +615,7 @@ def main() -> None:
         for key, reason in unknown_entries[: max(args.max_empty_print, 0)]:
             print(f"  {key}: {reason}")
 
+    # region_yields coverage
     missing_from_region = _check_region_yields(out, tuple_keys)
     if missing_from_region:
         print(f"Region->hist coverage gaps: {len(missing_from_region)}")
@@ -292,17 +624,36 @@ def main() -> None:
     else:
         print("No region_yields coverage gaps detected.")
 
+    if not args.no_print_totals and "region_yields" in out:
+        totals = _compute_region_totals(out.get("region_yields"), args.totals_by)
+        _print_totals(totals, args.totals_by)
+
+    # sumw2 partner checks
+    sumw2_missing = _check_sumw2_partners(
+        tuple_keys,
+        require_all=bool(args.require_sumw2),
+        require_for_vars=args.require_sumw2_for,
+    )
+    if sumw2_missing:
+        print(f"sumw2 partner gaps: {len(sumw2_missing)}")
+        for msg in sumw2_missing[: max(args.max_empty_print, 0)]:
+            print(f"  {msg}")
+    else:
+        if args.require_sumw2 or args.require_sumw2_for:
+            print("No sumw2 partner gaps detected.")
+
+    # Determine exit code
     fail = False
     if empty_entries:
         fail = True
     if missing_from_region:
         fail = True
+    if sumw2_missing:
+        fail = True
     if args.strict_unknown and unknown_entries:
         fail = True
 
-    if fail:
-        sys.exit(2)
-    sys.exit(0)
+    sys.exit(2 if fail else 0)
 
 
 if __name__ == "__main__":

--- a/analysis/topeft_run2/quick_check.py
+++ b/analysis/topeft_run2/quick_check.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""
+quick_check.py
+
+Validate Run-2 output pickle/gzip artifacts by inspecting tuple-keyed histograms
+and region_yields using the conventions encoded in the workflow/processor.
+
+Usage:
+  python quick_check.py path/to/output.pkl.gz [--max-empty-print N] [--strict-unknown]
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import sys
+from collections import OrderedDict
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+
+import cloudpickle
+
+DEFAULT_MAX_EMPTY_PRINT = 10
+
+
+def smart_load_output(path: str) -> Any:
+    """Load an output file by sniffing its magic bytes."""
+
+    with open(path, "rb") as f:
+        magic4 = f.read(4)
+
+    if magic4[:2] == b"\x1f\x8b":
+        with gzip.open(path, "rb") as fin:
+            return cloudpickle.load(fin)
+
+    if magic4 == b"\x04\x22\x4d\x18":
+        from coffea.util import load
+
+        return load(path)
+
+    raise RuntimeError(
+        f"Unrecognized output format for {path!r}: magic={magic4.hex()} "
+        "(expected gzip 1f8b... or lz4 frame 04224d18)."
+    )
+
+
+def _infer_expected_sidecars() -> List[str]:
+    """Best-effort inference of non-histogram keys from workflow/processor code."""
+
+    candidates: List[str] = []
+    try:
+        from analysis.topeft_run2 import analysis_processor
+
+        key = getattr(analysis_processor.AnalysisProcessor, "VARIATION_SUMMARY_KEY", None)
+        if key:
+            candidates.append(str(key))
+        candidates.append("region_yields")
+    except Exception:
+        candidates.append("region_yields")
+    return candidates
+
+
+def _is_mapping(obj: Any) -> bool:
+    return isinstance(obj, MutableMapping) or isinstance(obj, Mapping)
+
+
+def _inventory_tuple_keys(payload: Mapping[Any, Any]) -> Tuple[List[Tuple[Any, ...]], Dict[str, set]]:
+    tuple_keys: List[Tuple[Any, ...]] = []
+    uniques = {
+        "variable": set(),
+        "channel": set(),
+        "application": set(),
+        "dataset": set(),
+        "systematic": set(),
+    }
+
+    for key in payload.keys():
+        if isinstance(key, tuple) and len(key) == 5:
+            tuple_keys.append(key)
+            uniques["variable"].add(key[0])
+            uniques["channel"].add(key[1])
+            uniques["application"].add(key[2])
+            uniques["dataset"].add(key[3])
+            uniques["systematic"].add(key[4])
+    return tuple_keys, uniques
+
+
+def _dense_empty_info(hist_obj: Any) -> Tuple[Optional[str], Optional[int]]:
+    dense = getattr(hist_obj, "_dense_hists", None)
+    if isinstance(dense, dict):
+        if len(dense) == 0:
+            return "dense_map_empty", 0
+        nonzero = 0
+        total = 0
+        for val in dense.values():
+            try:
+                arr = getattr(val, "values", lambda: val)()
+            except Exception:
+                arr = val
+            try:
+                arr_len = len(arr)  # type: ignore[arg-type]
+            except Exception:
+                arr_len = None
+            total += 1 if arr_len is not None else 0
+            if arr_len:
+                try:
+                    if getattr(arr, "sum", lambda: 0)() != 0:
+                        nonzero += 1
+                except Exception:
+                    nonzero += 1
+        if total == 0:
+            return "dense_map_no_lengths", len(dense)
+        if nonzero == 0:
+            return "dense_map_all_zero", len(dense)
+        return None, len(dense)
+    return None, None
+
+
+def classify_histogram_empty(hist_obj: Any) -> Tuple[str, str]:
+    """Return (status, reason) where status is empty/non-empty/unknown."""
+
+    dense_reason, dense_len = _dense_empty_info(hist_obj)
+    if dense_reason:
+        return "empty", dense_reason
+    if dense_len:
+        return "non-empty", "dense_map_nonzero"
+
+    # Fallback to values() if present
+    values_fn = getattr(hist_obj, "values", None)
+    if callable(values_fn):
+        try:
+            vals = values_fn()
+            if isinstance(vals, Mapping):
+                if not vals:
+                    return "empty", "values_mapping_empty"
+                has_nonzero = False
+                for payload in vals.values():
+                    try:
+                        arr = payload[0] if isinstance(payload, tuple) else payload
+                        if getattr(arr, "size", None) not in (None, 0):
+                            has_nonzero = True
+                            break
+                    except Exception:
+                        continue
+                return ("non-empty" if has_nonzero else "empty", "values_mapping_checked")
+            else:
+                size = getattr(vals, "size", None)
+                if size is not None and size > 0:
+                    return "non-empty", "values_size>0"
+                return "empty", "values_size==0"
+        except Exception as exc:
+            return "unknown", f"values_failed:{exc}"
+
+    return "unknown", "no_dense_or_values"
+
+
+def _describe_sidecars(payload: Mapping[Any, Any]) -> List[Tuple[Any, str]]:
+    results: List[Tuple[Any, str]] = []
+    expected = set(_infer_expected_sidecars())
+    for key, value in payload.items():
+        if not isinstance(key, tuple):
+            label = type(value).__name__
+            if key in expected:
+                label = f"{label} (expected sidecar)"
+            results.append((key, label))
+    return results
+
+
+def _infer_region_schema(region_obj: Any) -> str:
+    if not _is_mapping(region_obj) or not region_obj:
+        return "unknown"
+    sample_key = next(iter(region_obj.keys()))
+    if isinstance(sample_key, tuple):
+        return f"tuple(len={len(sample_key)})"
+    return type(sample_key).__name__
+
+
+def _region_yields_entries(region_obj: Any) -> Iterable[Tuple[Any, Any]]:
+    if _is_mapping(region_obj):
+        return region_obj.items()
+    return ()
+
+
+def _has_hist_for(tuple_keys: List[Tuple[Any, ...]], channel: Any, app: Any, dataset: Any, syst: Any) -> bool:
+    for var, ch, ap, ds, sy in tuple_keys:
+        if ch == channel and ap == app and ds == dataset and sy == syst:
+            return True
+    return False
+
+
+def _check_region_yields(payload: Mapping[Any, Any], tuple_keys: List[Tuple[Any, ...]]) -> List[str]:
+    missing: List[str] = []
+    region_obj = payload.get("region_yields")
+    if region_obj is None:
+        return missing
+
+    schema = _infer_region_schema(region_obj)
+    print(f"[region_yields] detected schema: {schema}")
+
+    for key, value in _region_yields_entries(region_obj):
+        try:
+            n_events = float(value[0]) if isinstance(value, (list, tuple)) else float(value)
+        except Exception:
+            n_events = 0.0
+        if n_events <= 0:
+            continue
+
+        if isinstance(key, tuple) and len(key) >= 4:
+            dataset, channel, app, syst = key[0], key[1], key[2], key[3]
+        else:
+            # Cannot interpret; skip reporting to avoid false positives
+            continue
+
+        if not _has_hist_for(tuple_keys, channel, app, dataset, syst):
+            missing.append(f"Missing histogram for region_yield key={key!r}")
+
+    return missing
+
+
+def _print_inventory(tuple_keys: List[Tuple[Any, ...]], uniques: Dict[str, set], sidecars: List[Tuple[Any, str]]) -> None:
+    print(f"Histogram entries: {len(tuple_keys)}")
+    for name in ("variable", "channel", "application", "dataset", "systematic"):
+        vals = sorted(str(v) for v in uniques[name])
+        print(f"  {name}s ({len(vals)}): {', '.join(vals[:30])}" + (" ..." if len(vals) > 30 else ""))
+    if sidecars:
+        print("Sidecar keys (non-tuple):")
+        for key, desc in sidecars:
+            print(f"  {key!r}: {desc}")
+    else:
+        print("No sidecar keys detected.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate a topeft Run-2 output pickle.")
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default="histos/refact_250901_c1_it_test_cr.pkl.gz",
+        help="Path to the output file (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--max-empty-print",
+        type=int,
+        default=DEFAULT_MAX_EMPTY_PRINT,
+        help="Print at most N empty histogram diagnostics.",
+    )
+    parser.add_argument(
+        "--strict-unknown",
+        action="store_true",
+        help="Treat unknown histogram states as failures.",
+    )
+    args = parser.parse_args()
+
+    out = smart_load_output(args.path)
+
+    if not _is_mapping(out):
+        print(f"Loaded object is not a mapping: {type(out)}")
+        sys.exit(1)
+
+    tuple_keys, uniques = _inventory_tuple_keys(out)
+    sidecars = _describe_sidecars(out)
+
+    _print_inventory(tuple_keys, uniques, sidecars)
+
+    empty_entries: List[Tuple[Tuple[Any, ...], str]] = []
+    unknown_entries: List[Tuple[Tuple[Any, ...], str]] = []
+
+    for key in tuple_keys:
+        hist_obj = out.get(key)
+        status, reason = classify_histogram_empty(hist_obj)
+        if status == "empty":
+            empty_entries.append((key, reason))
+        elif status == "unknown":
+            unknown_entries.append((key, reason))
+
+    if empty_entries:
+        print(f"Empty histograms detected: {len(empty_entries)}")
+        for key, reason in empty_entries[: max(args.max_empty_print, 0)]:
+            print(f"  {key}: {reason}")
+    else:
+        print("No empty histograms detected.")
+
+    if unknown_entries:
+        print(f"Unknown histogram states: {len(unknown_entries)}")
+        for key, reason in unknown_entries[: max(args.max_empty_print, 0)]:
+            print(f"  {key}: {reason}")
+
+    missing_from_region = _check_region_yields(out, tuple_keys)
+    if missing_from_region:
+        print(f"Region->hist coverage gaps: {len(missing_from_region)}")
+        for msg in missing_from_region[: max(args.max_empty_print, 0)]:
+            print(f"  {msg}")
+    else:
+        print("No region_yields coverage gaps detected.")
+
+    fail = False
+    if empty_entries:
+        fail = True
+    if missing_from_region:
+        fail = True
+    if args.strict_unknown and unknown_entries:
+        fail = True
+
+    if fail:
+        sys.exit(2)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/topeft_run2/workflow.py
+++ b/analysis/topeft_run2/workflow.py
@@ -300,10 +300,10 @@ class ChannelPlanner:
                         for jet_cat in jet_bins:
                             if jet_cat is None:
                                 continue
-                            jet_suffix = normalize_jet_category(jet_cat)
+                            jet_selection = normalize_jet_category(jet_cat)
                             ch_name = build_channel_label(
                                 [base_ch],
-                                jet_selection=jet_suffix,
+                                jet_selection=jet_selection,
                             )
                             current = result.setdefault(ch_name, [])
                             for appl in appl_list:

--- a/analysis/topeft_run2/workflow.py
+++ b/analysis/topeft_run2/workflow.py
@@ -53,6 +53,7 @@ from typing import (
 
 import topcoffea
 
+from topeft.modules.channel_metadata import build_channel_label
 from topeft.modules.executor import (
     build_futures_executor,
     build_taskvine_args,
@@ -246,6 +247,10 @@ class ChannelPlanner:
                             chan_def_lst = self._normalize_channel_definition(
                                 region.to_legacy_list(), active_features
                             )
+                            channel_label = build_channel_label(
+                                chan_def_lst,
+                                jet_selection=jet_key,
+                            )
                             return {
                                 "jet_selection": jet_key,
                                 "chan_def_lst": chan_def_lst,
@@ -256,6 +261,7 @@ class ChannelPlanner:
                                 if include_set
                                 else (),
                                 "channel_var_blacklist": tuple(sorted(exclude_set)),
+                                "channel_label": channel_label,
                             }
             return None
 
@@ -295,8 +301,10 @@ class ChannelPlanner:
                             if jet_cat is None:
                                 continue
                             jet_suffix = normalize_jet_category(jet_cat)
-                            clean_suffix = jet_suffix.split("_")[-1]
-                            ch_name = f"{base_ch}_{clean_suffix}"
+                            ch_name = build_channel_label(
+                                [base_ch],
+                                jet_selection=jet_suffix,
+                            )
                             current = result.setdefault(ch_name, [])
                             for appl in appl_list:
                                 if appl not in current:
@@ -472,7 +480,8 @@ class HistogramPlanner:
         self._config = config
         self._var_defs = variable_definitions
         self._channel_planner = channel_planner
-        self._analysis_processor_module = None
+        self._channel_metadata_log_count = 0
+        self._channel_metadata_log_limit = 8
 
     def plan(
         self,
@@ -575,9 +584,21 @@ class HistogramPlanner:
                     continue
 
                 flavored_channels = self._resolve_flavored_channels(channel_metadata)
+                channel_label = channel_metadata.get("channel_label") or clean_ch
+
+                if self._channel_metadata_log_count < self._channel_metadata_log_limit:
+                    logger.info(
+                        "Channel metadata: channel_label=%s, chan_def_lst=%s, jet_selection=%s, appregion=%s, features=%s",
+                        channel_label,
+                        channel_metadata.get("chan_def_lst"),
+                        channel_metadata.get("jet_selection"),
+                        channel_metadata.get("appl_region"),
+                        channel_metadata.get("features"),
+                    )
+                    self._channel_metadata_log_count += 1
 
                 yield ChannelApplicationSelection(
-                    clean_channel=clean_ch,
+                    clean_channel=channel_label,
                     application=appl,
                     metadata=channel_metadata,
                     flavored_channels=flavored_channels,
@@ -590,7 +611,6 @@ class HistogramPlanner:
         if not self._config.split_lep_flavor:
             return ()
 
-        analysis_processor_module = self._get_analysis_processor_module()
         flavored_candidates: List[str] = []
         lep_flavors = channel_metadata.get("lep_flav_lst") or []
         lep_chan_defs = channel_metadata.get("chan_def_lst") or []
@@ -600,20 +620,13 @@ class HistogramPlanner:
             for lep_flavor in lep_flavors:
                 if not lep_flavor:
                     continue
-                flavored_name = analysis_processor_module.construct_cat_name(
-                    lep_base,
-                    njet_str=jet_selection,
-                    flav_str=lep_flavor,
+                flavored_name = build_channel_label(
+                    [lep_base],
+                    jet_selection=jet_selection,
+                    lep_flav=lep_flavor,
                 )
                 flavored_candidates.append(flavored_name)
         return tuple(flavored_candidates)
-
-    def _get_analysis_processor_module(self):
-        if self._analysis_processor_module is None:
-            from . import analysis_processor as analysis_processor_module
-
-            self._analysis_processor_module = analysis_processor_module
-        return self._analysis_processor_module
 
     def _expand_systematics(
         self,

--- a/topeft/modules/channel_metadata.py
+++ b/topeft/modules/channel_metadata.py
@@ -17,6 +17,50 @@ from typing import Dict, Iterable, Iterator, List, Mapping, Optional, Sequence, 
 logger = logging.getLogger(__name__)
 
 
+def build_channel_label(
+    chan_def_lst: Sequence[str],
+    jet_selection: Optional[str] = None,
+    lep_flav: Optional[str] = None,
+) -> str:
+    """
+    Return the canonical channel label including the jet bin and optional flavor.
+
+    The jet-selection tag is expected to follow the existing normalized scheme
+    (e.g. ``exactly_0j``, ``atleast_2j``); the trailing component is appended as
+    the jet-bin suffix to the base channel.  This helper codifies the existing
+    naming convention without altering which jet-selection tags are available.
+    """
+
+    if not chan_def_lst:
+        raise ValueError("chan_def_lst must contain at least one entry")
+
+    base_channel_raw = str(chan_def_lst[0]).strip()
+    if not base_channel_raw:
+        raise ValueError("chan_def_lst[0] must be a non-empty string")
+
+    base_parts = base_channel_raw.split("_")
+    nlep_prefix = base_parts[0]
+    remainder = "_".join(part for part in base_parts[1:] if part)
+
+    components: List[str] = [nlep_prefix]
+
+    if lep_flav:
+        flav = str(lep_flav).strip()
+        if flav:
+            components.append(flav)
+
+    if remainder:
+        components.append(remainder)
+
+    jet_tag = str(jet_selection).strip() if jet_selection is not None else ""
+    if jet_tag:
+        jet_suffix = jet_tag.split("_")[-1]
+        if jet_suffix:
+            components.append(jet_suffix)
+
+    return "_".join(components)
+
+
 def _normalize_histogram_list(
     values: Optional[object], *, context: str, field_name: str
 ) -> Tuple[str, ...]:


### PR DESCRIPTION
## Summary
This PR standardizes channel naming for Run-2 tuple-keyed outputs and adds a small validation utility:

- **Canonical channel labels**: introduce `build_channel_label(...)` and propagate a single “canonical” channel label (including jet-bin suffix, and optional lepton-flavor tag) consistently through planning, histogram filling, and `region_yields`.
- **Aligned `region_yields` keys**: `region_yields` logging/storage now uses the same canonical channel label used by the histogram tuple keys, so coverage checks and totals line up cleanly.
- **New validator script**: adds `analysis/topeft_run2/quick_check.py` to quickly sanity-check `.pkl.gz` / `.lz4` outputs (tuple-key inventory, emptiness heuristics, region-yields coverage + totals, optional `*_sumw2` partner checks), including robust numpy/duck-typed parsing for region yields.

---

## Motivation

### 1) Channel naming drift (jet bins + flavor splits)
With tuple-keyed outputs, downstream tooling expects the `channel` component of the tuple key to be stable and meaningful. In practice, channel naming could drift between:
- what the workflow/planners consider the “clean channel” for bookkeeping, and
- what the processor uses when filling and when recording `region_yields`.

This is especially easy to trip over when:
- channels are **jet-binned** and the label is derived from the jet selection tag, and/or
- channels are **split by lepton flavor**.

The goal here is to make the channel label deterministic, centralized, and consistent everywhere.

### 2) Lightweight output validation
We also want a fast way to validate produced artifacts without custom notebooks:
- enumerate tuple keys, types, and obvious empties,
- verify that `region_yields` entries correspond to at least one histogram key for the same `(channel, application, dataset, systematic)`,
- print totals (optionally grouped) even when yields are stored as numpy arrays/scalars.

---

## Implementation details

### A) Canonical label helper: `build_channel_label`
File: `topeft/modules/channel_metadata.py`

- Adds `build_channel_label(chan_def_lst, jet_selection=None, lep_flav=None)`.
- Encodes the existing naming convention in one place:
  - starts from the base channel (first element of `chan_def_lst`)
  - optionally inserts `lep_flav`
  - appends the **jet-bin suffix** derived from the last component of `jet_selection` (e.g. `exactly_0j → 0j`).
- This keeps the “what jet categories exist” logic unchanged; it only standardizes the *string label*.

### B) Workflow: propagate `channel_label` and use it consistently
File: `analysis/topeft_run2/workflow.py`

- `ChannelPlanner` now computes `channel_label` once and stores it into the channel metadata payload:
  - `channel_label = build_channel_label(chan_def_lst, jet_selection=jet_key)`
- Jet-binned channels are named via `build_channel_label(...)` rather than manual suffix concatenation.
- `HistogramPlanner`:
  - uses `channel_label` (fallback to `clean_ch`) when yielding `ChannelApplicationSelection(clean_channel=...)`
  - adds bounded INFO logging of channel metadata (first N entries) to ease debugging without log spam
  - removes the old dependency on importing `analysis_processor` just to construct flavored names.

### C) Processor: fill + `region_yields` keyed by canonical labels
File: `analysis/topeft_run2/analysis_processor.py`

- Captures `_channel_label` and `_jet_selection` early from `channel_dict`:
  - if `channel_label` is present in metadata, use it;
  - otherwise, attempt to build it with `build_channel_label(...)`, and fall back safely if that fails.
- When split-by-flavor is enabled:
  - `ch_name` becomes the canonical base label, optionally rebuilt with `lep_flav=...`.
- `region_yields` logging and accumulator keys now use the **same canonical channel label** as the histogram tuple keys (including jet-bin and flavor where applicable), avoiding “base channel vs flavored channel” mismatches.

### D) New validator: `analysis/topeft_run2/quick_check.py`
File: `analysis/topeft_run2/quick_check.py` (new)

Key features:
- **Smart load**:
  - gzip + `cloudpickle.load`
  - lz4 frame + `coffea.util.load`
- **Tuple-key inventory**:
  - detects keys of the form `(variable, channel, application, dataset, systematic)`
  - prints unique sets and (optionally) the keys themselves
  - prints histogram value-type summaries (overall + per variable)
- **Emptiness heuristics**:
  - checks `_dense_hists` if present
  - falls back to `values()` inspection when available
  - special-case: `HistEFT.values()` raising empty-tuple-like `"()"` is treated as **empty** (not “unknown”)
- **`region_yields` checks**:
  - schema inference
  - coverage check: if a region_yields entry has `n_events > 0`, require at least one histogram key with matching `(channel, application, dataset, systematic)`
  - totals printing with `--totals-by {none,dataset,channel,application,systematic,all}`
  - robust yield parsing for:
    - numpy arrays / numpy scalars
    - python list/tuple/scalar
    - duck-typed arrays (flatten/ravel/item) when numpy isn’t importable
  - optional warning on numpy import failure via `--warn-numpy-import`
- **Optional partner enforcement**:
  - `--require-sumw2` or `--require-sumw2-for ...` to enforce `x` ↔ `x_sumw2` key pairs.

---

## Backwards compatibility / behavior changes
- **Tuple key “channel” values** (and `region_yields` channel values) now follow the canonical `build_channel_label(...)` convention. Any downstream tooling or reference artifacts that assumed the older ad-hoc naming may need to be updated/regenerated.
- This PR is intended to be *naming/metadata alignment* rather than a physics-selection change; however, since labels and bookkeeping keys change, comparisons that join on channel strings will see the difference.

---

## Testing
- `PYTHONPATH= /path/to/python -m compileall analysis/topeft_run2/quick_check.py`
- Example validation run:
  - `PYTHONPATH= /path/to/python analysis/topeft_run2/quick_check.py histos/<file>.pkl.gz --totals-by all`
- Verified that `region_yields` totals parse correctly when yields are stored as numpy arrays/scalars and that coverage checks succeed when histogram keys are present.

---

## Follow-ups
- If we find any external consumers that still depend on the old channel-string convention, we can add a small compatibility shim (or document the mapping) — but the goal is to converge everything on the canonical label going forward.
