### PR TITLE
single metadata authority + enforce --options as single source of truth

### DIFF
--- a/analysis/topeft_run2/__init__.py
+++ b/analysis/topeft_run2/__init__.py
@@ -11,32 +11,31 @@ try:
         normalize_jet_category,
         run_workflow,
     )
+    _WORKFLOW_AVAILABLE = True
 except ImportError:  # pragma: no cover - optional workflow helper
-    from .workflow import (  # type: ignore[misc]
-        ChannelPlanner,
-        ExecutorFactory,
-        HistogramPlan,
-        HistogramPlanner,
-        HistogramTask,
-        normalize_jet_category,
-        run_workflow,
-    )
+    ChannelPlanner = None  # type: ignore[assignment]
+    ExecutorFactory = None  # type: ignore[assignment]
+    HistogramPlan = None  # type: ignore[assignment]
+    HistogramPlanner = None  # type: ignore[assignment]
+    HistogramTask = None  # type: ignore[assignment]
+    normalize_jet_category = None  # type: ignore[assignment]
+    run_workflow = None  # type: ignore[assignment]
     RunWorkflow = None  # type: ignore[assignment]
+    _WORKFLOW_AVAILABLE = False
 from .quickstart import PreparedSamples, prepare_samples, run_quickstart
 
-__all__ = [
-    "ChannelPlanner",
-    "ExecutorFactory",
-    "HistogramPlan",
-    "HistogramPlanner",
-    "HistogramTask",
-    "normalize_jet_category",
-    "run_workflow",
-    "PreparedSamples",
-    "prepare_samples",
-    "run_quickstart",
-]
-
-if RunWorkflow is not None:
-    __all__.append("RunWorkflow")
-
+__all__ = ["PreparedSamples", "prepare_samples", "run_quickstart"]
+if _WORKFLOW_AVAILABLE:
+    __all__.extend(
+        [
+            "ChannelPlanner",
+            "ExecutorFactory",
+            "HistogramPlan",
+            "HistogramPlanner",
+            "HistogramTask",
+            "normalize_jet_category",
+            "run_workflow",
+        ]
+    )
+    if RunWorkflow is not None:
+        __all__.append("RunWorkflow")

--- a/analysis/topeft_run2/metadata_authority.py
+++ b/analysis/topeft_run2/metadata_authority.py
@@ -1,0 +1,56 @@
+"""Resolve the authoritative metadata path for Run 2 execution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional, Tuple
+
+from analysis.topeft_run2.metadata_loader import resolve_metadata_path
+from analysis.topeft_run2.scenario_registry import resolve_scenario_choice
+
+MetadataResolution = Tuple[str, str]
+
+
+def _normalize_metadata_value(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    candidate = str(value).strip()
+    return candidate or None
+
+
+def resolve_effective_metadata_path(
+    *,
+    scenario_name: str,
+    metadata_cli: Optional[str] = None,
+    metadata_options: Optional[str] = None,
+) -> MetadataResolution:
+    """Return the metadata path and its provenance for ``scenario_name``.
+
+    Precedence:
+      1) Explicit CLI metadata path.
+      2) Metadata path from options YAML.
+      3) Scenario registry fallback.
+    """
+
+    if not scenario_name:
+        raise ValueError("scenario_name must be provided to resolve metadata")
+
+    metadata_cli = _normalize_metadata_value(metadata_cli)
+    metadata_options = _normalize_metadata_value(metadata_options)
+
+    if metadata_cli:
+        metadata_path = metadata_cli
+        provenance = "cli"
+    elif metadata_options:
+        metadata_path = metadata_options
+        provenance = "options"
+    else:
+        resolution = resolve_scenario_choice(scenario_name)
+        metadata_path = resolution.metadata_path
+        provenance = "scenario_registry"
+
+    resolved = resolve_metadata_path(metadata_path)
+    return str(Path(resolved)), provenance
+
+
+__all__ = ["resolve_effective_metadata_path", "MetadataResolution"]

--- a/analysis/topeft_run2/metadata_authority.py
+++ b/analysis/topeft_run2/metadata_authority.py
@@ -26,10 +26,9 @@ def resolve_effective_metadata_path(
 ) -> MetadataResolution:
     """Return the metadata path and its provenance for ``scenario_name``.
 
-    Precedence:
-      1) Explicit CLI metadata path.
-      2) Metadata path from options YAML.
-      3) Scenario registry fallback.
+    ``metadata_cli`` and ``metadata_options`` are mutually exclusive; providing
+    both raises ``ValueError``. When only one is set, it wins over the scenario
+    registry fallback.
     """
 
     if not scenario_name:
@@ -37,6 +36,12 @@ def resolve_effective_metadata_path(
 
     metadata_cli = _normalize_metadata_value(metadata_cli)
     metadata_options = _normalize_metadata_value(metadata_options)
+
+    if metadata_cli and metadata_options:
+        raise ValueError(
+            "metadata_cli and metadata_options are mutually exclusive. "
+            "When using --options, options YAML is the single source of truth."
+        )
 
     if metadata_cli:
         metadata_path = metadata_cli

--- a/analysis/topeft_run2/quickstart.py
+++ b/analysis/topeft_run2/quickstart.py
@@ -37,14 +37,14 @@ try:
         HistogramPlanner,
         RunWorkflow,
     )
+    _WORKFLOW_AVAILABLE = True
 except ImportError:  # pragma: no cover - optional workflow helper
-    from .workflow import (  # type: ignore[misc]
-        DEFAULT_SCENARIO_NAME,
-        ChannelPlanner,
-        ExecutorFactory,
-        HistogramPlanner,
-    )
+    DEFAULT_SCENARIO_NAME = "TOP_22_006"
+    ChannelPlanner = None  # type: ignore[assignment]
+    ExecutorFactory = None  # type: ignore[assignment]
+    HistogramPlanner = None  # type: ignore[assignment]
     RunWorkflow = None  # type: ignore[assignment]
+    _WORKFLOW_AVAILABLE = False
 
 _DEFAULT_VARIABLES: Tuple[str, ...] = ("lj0pt",)
 _DEFAULT_METADATA_PATH = topeft_path("analysis/metadata/metadata.yml")

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -64,6 +64,8 @@ from run_analysis_helpers import (
     _enforce_taskvine_logging_policy,
     _normalize_executor_name,
     _resolve_effective_log_level,
+    enforce_options_single_source,
+    options_allowlist,
 )
 from topeft.modules.executor_cli import (
     ExecutorCLIHelper,
@@ -192,7 +194,7 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help=(
             "Path to the metadata YAML bundle. When supplied it overrides the "
-            "metadata from the options YAML or the scenario registry."
+            "metadata from the scenario registry. Cannot be used with --options."
         ),
     )
     parser.add_argument(
@@ -311,7 +313,7 @@ def build_parser() -> argparse.ArgumentParser:
             "YAML file that specifies command-line options. Accepts either"
             " 'path.yml' for the default profile or 'path.yml:profile' to select"
             " a specific profile. When provided, CLI flags are ignored in favour"
-            " of the YAML configuration (except --metadata, which always wins)."
+            " of the YAML configuration. Passing other config flags is an error."
         ),
     )
     parser.set_defaults(negotiate_manager_port=True)
@@ -350,9 +352,6 @@ def _apply_scenario_metadata_defaults(
         )
 
     scenario_name = scenario_names[0]
-    if metadata_cli is None and config.options_path is None and config.metadata_path:
-        metadata_cli = config.metadata_path
-
     metadata_options = config.metadata_path if config.options_path else None
     metadata_path, provenance = resolve_effective_metadata_path(
         scenario_name=scenario_name,
@@ -390,13 +389,9 @@ def main(argv: Sequence[str] | None = None) -> None:
         argv_list = list(sys.argv[1:])
     else:
         argv_list = list(argv)
-    args = parser.parse_args(argv_list)
+    enforce_options_single_source(parser, argv_list, options_allowlist(parser))
 
-    if getattr(args, "options", None) and getattr(args, "scenarios", None):
-        parser.error(
-            "Scenario selection must come from either --scenario or --options. "
-            "Set the scenario inside the options profile or drop the CLI flag."
-        )
+    args = parser.parse_args(argv_list)
 
     executor_from_cli = _argument_supplied(argv_list, "--executor", "-x")
     chunksize_from_cli = _argument_supplied(argv_list, "--chunksize", "-s")

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -19,7 +19,7 @@ from typing import Sequence
 
 import topcoffea
 
-from analysis.topeft_run2.scenario_registry import resolve_scenario_choice
+from analysis.topeft_run2.metadata_authority import resolve_effective_metadata_path
 
 
 def _verify_numpy_pandas_abi() -> None:
@@ -188,6 +188,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Name of the tree inside the files",
     )
     parser.add_argument(
+        "--metadata",
+        default=None,
+        help=(
+            "Path to the metadata YAML bundle. When supplied it overrides the "
+            "metadata from the options YAML or the scenario registry."
+        ),
+    )
+    parser.add_argument(
         "--do-errors",
         action="store_true",
         help="Save the w**2 coefficients",
@@ -303,7 +311,7 @@ def build_parser() -> argparse.ArgumentParser:
             "YAML file that specifies command-line options. Accepts either"
             " 'path.yml' for the default profile or 'path.yml:profile' to select"
             " a specific profile. When provided, CLI flags are ignored in favour"
-            " of the YAML configuration."
+            " of the YAML configuration (except --metadata, which always wins)."
         ),
     )
     parser.set_defaults(negotiate_manager_port=True)
@@ -320,13 +328,15 @@ def _ensure_supported_executor(value: str) -> None:
         )
 
 
-def _apply_scenario_metadata_defaults(config: RunConfig) -> tuple[str, str, bool]:
+def _apply_scenario_metadata_defaults(
+    config: RunConfig,
+    metadata_cli: str | None,
+) -> tuple[str, str, str]:
     """Resolve the effective scenario and metadata selection.
 
     Returns:
-        Tuple containing the scenario name, metadata path, and a boolean flag
-        indicating whether the metadata came from an options profile (True)
-        versus the scenario registry (False).
+        Tuple containing the scenario name, metadata path, and a provenance
+        label describing the metadata source.
     """
 
     scenario_names = config.scenario_names or ["TOP_22_006"]
@@ -340,12 +350,17 @@ def _apply_scenario_metadata_defaults(config: RunConfig) -> tuple[str, str, bool
         )
 
     scenario_name = scenario_names[0]
-    if config.metadata_path:
-        return scenario_name, config.metadata_path, True
+    if metadata_cli is None and config.options_path is None and config.metadata_path:
+        metadata_cli = config.metadata_path
 
-    resolution = resolve_scenario_choice(scenario_name)
-    config.metadata_path = resolution.metadata_path
-    return scenario_name, config.metadata_path, False
+    metadata_options = config.metadata_path if config.options_path else None
+    metadata_path, provenance = resolve_effective_metadata_path(
+        scenario_name=scenario_name,
+        metadata_cli=metadata_cli,
+        metadata_options=metadata_options,
+    )
+    config.metadata_path = metadata_path
+    return scenario_name, metadata_path, provenance
 
 
 def _argument_supplied(
@@ -386,6 +401,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     executor_from_cli = _argument_supplied(argv_list, "--executor", "-x")
     chunksize_from_cli = _argument_supplied(argv_list, "--chunksize", "-s")
     nchunks_from_cli = _argument_supplied(argv_list, "--nchunks", "-c")
+    metadata_from_cli = _argument_supplied(argv_list, "--metadata")
     executor_default = _normalize_executor_name(getattr(parser_defaults, "executor", ""))
     if not executor_default:
         executor_default = "taskvine"
@@ -403,9 +419,13 @@ def main(argv: Sequence[str] | None = None) -> None:
     except (ValueError, TypeError, KeyError) as exc:
         parser.error(str(exc))
 
+    metadata_cli_value = getattr(args, "metadata", None) if metadata_from_cli else None
     try:
-        scenario_name, metadata_path, metadata_from_options = _apply_scenario_metadata_defaults(config)
-    except ValueError as exc:
+        scenario_name, metadata_path, metadata_provenance = _apply_scenario_metadata_defaults(
+            config,
+            metadata_cli_value,
+        )
+    except (ValueError, FileNotFoundError) as exc:
         message = str(exc)
         if message:
             logger.error("%s", message)
@@ -443,18 +463,12 @@ def main(argv: Sequence[str] | None = None) -> None:
         allow_dev_debug=(config.executor != "taskvine"),
     )
 
-    if metadata_from_options:
-        logger.info(
-            "Using scenario '%s' with metadata '%s' (from options profile)",
-            scenario_name,
-            metadata_path,
-        )
-    else:
-        logger.info(
-            "Using scenario '%s' with metadata '%s'",
-            scenario_name,
-            metadata_path,
-        )
+    logger.info(
+        "Using scenario '%s' with metadata '%s' (source: %s)",
+        scenario_name,
+        metadata_path,
+        metadata_provenance,
+    )
 
     config.log_level = effective_log_level
     logger.info(

--- a/analysis/topeft_run2/run_analysis_helpers.py
+++ b/analysis/topeft_run2/run_analysis_helpers.py
@@ -69,6 +69,89 @@ def unique_preserving_order(values: Iterable[str]) -> List[str]:
     return result
 
 
+def _canonical_option_string(action: "argparse.Action") -> str:
+    for option in action.option_strings:
+        if option.startswith("--"):
+            return option
+    return action.option_strings[0]
+
+
+def find_explicit_cli_options(
+    argv: Sequence[str],
+    parser: "argparse.ArgumentParser",
+) -> List[str]:
+    """Return explicit CLI options in ``argv`` as canonical option strings."""
+
+    explicit: List[str] = []
+    seen: set[str] = set()
+    option_actions = parser._option_string_actions
+    for token in argv:
+        if token == "--":
+            break
+        if token.startswith("--"):
+            option = token.split("=", 1)[0]
+        elif token.startswith("-") and token != "-":
+            option = token.split("=", 1)[0]
+            if option not in option_actions and len(option) > 2:
+                option = option[:2]
+        else:
+            continue
+        action = option_actions.get(option)
+        if action is None:
+            continue
+        canonical = _canonical_option_string(action)
+        if canonical in seen:
+            continue
+        seen.add(canonical)
+        explicit.append(canonical)
+    return explicit
+
+
+def options_allowlist(
+    parser: "argparse.ArgumentParser",
+) -> set[str]:
+    """Return the minimal set of options allowed alongside ``--options``."""
+
+    allowlist: set[str] = set()
+    for option in ("--help", "--version"):
+        action = parser._option_string_actions.get(option)
+        if action is None:
+            continue
+        allowlist.add(_canonical_option_string(action))
+    return allowlist
+
+
+def find_options_conflicts(
+    argv: Sequence[str],
+    parser: "argparse.ArgumentParser",
+    allowlist: set[str],
+) -> List[str]:
+    """Return conflicting options when ``--options`` is present."""
+
+    explicit = find_explicit_cli_options(argv, parser)
+    if "--options" not in explicit:
+        return []
+    allowed = set(allowlist)
+    allowed.add("--options")
+    return [option for option in explicit if option not in allowed]
+
+
+def enforce_options_single_source(
+    parser: "argparse.ArgumentParser",
+    argv: Sequence[str],
+    allowlist: set[str],
+) -> None:
+    """Raise an argparse error if ``--options`` conflicts with CLI flags."""
+
+    conflicts = find_options_conflicts(argv, parser, allowlist)
+    if conflicts:
+        parser.error(
+            "--options was provided, so options YAML is the single source of truth. "
+            "Remove these conflicting CLI flags (or move them into the options YAML): "
+            + ", ".join(conflicts)
+        )
+
+
 def coerce_bool(value: Any) -> Optional[bool]:
     """Convert ``value`` into a boolean if possible."""
 
@@ -679,7 +762,11 @@ __all__ = [
     "coerce_json_files",
     "coerce_optional_float",
     "coerce_port",
+    "enforce_options_single_source",
+    "find_explicit_cli_options",
+    "find_options_conflicts",
     "normalize_sequence",
+    "options_allowlist",
     "unique_preserving_order",
     "weight_variations_from_metadata",
 ]

--- a/tests/test_metadata_authority.py
+++ b/tests/test_metadata_authority.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from analysis.topeft_run2.metadata_authority import resolve_effective_metadata_path
 
 
@@ -21,14 +23,24 @@ def test_options_metadata_wins_over_registry(tmp_path: Path) -> None:
     assert provenance == "options"
 
 
-def test_cli_metadata_wins_over_options(tmp_path: Path) -> None:
+def test_cli_metadata_wins_over_registry(tmp_path: Path) -> None:
     cli_path = _write_metadata(tmp_path, "cli.yml")
-    options_path = _write_metadata(tmp_path, "options.yml")
     resolved_path, provenance = resolve_effective_metadata_path(
         scenario_name="TOP_22_006",
         metadata_cli=str(cli_path),
-        metadata_options=str(options_path),
+        metadata_options=None,
     )
 
     assert Path(resolved_path) == cli_path.resolve()
     assert provenance == "cli"
+
+
+def test_cli_and_options_metadata_are_mutually_exclusive(tmp_path: Path) -> None:
+    cli_path = _write_metadata(tmp_path, "cli.yml")
+    options_path = _write_metadata(tmp_path, "options.yml")
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        resolve_effective_metadata_path(
+            scenario_name="TOP_22_006",
+            metadata_cli=str(cli_path),
+            metadata_options=str(options_path),
+        )

--- a/tests/test_metadata_authority.py
+++ b/tests/test_metadata_authority.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+from analysis.topeft_run2.metadata_authority import resolve_effective_metadata_path
+
+
+def _write_metadata(tmp_path: Path, name: str) -> Path:
+    path = tmp_path / name
+    path.write_text("variables: {}\n")
+    return path
+
+
+def test_options_metadata_wins_over_registry(tmp_path: Path) -> None:
+    metadata_path = _write_metadata(tmp_path, "options.yml")
+    resolved_path, provenance = resolve_effective_metadata_path(
+        scenario_name="TOP_22_006",
+        metadata_cli=None,
+        metadata_options=str(metadata_path),
+    )
+
+    assert Path(resolved_path) == metadata_path.resolve()
+    assert provenance == "options"
+
+
+def test_cli_metadata_wins_over_options(tmp_path: Path) -> None:
+    cli_path = _write_metadata(tmp_path, "cli.yml")
+    options_path = _write_metadata(tmp_path, "options.yml")
+    resolved_path, provenance = resolve_effective_metadata_path(
+        scenario_name="TOP_22_006",
+        metadata_cli=str(cli_path),
+        metadata_options=str(options_path),
+    )
+
+    assert Path(resolved_path) == cli_path.resolve()
+    assert provenance == "cli"

--- a/tests/test_run_analysis_options_conflicts.py
+++ b/tests/test_run_analysis_options_conflicts.py
@@ -1,0 +1,56 @@
+import argparse
+
+import pytest
+
+from analysis.topeft_run2.run_analysis_helpers import (
+    enforce_options_single_source,
+    find_options_conflicts,
+    options_allowlist,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(add_help=True)
+    parser.add_argument("--options")
+    parser.add_argument("--metadata")
+    parser.add_argument("--executor", "-x")
+    parser.add_argument("--chunksize", "-s")
+    return parser
+
+
+def test_options_with_metadata_errors() -> None:
+    parser = _build_parser()
+    allowlist = options_allowlist(parser)
+    argv = ["--options", "opts.yml", "--metadata", "meta.yml"]
+    conflicts = find_options_conflicts(argv, parser, allowlist)
+    assert conflicts == ["--metadata"]
+    with pytest.raises(SystemExit) as excinfo:
+        enforce_options_single_source(parser, argv, allowlist)
+    assert excinfo.value.code == 2
+
+
+def test_options_with_executor_errors() -> None:
+    parser = _build_parser()
+    allowlist = options_allowlist(parser)
+    argv = ["--options", "opts.yml", "-x", "taskvine"]
+    conflicts = find_options_conflicts(argv, parser, allowlist)
+    assert conflicts == ["--executor"]
+    with pytest.raises(SystemExit) as excinfo:
+        enforce_options_single_source(parser, argv, allowlist)
+    assert excinfo.value.code == 2
+
+
+def test_options_only_is_allowed() -> None:
+    parser = _build_parser()
+    allowlist = options_allowlist(parser)
+    argv = ["--options", "opts.yml"]
+    conflicts = find_options_conflicts(argv, parser, allowlist)
+    assert conflicts == []
+
+
+def test_options_with_help_is_allowed() -> None:
+    parser = _build_parser()
+    allowlist = options_allowlist(parser)
+    argv = ["--options", "opts.yml", "--help"]
+    conflicts = find_options_conflicts(argv, parser, allowlist)
+    assert conflicts == []


### PR DESCRIPTION
## Summary
This PR tightens and centralizes Run-2 configuration semantics around metadata selection and `--options`:

- **Single metadata authority**: introduce `analysis/topeft_run2/metadata_authority.py` to resolve the effective metadata path exactly once, validate it, and attach a provenance label (`cli`, `options`, `scenario_registry`).
- **Options YAML as single source of truth**: enforce a strict CLI policy in `run_analysis.py` such that when `--options` is provided, any other config-affecting CLI flags trigger an early argparse error (minimal allowlist: `--help`, `--version`).
- **Resolver API aligned with the CLI policy**: update the resolver contract so `metadata_cli` and `metadata_options` are mutually exclusive (raises `ValueError` if both are provided), avoiding “theoretical precedence” branches that the main CLI now forbids.
- **Lightweight unit coverage**: add targeted tests for resolver precedence vs registry and for `--options` conflict detection; tests are fast and do not execute workflows.
- **Import resilience for unit tests**: make `analysis.topeft_run2` and `analysis/topeft_run2/quickstart.py` imports tolerant to missing workflow/runtime dependencies so unit tests can run in minimal environments.

---

## Motivation

### 1) Remove dual-source-of-truth ambiguity
Prior to this series, metadata selection could be influenced by multiple places with subtle precedence:
- CLI flags,
- options YAML profiles,
- scenario registry fallback.

This created ambiguity and “surprising overrides” when users mixed `--options` with other flags. The desired invariant is:
- **If `--options` is set, the YAML profile owns the run configuration.**
- Otherwise, CLI flags can be used, with scenario registry acting only as a fallback when unset.

### 2) Make metadata selection explicit, validated, and observable
Metadata is a critical input and should be:
- chosen once,
- normalized to a consistent (absolute) path,
- validated for existence early,
- logged with provenance (so users can see *why* a path was picked).

### 3) Enable fast, deterministic testing
The resolver logic is pure and should be unit-testable without pulling in the heavy workflow stack. Some `analysis.topeft_run2` imports currently couple to workflow dependencies; we want tests that stay lightweight and deterministic.

---

## Implementation details

### A) Central resolver: `metadata_authority.resolve_effective_metadata_path`
File: `analysis/topeft_run2/metadata_authority.py`

- Adds a small resolver that returns `(metadata_path, provenance)`.
- Inputs:
  - `scenario_name` (required)
  - `metadata_cli` (optional)
  - `metadata_options` (optional)
- Contract:
  - `metadata_cli` and `metadata_options` are **mutually exclusive**; providing both raises `ValueError`.
  - If `metadata_cli` is set: use it (`provenance="cli"`).
  - Else if `metadata_options` is set: use it (`provenance="options"`).
  - Else: fall back to scenario registry (`provenance="scenario_registry"`).
- Normalization/validation:
  - Always passes the chosen path through `resolve_metadata_path(...)` to normalize to an absolute path and validate existence.

This makes “what metadata are we using?” both explicit and centrally enforced.

### B) Run-2 CLI integration: resolve once, log provenance once
File: `analysis/topeft_run2/run_analysis.py`

- Adds/keeps a dedicated `--metadata` CLI flag (usable only when not using `--options`).
- Computes a single authoritative `config.metadata_path` via the resolver:
  - if running via `--options`: `metadata_options = config.metadata_path` (from the options profile)
  - if running via CLI: `metadata_cli = args.metadata` (if explicitly supplied)
- Emits a single startup INFO line:
  - `"Using scenario '<scenario>' with metadata '<path>' (source: <provenance>)"`
- Ensures `RunConfig.metadata_path` is set **exactly once** and isn’t silently re-filled later by registry logic.

### C) Enforce `--options` as the only configuration source
Files: `analysis/topeft_run2/run_analysis.py`, `analysis/topeft_run2/run_analysis_helpers.py`

- Introduces `enforce_options_single_source(...)` and supporting helpers to detect explicit CLI flags in `argv`.
- When `--options` is present:
  - any config-affecting CLI flags (e.g. `--metadata`, `--executor`, `--chunksize`, etc.) are **rejected** with a clear argparse error telling users to move those settings into the options YAML.
  - minimal allowlist is retained for non-config flags that should still work with `--options`:
    - `--help`
    - `--version`
- This resolves ambiguity permanently at the CLI boundary: no “sometimes this flag wins” behavior.

### D) Unit tests (fast, resolver-focused)
Files: `tests/test_metadata_authority.py`, `tests/test_run_analysis_options_conflicts.py`

- `test_metadata_authority.py` covers:
  - options metadata wins over registry
  - CLI metadata wins over registry
  - CLI + options metadata together raises (mutual-exclusion guarantee)
- `test_run_analysis_options_conflicts.py` covers:
  - `--options` + `--metadata` is an error
  - `--options` + `--executor` is an error
  - `--options` alone is allowed
  - `--options` + `--help` is allowed

These tests validate the new invariants without invoking any coffea workflow execution.

### E) Import resilience to unblock lightweight tests
Files: `analysis/topeft_run2/__init__.py`, `analysis/topeft_run2/quickstart.py`

- Makes workflow-related imports optional and avoids importing heavy dependencies at import time when not needed.
- Provides a minimal surface (`prepare_samples`, `run_quickstart`) even when workflow bits are unavailable, enabling unit tests to import `analysis.topeft_run2` without requiring the full runtime stack.

---

## Backwards compatibility / behavior changes

### 1) Strict `--options` policy (intentional)
- **New behavior**: providing `--options` together with other configuration flags now errors out.
- Users must move those settings into the selected options YAML profile.
- This is a deliberate breaking change aimed at making runs reproducible and unambiguous.

### 2) Metadata selection is now explicit and validated once
- Metadata path resolution is now centralized and validated early.
- Scenario registry only participates when no metadata was provided via CLI or options.

### 3) Import-time behavior in `analysis.topeft_run2`
- `analysis.topeft_run2` becomes more tolerant to missing workflow dependencies.
- This should be transparent for normal executions, but it does change import-time behavior for environments missing optional deps (now degrades gracefully rather than failing early).

---

## Testing
- `PYTHON_ENV="/users/apiccine/work/miniconda3/envs/coffea2025/bin/python" $PYTHON_ENV -m compileall analysis/topeft_run2`
- `PYTHON_ENV="/users/apiccine/work/miniconda3/envs/coffea2025/bin/python" $PYTHON_ENV -m pytest -q tests/test_metadata_authority.py`
- `PYTHON_ENV="/users/apiccine/work/miniconda3/envs/coffea2025/bin/python" $PYTHON_ENV -m pytest -q tests/test_run_analysis_options_conflicts.py`

---

## Follow-ups
- Apply the same “options-only” conflict policy consistently across any other Run-2 utility entrypoints that accept `--options` (if applicable).
- Proceed with M2 tasks (scenario_groups strictness/gating, quickstart/datacards alignment) on top of this PR once the new CLI invariants are merged.