### PR TITLE
Add guardrail tests for metadata authority and scenario-group strictness

### DIFF
--- a/tests/data/metadata_minimal.yml
+++ b/tests/data/metadata_minimal.yml
@@ -1,0 +1,5 @@
+channels:
+  groups:
+    TOP22_006_CH_LST_SR:
+      description: "minimal"
+      regions: []

--- a/tests/test_metadata_authority.py
+++ b/tests/test_metadata_authority.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from analysis.topeft_run2.metadata_authority import resolve_effective_metadata_path
+from analysis.topeft_run2 import metadata_authority
 
 
 def _write_metadata(tmp_path: Path, name: str) -> Path:
@@ -11,9 +11,15 @@ def _write_metadata(tmp_path: Path, name: str) -> Path:
     return path
 
 
-def test_options_metadata_wins_over_registry(tmp_path: Path) -> None:
+def test_options_metadata_bypasses_registry(tmp_path: Path, monkeypatch) -> None:
     metadata_path = _write_metadata(tmp_path, "options.yml")
-    resolved_path, provenance = resolve_effective_metadata_path(
+
+    def fail_registry(*args, **kwargs):
+        raise AssertionError("Scenario registry should not be consulted for options metadata")
+
+    monkeypatch.setattr(metadata_authority, "resolve_scenario_choice", fail_registry)
+
+    resolved_path, provenance = metadata_authority.resolve_effective_metadata_path(
         scenario_name="TOP_22_006",
         metadata_cli=None,
         metadata_options=str(metadata_path),
@@ -23,9 +29,15 @@ def test_options_metadata_wins_over_registry(tmp_path: Path) -> None:
     assert provenance == "options"
 
 
-def test_cli_metadata_wins_over_registry(tmp_path: Path) -> None:
+def test_cli_metadata_bypasses_registry(tmp_path: Path, monkeypatch) -> None:
     cli_path = _write_metadata(tmp_path, "cli.yml")
-    resolved_path, provenance = resolve_effective_metadata_path(
+
+    def fail_registry(*args, **kwargs):
+        raise AssertionError("Scenario registry should not be consulted for CLI metadata")
+
+    monkeypatch.setattr(metadata_authority, "resolve_scenario_choice", fail_registry)
+
+    resolved_path, provenance = metadata_authority.resolve_effective_metadata_path(
         scenario_name="TOP_22_006",
         metadata_cli=str(cli_path),
         metadata_options=None,
@@ -39,8 +51,19 @@ def test_cli_and_options_metadata_are_mutually_exclusive(tmp_path: Path) -> None
     cli_path = _write_metadata(tmp_path, "cli.yml")
     options_path = _write_metadata(tmp_path, "options.yml")
     with pytest.raises(ValueError, match="mutually exclusive"):
-        resolve_effective_metadata_path(
+        metadata_authority.resolve_effective_metadata_path(
             scenario_name="TOP_22_006",
             metadata_cli=str(cli_path),
             metadata_options=str(options_path),
         )
+
+
+def test_registry_fallback_when_no_metadata() -> None:
+    resolved_path, provenance = metadata_authority.resolve_effective_metadata_path(
+        scenario_name="TOP_22_006",
+        metadata_cli=None,
+        metadata_options=None,
+    )
+
+    assert Path(resolved_path).exists()
+    assert provenance == "scenario_registry"

--- a/tests/test_scenario_groups_strictness.py
+++ b/tests/test_scenario_groups_strictness.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+import pytest
+
+from topeft.modules import scenario_groups
+
+
+def _fixture_path(name: str) -> Path:
+    return Path(__file__).resolve().parent / "data" / name
+
+
+def test_strict_missing_group_raises(monkeypatch) -> None:
+    def fail_fallback():
+        raise AssertionError("Canonical metadata fallback should not be used")
+
+    monkeypatch.setattr(scenario_groups, "_load_group_metadata", fail_fallback)
+
+    metadata_path = _fixture_path("metadata_minimal.yml")
+    with pytest.raises(KeyError, match="unknown group") as excinfo:
+        scenario_groups.load_channels_for_scenario(
+            "TOP_22_006",
+            metadata_path=metadata_path,
+            strict=True,
+        )
+
+    assert "CH_LST_CR" in str(excinfo.value)
+
+
+def test_allow_partial_requires_flag(monkeypatch) -> None:
+    def fail_fallback():
+        raise AssertionError("Canonical metadata fallback should not be used")
+
+    monkeypatch.setattr(scenario_groups, "_load_group_metadata", fail_fallback)
+
+    metadata_path = _fixture_path("metadata_minimal.yml")
+    result = scenario_groups.load_channels_for_scenario(
+        "TOP_22_006",
+        metadata_path=metadata_path,
+        strict=False,
+    )
+
+    groups = result.get("groups") or {}
+    assert "TOP22_006_CH_LST_SR" in groups
+    assert "CH_LST_CR" not in groups
+
+
+def test_missing_group_payload_does_not_fallback(monkeypatch, tmp_path) -> None:
+    def fail_fallback():
+        raise AssertionError("Canonical metadata fallback should not be used")
+
+    monkeypatch.setattr(scenario_groups, "_load_group_metadata", fail_fallback)
+
+    metadata_path = tmp_path / "missing_groups.yml"
+    metadata_path.write_text("channels: {}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="No channel groups available"):
+        scenario_groups.load_channels_for_scenario(
+            "TOP_22_006",
+            metadata_path=metadata_path,
+            strict=True,
+        )


### PR DESCRIPTION
## Summary
This PR adds targeted guardrail tests to prevent regressions in Run-2 metadata authority and scenario-group strictness:

- **Registry-bypass tests**: assert that when a metadata override is provided (via CLI-style input or options-style input), the scenario registry is **not consulted** and provenance is reported correctly (`cli` / `options`).
- **Registry fallback coverage**: assert that when no overrides exist, the resolver uses the scenario registry (provenance `scenario_registry`) and resolves to an existing metadata path.
- **Scenario-group strictness tests**: enforce that missing group references are an error in strict mode (no silent fallback), and that partial groups are only allowed when strictness is explicitly disabled.
- **Minimal fixture**: adds a tiny metadata YAML under `tests/data/` to exercise strict vs partial group handling deterministically.

---

## Motivation
The metadata authority behavior is foundational and easy to accidentally weaken via “helpful” fallbacks or implicit precedence. These tests make the intended invariants executable so that future refactors can’t silently reintroduce:
- consulting the scenario registry even when an override exists,
- falling back to canonical metadata unexpectedly,
- allowing partial/missing groups without an explicit opt-in.

---

## Implementation details

### A) Metadata authority tests
File: `tests/test_metadata_authority.py`

- Uses `monkeypatch` to replace `resolve_scenario_choice` with a function that raises if called.
- Verifies:
  - options-style metadata path resolves without consulting registry, provenance is `options`
  - CLI-style metadata path resolves without consulting registry, provenance is `cli`
  - when no overrides exist, provenance is `scenario_registry` and resolved path exists

### B) Scenario-group strictness tests
File: `tests/test_scenario_groups_strictness.py`  
Fixture: `tests/data/metadata_minimal.yml`

- Strict mode (`strict=True`) raises on missing group references (and must not consult canonical fallback).
- Partial mode (`strict=False`) succeeds but only returns groups present in the provided metadata.
- Missing/invalid group payload raises a clear error (again without fallback).

---

## Testing
Ran (lightweight / targeted):
- `python -m compileall tests`
- `pytest -q tests/test_metadata_authority.py tests/test_scenario_groups_strictness.py`

Note:
- A broader `pytest` collection can fail in some environments due to NumPy ABI / C-extension import issues; these tests are designed to remain lightweight and pass when invoked directly.

---

## Review notes
- This PR is intentionally tests-only (+ tiny fixture) and does not change production logic.
- The tests are written as guardrails against the specific failure modes we care about (registry consulted when it shouldn’t be, and silent fallback/partial groups without an explicit opt-in).