### PR TITLE
Align SR njets aggregation with CR, harden zero-yield reporting, and update Run-3 configs

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -97,7 +97,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         return base_hist_names_ordered, expanded_hist_names_ordered
 
-    def __init__(self, samples, wc_names_lst=[], hist_lst=None, ecut_threshold=None, fill_sumw2_hist=True, do_systematics=False, split_by_lepton_flavor=False, skip_signal_regions=False, skip_control_regions=False, muonSyst='nominal', dtype=np.float32, rebin=False, offZ_split=False, tau_h_analysis=False, fwd_analysis=False, useRun3MVA=True, tau_run_mode="standard"):
+    def __init__(self, samples, wc_names_lst=[], hist_lst=None, ecut_threshold=None, fill_sumw2_hist=True, do_systematics=False, split_by_lepton_flavor=False, skip_signal_regions=False, skip_control_regions=False, muonSyst='nominal', dtype=np.float32, rebin=False, offZ_split=False, tau_h_analysis=False, fwd_analysis=False, all_analysis=False, useRun3MVA=True, tau_run_mode="standard"):
 
         self._samples = samples
         self._wc_names_lst = wc_names_lst
@@ -105,6 +105,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         self.offZ_3l_split = offZ_split
         self.tau_h_analysis = tau_h_analysis
         self.fwd_analysis = fwd_analysis
+        self.all_analysis = all_analysis
         self.useRun3MVA = useRun3MVA #can be switched to False use the alternative cuts
         self.tau_run_mode = tau_run_mode
         # self._tau_wp_checked = False

--- a/analysis/topeft_run2/make_cr_and_sr_plots.py
+++ b/analysis/topeft_run2/make_cr_and_sr_plots.py
@@ -832,8 +832,17 @@ def _summarize_zero_yield_processes(
     *,
     region_name,
     preserve_njets_bins=False,
+    region_ctx=None,
+    variables=None,
 ):
     """Return a structured summary of zero-yield processes per channel."""
+
+    if region_ctx is not None and region_name.upper() != "CR":
+        return _summarize_zero_yield_processes_by_variable(
+            dict_of_hists,
+            region_ctx=region_ctx,
+            variables=variables,
+        )
 
     summary = {
         "region": region_name,
@@ -927,6 +936,146 @@ def _summarize_zero_yield_processes(
     return summary
 
 
+def _summarize_zero_yield_processes_by_variable(
+    dict_of_hists,
+    *,
+    region_ctx,
+    variables=None,
+):
+    """Return a structured summary of zero-yield processes per channel and variable."""
+
+    summary = {
+        "region": region_ctx.name,
+        "channels_scanned": 0,
+        "channel_entries": [],
+        "zero_process_total": 0,
+        "data_driven_zero_total": 0,
+        "missing_data_driven_prefixes": set(),
+        "errors": [],
+    }
+
+    variables_to_scan = _resolve_requested_variables(
+        dict_of_hists, variables, context="zero-yield scan"
+    )
+
+    prepared_cache = {}
+    missing_data_driven = {}
+    for matcher in DATA_DRIVEN_MATCHERS:
+        missing_data_driven[_describe_data_driven_matcher(matcher)] = False
+
+    for var_name in variables_to_scan:
+        if "sumw2" in var_name:
+            continue
+        if region_ctx.apply_category_skips and var_name in region_ctx.skip_variables:
+            continue
+
+        variable_metadata = _prepare_variable_payload(
+            var_name,
+            region_ctx,
+            metadata_only=True,
+            prepared_cache=prepared_cache,
+        )
+        if not variable_metadata:
+            prepared_cache.setdefault(var_name, None)
+            continue
+
+        histo = dict_of_hists.get(var_name)
+        if histo is None:
+            continue
+
+        channel_transformations = variable_metadata["channel_transformations"]
+        available_channels = set(variable_metadata.get("available_channels") or ())
+        available_processes = tuple(_resolve_process_axis_labels(histo))
+
+        if not _has_axis(histo, "process"):
+            summary["errors"].append(
+                f"No process axis available for zero-yield scan in variable '{var_name}'."
+            )
+            continue
+
+        if not available_channels:
+            summary["errors"].append(
+                f"No channel axis labels available for zero-yield scan in variable '{var_name}'."
+            )
+            continue
+
+        if not available_processes:
+            summary["errors"].append(
+                f"No process labels available for zero-yield scan in variable '{var_name}'."
+            )
+            continue
+
+        for matcher in DATA_DRIVEN_MATCHERS:
+            label = _describe_data_driven_matcher(matcher)
+            if not missing_data_driven.get(label):
+                missing_data_driven[label] = any(
+                    matcher.search(proc) for proc in available_processes
+                )
+
+        for chan_label, chan_bins in region_ctx.channel_map.items():
+            summary["channels_scanned"] += 1
+            unique_bins = tuple(dict.fromkeys(chan_bins))
+            selected_bins = []
+            missing_bins = []
+            for bin_name in unique_bins:
+                transformed = _apply_channel_transforms(
+                    bin_name, channel_transformations
+                )
+                if transformed in available_channels:
+                    selected_bins.append(transformed)
+                else:
+                    missing_bins.append(bin_name)
+
+            if not selected_bins:
+                summary["channel_entries"].append(
+                    {
+                        "label": chan_label,
+                        "variable": var_name,
+                        "missing_bins": tuple(missing_bins),
+                        "zero_processes": [],
+                    }
+                )
+                continue
+
+            selected_bins = list(dict.fromkeys(selected_bins))
+
+            zero_processes = []
+            for proc in available_processes:
+                try:
+                    proc_hist = histo.integrate("process", [proc])
+                    proc_hist = proc_hist.integrate("channel", selected_bins)
+                except Exception:
+                    continue
+
+                proc_hist = _integrate_nominal_axis(proc_hist)
+
+                if not _hist_has_content(proc_hist):
+                    is_data_driven = any(
+                        matcher.search(proc) for matcher in DATA_DRIVEN_MATCHERS
+                    )
+                    zero_processes.append((proc, is_data_driven))
+
+            if zero_processes or missing_bins:
+                summary["channel_entries"].append(
+                    {
+                        "label": chan_label,
+                        "variable": var_name,
+                        "missing_bins": tuple(missing_bins),
+                        "zero_processes": zero_processes,
+                    }
+                )
+                summary["zero_process_total"] += len(zero_processes)
+                summary["data_driven_zero_total"] += sum(
+                    1 for _, is_data_driven in zero_processes if is_data_driven
+                )
+
+    for pattern_label, seen in missing_data_driven.items():
+        if not seen:
+            summary["missing_data_driven_prefixes"].add(pattern_label)
+
+    return summary
+
+
 def _emit_zero_yield_summary(summary, *, detailed=False):
     """Print a short or detailed zero-yield report for the supplied *summary*."""
 
@@ -941,6 +1090,10 @@ def _emit_zero_yield_summary(summary, *, detailed=False):
     if detailed:
         print("\nZero-yield content summary:")
         for entry in flagged_channels:
+            entry_label = entry.get("label", "<unknown>")
+            variable = entry.get("variable")
+            if variable:
+                entry_label = f"{entry_label} [{variable}]"
             issues = []
             if entry.get("missing_bins"):
                 issues.append(
@@ -955,7 +1108,7 @@ def _emit_zero_yield_summary(summary, *, detailed=False):
                     zero_labels.append(label)
                 issues.append("zero-content processes: " + ", ".join(zero_labels))
             if issues:
-                print(f"  - {region_label}::{entry['label']}: " + "; ".join(issues))
+                print(f"  - {region_label}::{entry_label}: " + "; ".join(issues))
 
         if missing_data_driven:
             print(
@@ -6039,6 +6192,7 @@ def run_plots_for_region(
         dict_of_hists, reference_channel_map=CHANNEL_REFERENCE_MAP
     )
     restored_channel_labels = False
+    summary_region_ctx = None
 
     if not split_channels_available and "per-channel" in requested_channel_modes:
         restored_channel_labels = yt.restore_split_channel_labels(
@@ -6064,6 +6218,8 @@ def run_plots_for_region(
             preserve_njets_bins=preserve_njets_bins,
             enable_category_skips=enable_category_skips,
         )
+        if summary_region_ctx is None:
+            summary_region_ctx = region_ctx
 
         if region_ctx.channel_mode == "per-channel" and not split_channels_available:
             mode_label = CHANNEL_MODE_LABELS.get(channel_mode, channel_mode)
@@ -6096,6 +6252,8 @@ def run_plots_for_region(
         dict_of_hists,
         region_name=region_name,
         preserve_njets_bins=preserve_njets_bins,
+        region_ctx=summary_region_ctx,
+        variables=variables,
     )
     _emit_zero_yield_summary(
         zero_yield_summary,

--- a/analysis/topeft_run2/make_cr_and_sr_plots.py
+++ b/analysis/topeft_run2/make_cr_and_sr_plots.py
@@ -837,7 +837,7 @@ def _summarize_zero_yield_processes(
 ):
     """Return a structured summary of zero-yield processes per channel."""
 
-    if region_ctx is not None and region_name.upper() != "CR":
+    if region_ctx is not None:
         return _summarize_zero_yield_processes_by_variable(
             dict_of_hists,
             region_ctx=region_ctx,
@@ -966,7 +966,7 @@ def _summarize_zero_yield_processes_by_variable(
     for var_name in variables_to_scan:
         if "sumw2" in var_name:
             continue
-        if region_ctx.apply_category_skips and var_name in region_ctx.skip_variables:
+        if var_name in region_ctx.skip_variables:
             continue
 
         variable_metadata = _prepare_variable_payload(
@@ -4311,9 +4311,7 @@ def build_region_context(
         region_upper, region_plot_cfg.get("stacked_ratio_style")
     )
 
-    skip_variables = (
-        set(region_plot_cfg.get("skip_variables", [])) if enable_category_skips else set()
-    )
+    skip_variables = set(region_plot_cfg.get("skip_variables", []))
     analysis_bins = {}
     for var_name, spec in region_plot_cfg.get("analysis_bins", {}).items():
         if isinstance(spec, str):

--- a/analysis/topeft_run2/make_cr_and_sr_plots.py
+++ b/analysis/topeft_run2/make_cr_and_sr_plots.py
@@ -423,6 +423,45 @@ def _resolve_process_axis_labels(histogram):
         return tuple(axis)
 
 
+def _resolve_grouped_processes(group_map):
+    """Return the ordered tuple of process names covered by *group_map*."""
+
+    grouped = []
+    seen = set()
+    for members in (group_map or {}).values():
+        for name in members or ():
+            if name in seen:
+                continue
+            seen.add(name)
+            grouped.append(name)
+    return tuple(grouped)
+
+
+def _filter_process_axis(histogram, allowed_processes):
+    """Return *histogram* with any process not in *allowed_processes* removed."""
+
+    if histogram is None or not _has_axis(histogram, "process"):
+        return histogram
+
+    allowed_set = set(allowed_processes or ())
+    axis_labels = _resolve_process_axis_labels(histogram)
+    if not axis_labels:
+        return histogram
+
+    if allowed_set:
+        to_remove = [proc for proc in axis_labels if proc not in allowed_set]
+    else:
+        to_remove = list(axis_labels)
+
+    if not to_remove:
+        return histogram
+
+    try:
+        return histogram.remove("process", to_remove)
+    except Exception:
+        return histogram
+
+
 def _has_axis(histogram, axis_name):
     """Return ``True`` when *histogram* exposes *axis_name* as an axis."""
 
@@ -993,6 +1032,14 @@ def _summarize_zero_yield_processes_by_variable(
             )
             continue
 
+        allowed_processes = _resolve_grouped_processes(region_ctx.group_map)
+        if allowed_processes:
+            available_processes = tuple(
+                proc for proc in available_processes if proc in allowed_processes
+            )
+        else:
+            available_processes = ()
+
         if not available_channels:
             summary["errors"].append(
                 f"No channel axis labels available for zero-yield scan in variable '{var_name}'."
@@ -1001,7 +1048,7 @@ def _summarize_zero_yield_processes_by_variable(
 
         if not available_processes:
             summary["errors"].append(
-                f"No process labels available for zero-yield scan in variable '{var_name}'."
+                f"No grouped process labels available for zero-yield scan in variable '{var_name}'."
             )
             continue
 
@@ -1899,6 +1946,14 @@ def _prepare_variable_payload(
                 "process", region_ctx.signal_samples
             )
 
+    allowed_processes = _resolve_grouped_processes(region_ctx.group_map)
+    hist_mc = _filter_process_axis(hist_mc, allowed_processes)
+    hist_data = _filter_process_axis(hist_data, allowed_processes)
+    if hist_mc_sumw2_orig is not None:
+        hist_mc_sumw2_orig = _filter_process_axis(
+            hist_mc_sumw2_orig, allowed_processes
+        )
+
     if region_ctx.debug_channel_lists and verbose:
         try:
             channels_lst = yt.get_cat_lables(histo, "channel")
@@ -2514,7 +2569,7 @@ def validate_channel_group(histos, expected_labels, transformations, region, sub
 
 def populate_group_map(samples, pattern_map):
     out = OrderedDict((k, []) for k in pattern_map)
-    fallback_groups = OrderedDict()
+    unmatched = []
 
     for proc_name in samples:
         canonical_name = tc_utils.canonicalize_process_name(proc_name)
@@ -2528,17 +2583,14 @@ def populate_group_map(samples, pattern_map):
             if matched:
                 break
         if not matched:
-            if proc_name not in fallback_groups:
-                logger.warning(
-                    "Process name '%s' does not match any configured group pattern; "
-                    "assigning it to fallback group '%s'.",
-                    proc_name,
-                    proc_name,
-                )
-                fallback_groups[proc_name] = []
-            fallback_groups[proc_name].append(proc_name)
+            unmatched.append(proc_name)
 
-    out.update(fallback_groups)
+    if unmatched:
+        logger.warning(
+            "Process names did not match any configured group pattern; skipping: %s",
+            ", ".join(sorted(unmatched)),
+        )
+
     return out
 
 

--- a/analysis/topeft_run2/make_cr_and_sr_plots.py
+++ b/analysis/topeft_run2/make_cr_and_sr_plots.py
@@ -2009,23 +2009,23 @@ def _render_variable_category(
             hist_data_nominal = hist_data_integrated[{"process": sum}].integrate(
                 "systematic", "nominal"
             )
-            if not _hist_has_content(hist_mc_nominal):
+            hist_data_like = (
+                hist_data_nominal
+                if (unblind_flag or not region_ctx.use_mc_as_data_when_blinded)
+                else hist_mc_nominal
+            )
+            has_mc = _hist_has_content(hist_mc_nominal)
+            has_data_like = _hist_has_content(hist_data_like)
+            if not has_mc and not has_data_like:
                 logger.warning(
-                    "Empty histogram for hist_cat=%s var_name=%s, skipping 2D plot.",
-                    hist_cat,
-                    var_name,
-                )
-                return 0, 0, html_dirs
-            if not _hist_has_content(hist_data_nominal):
-                logger.warning(
-                    "Empty data histogram for hist_cat=%s var_name=%s, skipping 2D plot.",
+                    "Empty data-like and MC histogram for hist_cat=%s var_name=%s, skipping 2D plot.",
                     hist_cat,
                     var_name,
                 )
                 return 0, 0, html_dirs
             fig = make_sparse2d_fig(
                 hist_mc_nominal,
-                hist_data_nominal,
+                hist_data_like,
                 var_name,
                 channel_name=hist_cat,
                 lumitag=region_ctx.lumi_pair[0],
@@ -2043,16 +2043,16 @@ def _render_variable_category(
             hist_data_integrated = hist_data_integrated.integrate(
                 "systematic", "nominal"
             )
-            if not _hist_has_content(hist_mc_integrated):
+            hist_data_like = (
+                hist_data_integrated
+                if (unblind_flag or not region_ctx.use_mc_as_data_when_blinded)
+                else hist_mc_integrated
+            )
+            has_mc = _hist_has_content(hist_mc_integrated)
+            has_data_like = _hist_has_content(hist_data_like)
+            if not has_mc and not has_data_like:
                 logger.warning(
-                    "Empty histogram for hist_cat=%s var_name=%s, skipping plot.",
-                    hist_cat,
-                    var_name,
-                )
-                return 0, 0, html_dirs
-            if not _hist_has_content(hist_data_integrated):
-                logger.warning(
-                    "Empty data histogram for hist_cat=%s var_name=%s, skipping plot.",
+                    "Empty data-like and MC histogram for hist_cat=%s var_name=%s, skipping plot.",
                     hist_cat,
                     var_name,
                 )
@@ -2076,7 +2076,7 @@ def _render_variable_category(
                 stacked_kwargs["bins"] = bins_override
             fig = make_region_stacked_ratio_fig(
                 hist_mc_integrated,
-                hist_data_integrated,
+                hist_data_like,
                 unit_norm_bool,
                 var=var_name,
                 group=group,

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -884,7 +884,7 @@ if __name__ == "__main__":
             # use mid-range compression for chunks results.
             # Valid values are 0 (minimum compression, less memory
             # usage) to 16 (maximum compression, more memory usage).
-            "compression": 8,
+            "compression": 9,
             # automatically find an adequate resource allocation for tasks.
             # tasks are first tried using the maximum resources seen of previously ran
             # tasks. on resource exhaustion, they are retried with the maximum resource
@@ -910,7 +910,9 @@ if __name__ == "__main__":
             # 'disk': 8000,   #MB
             # 'memory': 10000, #MB
             # control the size of accumulation tasks.
-            "treereduction": 10,
+            # "treereduction": 10,
+            'chunks_per_accum': 25,
+            'chunks_accum_in_mem': 2,
             # terminate workers on which tasks have been running longer than average.
             # This is useful for temporary conditions on worker nodes where a task will
             # be finish faster is ran in another worker.

--- a/input_samples/cfgs/NDSkim_2022EE_signal_samples.cfg
+++ b/input_samples/cfgs/NDSkim_2022EE_signal_samples.cfg
@@ -1,10 +1,16 @@
 root://skynet013.crc.nd.edu/
 #file:///cms/cephfs/data
-../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_ttHnobb-1Jets_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_ttHnobb_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_TTLL_MLL-4to50_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_TTLL_MLL-50_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_TTTT_NDSkim.json
-#../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_TZQB-4FS_OnshellZ_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_TZQB-Zto2L-4FS_MLL-30_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_TTLNu_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_ttHnobb-1Jets_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_ttHnobb_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_TTLL_MLL-4to50_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_TTLL_MLL-50_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_TTTT_NDSkim.json
+# #../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_TZQB-4FS_OnshellZ_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_TZQB-Zto2L-4FS_MLL-30_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/2022EE_TTLNu_NDSkim.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2022EE/2022EE_tHq.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2022EE/2022EE_tllq.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2022EE/2022EE_ttH.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2022EE/2022EE_ttll.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2022EE/2022EE_ttlnu.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2022EE/2022EE_tttt.json

--- a/input_samples/cfgs/NDSkim_2022_signal_samples.cfg
+++ b/input_samples/cfgs/NDSkim_2022_signal_samples.cfg
@@ -1,11 +1,17 @@
 # Central 2022 background samples
 root://skynet013.crc.nd.edu/
 #file:///cms/cephfs/data/
-../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_ttHnobb-1Jets_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_ttHnobb_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_TTLL_MLL-4to50_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_TTLL_MLL-50_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_TTLNu_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_TTTT_NDSkim.json
-#../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_TZQB-4FS_OnshellZ_NDSkim.json #not recommended by MC contacts
-../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_TZQB-Zto2L-4FS_MLL-30_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_ttHnobb-1Jets_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_ttHnobb_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_TTLL_MLL-4to50_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_TTLL_MLL-50_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_TTLNu_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_TTTT_NDSkim.json
+# #../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_TZQB-4FS_OnshellZ_NDSkim.json #not recommended by MC contacts
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022/2022_TZQB-Zto2L-4FS_MLL-30_NDSkim.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2022/2022_tHq.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2022/2022_tllq.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2022/2022_ttH.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2022/2022_ttll.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2022/2022_ttlnu.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2022/2022_tttt.json

--- a/input_samples/cfgs/NDSkim_2023BPix_signal_samples.cfg
+++ b/input_samples/cfgs/NDSkim_2023BPix_signal_samples.cfg
@@ -1,9 +1,15 @@
 root://skynet013.crc.nd.edu/
 #file:///cms/cephfs/data/
-#../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/2023BPix_ttHnobb-1Jets_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/2023BPix_ttHnobb_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/2023BPix_TTLL_MLL-4to50_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/2023BPix_TTLL_MLL-50_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/2023BPix_TTLNu_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/2023BPix_TTTT_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/2023BPix_TZQB-Zto2L-4FS_MLL-30_NDSkim.json
+# #../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/2023BPix_ttHnobb-1Jets_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/2023BPix_ttHnobb_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/2023BPix_TTLL_MLL-4to50_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/2023BPix_TTLL_MLL-50_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/2023BPix_TTLNu_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/2023BPix_TTTT_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/2023BPix_TZQB-Zto2L-4FS_MLL-30_NDSkim.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2023BPix/2023BPix_tHq.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2023BPix/2023BPix_tllq.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2023BPix/2023BPix_ttH.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2023BPix/2023BPix_ttll.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2023BPix/2023BPix_ttlnu.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2023BPix/2023BPix_tttt.json

--- a/input_samples/cfgs/NDSkim_2023_signal_samples.cfg
+++ b/input_samples/cfgs/NDSkim_2023_signal_samples.cfg
@@ -1,9 +1,15 @@
 root://skynet013.crc.nd.edu/
 #file:///cms/cephfs/data/
-#../../input_samples/sample_jsons/signal_samples/ND_skim2023/2023_ttHnobb-1Jets_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023/2023_ttHnobb_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023/2023_TTLL_MLL-4to50_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023/2023_TTLL_MLL-50_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023/2023_TTLNu_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023/2023_TTTT_NDSkim.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023/2023_TZQB-Zto2L-4FS_MLL-30_NDSkim.json
+# #../../input_samples/sample_jsons/signal_samples/ND_skim2023/2023_ttHnobb-1Jets_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023/2023_ttHnobb_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023/2023_TTLL_MLL-4to50_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023/2023_TTLL_MLL-50_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023/2023_TTLNu_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023/2023_TTTT_NDSkim.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023/2023_TZQB-Zto2L-4FS_MLL-30_NDSkim.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2023/2023_tHq.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2023/2023_tllq.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2023/2023_ttH.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2023/2023_ttll.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2023/2023_ttlnu.json
+../../input_samples/samples_jsons/signal_samples/ND_skim2023/2023_tttt.json

--- a/tests/test_make_cr_and_sr_plots.py
+++ b/tests/test_make_cr_and_sr_plots.py
@@ -250,7 +250,7 @@ def test_sr_njets_channel_transform_matches_cr_behavior():
     )
 
 
-def test_sr_zero_yield_summary_respects_njets_aggregation():
+def test_sr_zero_yield_summary_respects_njets_aggregation(monkeypatch):
     process_axis = hist.axis.StrCategory(
         ["ttH_central2022", "data2022"], name="process"
     )
@@ -288,16 +288,23 @@ def test_sr_zero_yield_summary_respects_njets_aggregation():
         )
 
     hist_inputs = {"njets": hist_obj}
-    region_ctx = make_cr_and_sr_plots.build_region_context(
-        "SR", hist_inputs, years=["2022"], unblind=True
-    )
 
-    summary = make_cr_and_sr_plots._summarize_zero_yield_processes(
-        hist_inputs,
-        region_name="SR",
-        region_ctx=region_ctx,
-        variables=["njets"],
+    patched_cfg = copy.deepcopy(
+        make_cr_and_sr_plots.REGION_PLOTTING.get("SR", {})
     )
+    patched_cfg.update({"skip_variables": ["ptz"]})
+
+    with monkeypatch.context() as m:
+        m.setitem(make_cr_and_sr_plots.REGION_PLOTTING, "SR", patched_cfg)
+        region_ctx = make_cr_and_sr_plots.build_region_context(
+            "SR", hist_inputs, years=["2022"], unblind=True
+        )
+        summary = make_cr_and_sr_plots._summarize_zero_yield_processes(
+            hist_inputs,
+            region_name="SR",
+            region_ctx=region_ctx,
+            variables=["njets"],
+        )
 
     entry = _find_zero_yield_entry(summary, label="2lss_SR", variable="njets")
     assert entry is not None
@@ -356,6 +363,129 @@ def test_sr_zero_yield_summary_flags_missing_channels_for_lj0pt():
     assert entry is not None
     assert "2lss_4t_m_6j" in entry["missing_bins"]
     assert "2lss_4t_m_5j" not in entry["missing_bins"]
+
+    zero_processes = {proc for proc, _ in entry["zero_processes"]}
+    assert "data2022" in zero_processes
+
+
+def test_sr_zero_yield_summary_respects_skip_variables():
+    process_axis = hist.axis.StrCategory(["ttH_central2022"], name="process")
+    channel_axis = hist.axis.StrCategory(["3l_onZ_1b_2j"], name="channel")
+    syst_axis = hist.axis.StrCategory(["nominal"], name="systematic")
+    ptz_axis = hist.axis.Regular(1, 0.0, 1.0, name="ptz")
+
+    hist_obj = make_cr_and_sr_plots.tc_sparseHist.SparseHist(
+        process_axis, channel_axis, syst_axis, ptz_axis
+    )
+
+    hist_obj.fill(
+        process="ttH_central2022",
+        channel="3l_onZ_1b_2j",
+        systematic="nominal",
+        ptz=0.5,
+        weight=1.0,
+    )
+
+    hist_inputs = {"ptz": hist_obj}
+    region_ctx = make_cr_and_sr_plots.build_region_context(
+        "SR", hist_inputs, years=["2022"], unblind=True
+    )
+
+    summary = make_cr_and_sr_plots._summarize_zero_yield_processes(
+        hist_inputs,
+        region_name="SR",
+        region_ctx=region_ctx,
+        variables=["ptz"],
+    )
+
+    assert not summary["channel_entries"]
+
+
+def test_cr_zero_yield_summary_respects_skip_variables(monkeypatch):
+    process_axis = hist.axis.StrCategory(["ttH_central2022"], name="process")
+    channel_axis = hist.axis.StrCategory(["2lss_ee_CR_1j"], name="channel")
+    syst_axis = hist.axis.StrCategory(["nominal"], name="systematic")
+    ptz_axis = hist.axis.Regular(1, 0.0, 1.0, name="ptz")
+
+    hist_obj = make_cr_and_sr_plots.tc_sparseHist.SparseHist(
+        process_axis, channel_axis, syst_axis, ptz_axis
+    )
+
+    hist_obj.fill(
+        process="ttH_central2022",
+        channel="2lss_ee_CR_1j",
+        systematic="nominal",
+        ptz=0.5,
+        weight=1.0,
+    )
+
+    hist_inputs = {"ptz": hist_obj}
+
+    patched_cfg = copy.deepcopy(
+        make_cr_and_sr_plots.REGION_PLOTTING.get("CR", {})
+    )
+    patched_cfg.update({"skip_variables": ["ptz"]})
+
+    with monkeypatch.context() as m:
+        m.setitem(make_cr_and_sr_plots.REGION_PLOTTING, "CR", patched_cfg)
+        region_ctx = make_cr_and_sr_plots.build_region_context(
+            "CR", hist_inputs, years=["2022"], unblind=True
+        )
+        summary = make_cr_and_sr_plots._summarize_zero_yield_processes(
+            hist_inputs,
+            region_name="CR",
+            region_ctx=region_ctx,
+            variables=["ptz"],
+        )
+
+    assert not summary["channel_entries"]
+
+
+def test_cr_zero_yield_summary_reports_variable_and_missing_bins():
+    process_axis = hist.axis.StrCategory(
+        ["ttH_central2022", "data2022"], name="process"
+    )
+    channel_axis = hist.axis.StrCategory(
+        ["2lss_ee_CR_1j", "2lss_mm_CR_1j"], name="channel"
+    )
+    syst_axis = hist.axis.StrCategory(["nominal"], name="systematic")
+    met_axis = hist.axis.Regular(1, 0.0, 1.0, name="met")
+
+    hist_obj = make_cr_and_sr_plots.tc_sparseHist.SparseHist(
+        process_axis, channel_axis, syst_axis, met_axis
+    )
+
+    for channel in ("2lss_ee_CR_1j", "2lss_mm_CR_1j"):
+        hist_obj.fill(
+            process="ttH_central2022",
+            channel=channel,
+            systematic="nominal",
+            met=0.5,
+            weight=1.0,
+        )
+        hist_obj.fill(
+            process="data2022",
+            channel=channel,
+            systematic="nominal",
+            met=0.5,
+            weight=0.0,
+        )
+
+    hist_inputs = {"met": hist_obj}
+    region_ctx = make_cr_and_sr_plots.build_region_context(
+        "CR", hist_inputs, years=["2022"], unblind=True
+    )
+
+    summary = make_cr_and_sr_plots._summarize_zero_yield_processes(
+        hist_inputs,
+        region_name="CR",
+        region_ctx=region_ctx,
+        variables=["met"],
+    )
+
+    entry = _find_zero_yield_entry(summary, label="cr_2lss", variable="met")
+    assert entry is not None
+    assert "2lss_mm_CR_2j" in entry["missing_bins"]
 
     zero_processes = {proc for proc, _ in entry["zero_processes"]}
     assert "data2022" in zero_processes

--- a/tests/test_make_cr_and_sr_plots.py
+++ b/tests/test_make_cr_and_sr_plots.py
@@ -200,6 +200,49 @@ def test_both_njets_preserves_variables_for_merged_output(tmp_path):
     }.issubset(set(plot_names)), plot_names
 
 
+def test_sr_njets_channel_transform_matches_cr_behavior():
+    process_axis = hist.axis.StrCategory([], name="process", growth=True)
+    channel_axis = hist.axis.StrCategory([], name="channel", growth=True)
+    syst_axis = hist.axis.StrCategory([], name="systematic", growth=True)
+    njets_axis = hist.axis.Regular(1, 0.0, 1.0, name="njets")
+
+    hist_obj = make_cr_and_sr_plots.tc_sparseHist.SparseHist(
+        process_axis, channel_axis, syst_axis, njets_axis
+    )
+
+    for channel in ("3l_m_offZ_1b", "3l_p_offZ_2b"):
+        hist_obj.fill(
+            process="ttH_central2022",
+            channel=channel,
+            systematic="nominal",
+            njets=0.5,
+            weight=1.0,
+        )
+
+    hist_inputs = {"njets": hist_obj}
+
+    region_ctx = make_cr_and_sr_plots.build_region_context(
+        "SR", hist_inputs, years=["2022"], unblind=True
+    )
+    payload = make_cr_and_sr_plots._prepare_variable_payload(
+        "njets", region_ctx, metadata_only=True
+    )
+
+    assert "njets" in payload["channel_transformations"]
+
+    channel_bins = payload["channel_dict"].get("3l_offZ_SR")
+    assert channel_bins, "Expected SR channel bins for 3l_offZ_SR"
+
+    make_cr_and_sr_plots.validate_channel_group(
+        [hist_obj],
+        channel_bins,
+        payload["channel_transformations"],
+        region=region_ctx.name,
+        subgroup="3l_offZ_SR",
+        variable="njets",
+    )
+
+
 def test_data_driven_samples_preserved_for_1tau_cr():
     process_axis = hist.axis.StrCategory([], name="process", growth=True)
     channel_axis = hist.axis.StrCategory([], name="channel", growth=True)

--- a/tests/test_make_cr_and_sr_plots.py
+++ b/tests/test_make_cr_and_sr_plots.py
@@ -63,7 +63,7 @@ def test_unit_normalization_skips_empty_histograms(monkeypatch):
     assert any("Skipping data unit normalization" in msg for msg in logged_messages)
 
 
-def test_unmatched_sample_gets_fallback_group(monkeypatch):
+def test_unmatched_sample_is_skipped_from_group_map(monkeypatch):
     process_axis = hist.axis.StrCategory([], name="process", growth=True)
     value_axis = hist.axis.Regular(2, 0.0, 2.0, name="lj0pt")
     h_mc = hist.Hist(process_axis, value_axis, storage=hist.storage.Double())
@@ -97,9 +97,10 @@ def test_unmatched_sample_gets_fallback_group(monkeypatch):
         group_map = make_cr_and_sr_plots.populate_group_map(samples, pattern_map)
 
     assert "Top" in group_map
-    assert "mysteryProcess" in group_map
-    assert group_map["mysteryProcess"] == ["mysteryProcess"]
-    assert any("mysteryProcess" in msg for msg in captured)
+    assert "mysteryProcess" not in group_map
+    assert any(
+        "mysteryProcess" in msg and "skipping" in msg.lower() for msg in captured
+    )
 
     plotted_calls = []
 
@@ -129,7 +130,9 @@ def test_unmatched_sample_gets_fallback_group(monkeypatch):
         mc_call = plotted_calls[0]
         mc_stack_inputs = mc_call["args"][0]
         stacked_total = np.sum(np.stack(mc_stack_inputs), axis=0)
-        mc_totals = h_mc[{"process": sum}].as_hist({}).values(flow=True)[1:]
+        mc_totals = (
+            h_mc[{"process": "ttbarSL"}].as_hist({}).values(flow=True)[1:]
+        )
         np.testing.assert_allclose(stacked_total, mc_totals)
 
         colors = mc_call["kwargs"].get("color", [])
@@ -489,6 +492,120 @@ def test_cr_zero_yield_summary_reports_variable_and_missing_bins():
 
     zero_processes = {proc for proc, _ in entry["zero_processes"]}
     assert "data2022" in zero_processes
+
+
+def test_sr_zero_yield_skips_unmatched_processes(monkeypatch):
+    process_axis = hist.axis.StrCategory(
+        ["ttH_central2022", "ZG_MLL-50_PTG-600_central2022"], name="process"
+    )
+    channel_axis = hist.axis.StrCategory(["2lss_4t_m_4j"], name="channel")
+    syst_axis = hist.axis.StrCategory(["nominal"], name="systematic")
+    lj0pt_axis = hist.axis.Regular(1, 0.0, 1.0, name="lj0pt")
+
+    hist_obj = make_cr_and_sr_plots.tc_sparseHist.SparseHist(
+        process_axis, channel_axis, syst_axis, lj0pt_axis
+    )
+
+    hist_obj.fill(
+        process="ttH_central2022",
+        channel="2lss_4t_m_4j",
+        systematic="nominal",
+        lj0pt=0.5,
+        weight=1.0,
+    )
+    hist_obj.fill(
+        process="ZG_MLL-50_PTG-600_central2022",
+        channel="2lss_4t_m_4j",
+        systematic="nominal",
+        lj0pt=0.5,
+        weight=1.0,
+    )
+
+    hist_inputs = {"lj0pt": hist_obj}
+
+    with monkeypatch.context() as m:
+        warnings = []
+
+        def _capture_warning(msg, *args, **kwargs):
+            if args:
+                msg = msg % args
+            warnings.append(msg)
+
+        m.setattr(make_cr_and_sr_plots.logger, "warning", _capture_warning)
+        region_ctx = make_cr_and_sr_plots.build_region_context(
+            "SR", hist_inputs, years=["2022"], unblind=True
+        )
+        summary = make_cr_and_sr_plots._summarize_zero_yield_processes(
+            hist_inputs,
+            region_name="SR",
+            region_ctx=region_ctx,
+            variables=["lj0pt"],
+        )
+
+    assert any("ZG_MLL-50_PTG-600_central2022" in msg for msg in warnings)
+    unmatched_present = any(
+        proc == "ZG_MLL-50_PTG-600_central2022"
+        for entry in summary["channel_entries"]
+        for proc, _ in entry["zero_processes"]
+    )
+    assert not unmatched_present
+
+
+def test_cr_zero_yield_skips_unmatched_processes(monkeypatch):
+    process_axis = hist.axis.StrCategory(
+        ["TTTo2L2Nu_central2022", "mysteryProc2022"], name="process"
+    )
+    channel_axis = hist.axis.StrCategory(["2lss_ee_CR_1j"], name="channel")
+    syst_axis = hist.axis.StrCategory(["nominal"], name="systematic")
+    met_axis = hist.axis.Regular(1, 0.0, 1.0, name="met")
+
+    hist_obj = make_cr_and_sr_plots.tc_sparseHist.SparseHist(
+        process_axis, channel_axis, syst_axis, met_axis
+    )
+
+    hist_obj.fill(
+        process="TTTo2L2Nu_central2022",
+        channel="2lss_ee_CR_1j",
+        systematic="nominal",
+        met=0.5,
+        weight=1.0,
+    )
+    hist_obj.fill(
+        process="mysteryProc2022",
+        channel="2lss_ee_CR_1j",
+        systematic="nominal",
+        met=0.5,
+        weight=1.0,
+    )
+
+    hist_inputs = {"met": hist_obj}
+
+    with monkeypatch.context() as m:
+        warnings = []
+
+        def _capture_warning(msg, *args, **kwargs):
+            if args:
+                msg = msg % args
+            warnings.append(msg)
+
+        m.setattr(make_cr_and_sr_plots.logger, "warning", _capture_warning)
+        region_ctx = make_cr_and_sr_plots.build_region_context(
+            "CR", hist_inputs, years=["2022"], unblind=True
+        )
+        summary = make_cr_and_sr_plots._summarize_zero_yield_processes(
+            hist_inputs,
+            region_name="CR",
+            region_ctx=region_ctx,
+            variables=["met"],
+        )
+
+    assert any("mysteryProc2022" in msg for msg in warnings)
+    unmatched_present = any(
+        proc == "mysteryProc2022"
+        for entry in summary["channel_entries"]
+        for proc, _ in entry["zero_processes"]
+    )
+    assert not unmatched_present
 
 
 def test_sr_aggregate_blinded_uses_mc_when_data_empty(tmp_path):

--- a/tests/test_make_cr_and_sr_plots.py
+++ b/tests/test_make_cr_and_sr_plots.py
@@ -243,6 +243,49 @@ def test_sr_njets_channel_transform_matches_cr_behavior():
     )
 
 
+def test_sr_aggregate_blinded_uses_mc_when_data_empty(tmp_path):
+    process_axis = hist.axis.StrCategory([], name="process", growth=True)
+    channel_axis = hist.axis.StrCategory([], name="channel", growth=True)
+    syst_axis = hist.axis.StrCategory([], name="systematic", growth=True)
+    njets_axis = hist.axis.Regular(1, 0.0, 1.0, name="njets")
+
+    hist_obj = make_cr_and_sr_plots.tc_sparseHist.SparseHist(
+        process_axis, channel_axis, syst_axis, njets_axis
+    )
+
+    hist_obj.fill(
+        process="ttH_central2022",
+        channel="2lss_p",
+        systematic="nominal",
+        njets=0.5,
+        weight=5.0,
+    )
+    hist_obj.fill(
+        process="data2022",
+        channel="2lss_p",
+        systematic="nominal",
+        njets=0.5,
+        weight=0.0,
+    )
+
+    make_cr_and_sr_plots.run_plots_for_region(
+        "SR",
+        {"njets": hist_obj},
+        years=["2022"],
+        save_dir_path=str(tmp_path),
+        channel_output="merged",
+        skip_syst_errs=True,
+        workers=1,
+        verbose=False,
+        unblind=False,
+    )
+
+    plot_dir = tmp_path / "2lss_SR"
+    assert plot_dir.exists()
+    plot_paths = list(plot_dir.glob("*_njets.png"))
+    assert plot_paths, "Expected SR aggregate plot when MC is non-zero and data is empty"
+
+
 def test_data_driven_samples_preserved_for_1tau_cr():
     process_axis = hist.axis.StrCategory([], name="process", growth=True)
     channel_axis = hist.axis.StrCategory([], name="channel", growth=True)

--- a/tests/test_make_cr_and_sr_plots.py
+++ b/tests/test_make_cr_and_sr_plots.py
@@ -21,6 +21,13 @@ class _DummyHist:
         self.scale_factors.append(factor)
 
 
+def _find_zero_yield_entry(summary, *, label, variable):
+    for entry in summary.get("channel_entries", []):
+        if entry.get("label") == label and entry.get("variable") == variable:
+            return entry
+    return None
+
+
 def test_unit_normalization_skips_empty_histograms(monkeypatch):
     dummy_mc = _DummyHist()
     dummy_data = _DummyHist()
@@ -241,6 +248,117 @@ def test_sr_njets_channel_transform_matches_cr_behavior():
         subgroup="3l_offZ_SR",
         variable="njets",
     )
+
+
+def test_sr_zero_yield_summary_respects_njets_aggregation():
+    process_axis = hist.axis.StrCategory(
+        ["ttH_central2022", "data2022"], name="process"
+    )
+    channel_axis = hist.axis.StrCategory(
+        ["2lss_4t_m", "2lss_4t_p", "2lss_m", "2lss_p"], name="channel"
+    )
+    syst_axis = hist.axis.StrCategory(["nominal"], name="systematic")
+    njets_axis = hist.axis.Regular(1, 0.0, 1.0, name="njets")
+
+    hist_obj = make_cr_and_sr_plots.tc_sparseHist.SparseHist(
+        process_axis, channel_axis, syst_axis, njets_axis
+    )
+
+    hist_obj.fill(
+        process="ttH_central2022",
+        channel="2lss_4t_m",
+        systematic="nominal",
+        njets=0.5,
+        weight=1.0,
+    )
+    hist_obj.fill(
+        process="data2022",
+        channel="2lss_4t_m",
+        systematic="nominal",
+        njets=0.5,
+        weight=0.0,
+    )
+    for channel in ("2lss_4t_p", "2lss_m", "2lss_p"):
+        hist_obj.fill(
+            process="data2022",
+            channel=channel,
+            systematic="nominal",
+            njets=0.5,
+            weight=0.0,
+        )
+
+    hist_inputs = {"njets": hist_obj}
+    region_ctx = make_cr_and_sr_plots.build_region_context(
+        "SR", hist_inputs, years=["2022"], unblind=True
+    )
+
+    summary = make_cr_and_sr_plots._summarize_zero_yield_processes(
+        hist_inputs,
+        region_name="SR",
+        region_ctx=region_ctx,
+        variables=["njets"],
+    )
+
+    entry = _find_zero_yield_entry(summary, label="2lss_SR", variable="njets")
+    assert entry is not None
+    assert not entry["missing_bins"]
+
+
+def test_sr_zero_yield_summary_flags_missing_channels_for_lj0pt():
+    process_axis = hist.axis.StrCategory(
+        ["ttH_central2022", "data2022"], name="process"
+    )
+    channel_axis = hist.axis.StrCategory(
+        ["2lss_4t_m_4j", "2lss_4t_m_5j"], name="channel"
+    )
+    syst_axis = hist.axis.StrCategory(["nominal"], name="systematic")
+    lj0pt_axis = hist.axis.Regular(1, 0.0, 1.0, name="lj0pt")
+
+    hist_obj = make_cr_and_sr_plots.tc_sparseHist.SparseHist(
+        process_axis, channel_axis, syst_axis, lj0pt_axis
+    )
+
+    hist_obj.fill(
+        process="ttH_central2022",
+        channel="2lss_4t_m_4j",
+        systematic="nominal",
+        lj0pt=0.5,
+        weight=1.0,
+    )
+    hist_obj.fill(
+        process="data2022",
+        channel="2lss_4t_m_4j",
+        systematic="nominal",
+        lj0pt=0.5,
+        weight=0.0,
+    )
+    hist_obj.fill(
+        process="data2022",
+        channel="2lss_4t_m_5j",
+        systematic="nominal",
+        lj0pt=0.5,
+        weight=0.0,
+    )
+
+    hist_inputs = {"lj0pt": hist_obj}
+    region_ctx = make_cr_and_sr_plots.build_region_context(
+        "SR", hist_inputs, years=["2022"], unblind=True
+    )
+
+    summary = make_cr_and_sr_plots._summarize_zero_yield_processes(
+        hist_inputs,
+        region_name="SR",
+        region_ctx=region_ctx,
+        variables=["lj0pt"],
+    )
+
+    entry = _find_zero_yield_entry(summary, label="2lss_SR", variable="lj0pt")
+    assert entry is not None
+    assert "2lss_4t_m_6j" in entry["missing_bins"]
+    assert "2lss_4t_m_5j" not in entry["missing_bins"]
+
+    zero_processes = {proc for proc, _ in entry["zero_processes"]}
+    assert "data2022" in zero_processes
 
 
 def test_sr_aggregate_blinded_uses_mc_when_data_empty(tmp_path):

--- a/tools/audit_cr_channels_from_processor.py
+++ b/tools/audit_cr_channels_from_processor.py
@@ -15,17 +15,20 @@ REGION_SPECS = {
     "CR": {
         "ch_lst_keys": ("CH_LST_CR", "TAU_CH_LST_CR"),
         "yaml_key": "CR_CHAN_DICT",
+        # For CRs we assume the processor was run with --split-lep-flavor
+        "split_lep_flavor": True,
     },
     "SR": {
         "ch_lst_keys": (),
         "ch_lst_match": "CH_LST_SR",
         "yaml_key": "SR_CHAN_DICT",
+        # For SRs we assume the processor was run without --split-lep-flavor
+        "split_lep_flavor": False,
     },
 }
 
-# Semantic SR groups derived from fully flavour-split channels.
-# 1b/2b categorization has been removed: we now group all 3l+1tau
-# channels together regardless of b-tag multiplicity.
+# Semantic SR groups derived from channels.
+# No 1b/2b categorization at group level: 3l_1tau collects all 3l+1tau channels.
 SR_TAG_GROUP_RULES = {
     "2lss_SR": {
         "base": "2lss",
@@ -62,7 +65,7 @@ SR_TAG_GROUP_RULES = {
         "require": ["offZ"],
         "forbid": ["1tau", "fwd"],
     },
-    # New combined group replacing separate 3l_1tau_1b / 3l_1tau_2b:
+    # Combined 3l+1tau group (no 1b/2b split at group level)
     "3l_1tau": {
         "base": "3l",
         "require": ["1tau"],
@@ -104,11 +107,13 @@ def _postprocess_sr_groups(sr_dict):
     return sr_dict
 
 
-def _construct_cat_name(chan_str, njet_str=None):
+def _construct_cat_name(chan_str, njet_str=None, flav_str=None):
     """Match analysis_processor.construct_cat_name for channel labels.
 
-    We assume the pkl file was produced WITHOUT --split-lep-flavor,
-    so we do not include lepton flavor in the label.
+    For CRs (split_lep_flavor=True) we expect flav_str to be non-None and
+    produce labels like:  3l_eee_CR_0j
+    For SRs (split_lep_flavor=False) we pass flav_str=None and produce:
+      3l_CR_0j, 3l_m_offZ_1b_2j, etc.
     """
     nlep_str = chan_str.split("_")[0]
     chan_str = "_".join(chan_str.split("_")[1:])
@@ -123,7 +128,7 @@ def _construct_cat_name(chan_str, njet_str=None):
             )
 
     ret_str = nlep_str
-    for component in [chan_str, njet_str]:
+    for component in [flav_str, chan_str, njet_str]:
         if component is None:
             continue
         ret_str = "_".join([ret_str, component])
@@ -181,13 +186,17 @@ def _matches_tags(ch, require=(), forbid=()):
     return all(tag in ch for tag in require) and not any(tag in ch for tag in forbid)
 
 
-def build_channel_labels_from_ch_cfg(ch_cfg: dict, ch_lst_keys) -> OrderedDict:
+def build_channel_labels_from_ch_cfg(
+    ch_cfg: dict, ch_lst_keys, split_lep_flavor: bool
+) -> OrderedDict:
     """
     Reverse-engineered from topeft/analysis_processor.py, but implemented here.
 
-    We assume the pkl file has been produced WITHOUT using --split-lep-flavor,
-    so we do NOT expand over lep_flav_lst and we do NOT include lepton flavor
-    in the channel label.
+    If split_lep_flavor is True (CR), we expand over lep_flav_lst and include
+    the flavor in the label (e.g. 3l_eee_CR_0j).
+
+    If split_lep_flavor is False (SR), we ignore lep_flav_lst and build labels
+    without explicit flavor (e.g. 3l_CR_0j, 3l_m_offZ_1b_2j).
 
     Returns a mapping:
         base_name -> ordered list of full channel labels
@@ -202,21 +211,31 @@ def build_channel_labels_from_ch_cfg(ch_cfg: dict, ch_lst_keys) -> OrderedDict:
     for key in ch_lst_keys:
         cat_block = ch_cfg.get(key) or {}
         for base_name, cat_def in cat_block.items():
+            lep_flavs = list(cat_def.get("lep_flav_lst", []) or [None])
             jet_lst = cat_def.get("jet_lst", [])
             labels = out.setdefault(base_name, [])
             seen = seen_by_base.setdefault(base_name, set(labels))
 
             for jet_cat in jet_lst:
                 jet_key = _jet_cat_to_key(jet_cat)
+
+                # Decide whether to expand over lep_flav_lst
+                if split_lep_flavor:
+                    flav_loop = lep_flavs
+                else:
+                    flav_loop = [None]
+
                 for lep_chan in _iter_channel_defs(cat_def):
-                    label = _construct_cat_name(
-                        lep_chan,
-                        njet_str=jet_key,
-                    )
-                    if label in seen:
-                        continue
-                    seen.add(label)
-                    labels.append(label)
+                    for lep_flav in flav_loop:
+                        label = _construct_cat_name(
+                            lep_chan,
+                            njet_str=jet_key,
+                            flav_str=lep_flav,
+                        )
+                        if label in seen:
+                            continue
+                        seen.add(label)
+                        labels.append(label)
 
     return out
 
@@ -242,7 +261,11 @@ def _build_semantic_sr_groups(sr_proc_bases):
 def _collect_region_data(region_name, ch_cfg, meta_cfg):
     spec = REGION_SPECS[region_name]
     ch_lst_keys = _resolve_ch_lst_keys(region_name, ch_cfg)
-    proc_map = build_channel_labels_from_ch_cfg(ch_cfg, ch_lst_keys)
+    split_lep_flavor = bool(spec.get("split_lep_flavor", False))
+
+    proc_map = build_channel_labels_from_ch_cfg(
+        ch_cfg, ch_lst_keys, split_lep_flavor=split_lep_flavor
+    )
 
     yaml_key = spec["yaml_key"]
     if yaml_key not in meta_cfg:
@@ -426,11 +449,11 @@ def main():
         for name, chans in semantic_groups.items():
             updated[name] = chans
 
+        # Drop obsolete fixed-jet 4l groups if present
         for obsolete in ("4l_2j", "4l_3j", "4l_4j"):
             updated.pop(obsolete, None)
 
         # Apply higher-level SR post-processing: rename and clean up groups
-        # according to plotting/physics conventions (onZ/offZ, fwd, etc.).
         updated = _postprocess_sr_groups(updated)
 
         out_meta[yaml_key] = updated
@@ -447,8 +470,4 @@ def main():
     with out_path.open("w") as f:
         yaml.safe_dump(out_meta, f, sort_keys=False)
 
-    print(f"\nWrote augmented YAML to {out_path}")
-
-
-if __name__ == "__main__":
-    main()
+    print(f"\

--- a/tools/audit_cr_channels_from_processor.py
+++ b/tools/audit_cr_channels_from_processor.py
@@ -1,11 +1,27 @@
 #!/usr/bin/env python3
+import argparse
+import copy
 import json
+import sys
+from collections import OrderedDict
 from pathlib import Path
 
 import yaml
 
 CH_LST_PATH = Path("topeft/channels/ch_lst.json")
 META_YAML_PATH = Path("topeft/params/cr_sr_plots_metadata.yml")
+
+REGION_SPECS = {
+    "CR": {
+        "ch_lst_keys": ("CH_LST_CR", "TAU_CH_LST_CR"),
+        "yaml_key": "CR_CHAN_DICT",
+    },
+    "SR": {
+        "ch_lst_keys": (),
+        "ch_lst_match": "CH_LST_SR",
+        "yaml_key": "SR_CHAN_DICT",
+    },
+}
 
 
 def _construct_cat_name(chan_str, njet_str=None, flav_str=None):
@@ -54,33 +70,49 @@ def _iter_channel_defs(cat_def):
             yield entry
 
 
-def build_channel_labels_from_ch_cfg(ch_cfg: dict) -> dict:
+def _resolve_ch_lst_keys(region_name, ch_cfg):
+    spec = REGION_SPECS[region_name]
+    explicit_keys = list(spec.get("ch_lst_keys", ()))
+    if explicit_keys:
+        missing = [key for key in explicit_keys if key not in ch_cfg]
+        if missing:
+            raise KeyError(
+                f"Missing expected {region_name} ch_lst keys: {', '.join(missing)}"
+            )
+        return explicit_keys
+
+    match_token = spec.get("ch_lst_match")
+    if match_token:
+        matched = sorted(key for key in ch_cfg if match_token in key)
+        if matched:
+            return matched
+
+    raise KeyError(
+        f"Unable to resolve {region_name} ch_lst keys from {', '.join(ch_cfg.keys())}"
+    )
+
+
+def build_channel_labels_from_ch_cfg(ch_cfg: dict, ch_lst_keys) -> OrderedDict:
     """
     Reverse-engineered from topeft/analysis_processor.py, but implemented here.
 
     Returns a mapping:
-        base_name -> set of full channel labels
-
-    Only for CR definitions coming from:
-      - CH_LST_CR
-      - TAU_CH_LST_CR
-    in ch_lst.json.
+        base_name -> ordered list of full channel labels
 
     The returned labels must match the histogram channel labels
-    that CR_CHAN_DICT refers to, e.g.:
-      - 3l_eee_CR_0j
-      - 2los_ee_1tau_Ftau_2j
-      - 1l_m_dy_tautau_CR_4j
+    that CR_CHAN_DICT or SR_CHAN_DICT refer to.
     """
 
-    out = {}
+    out = OrderedDict()
+    seen_by_base = {}
 
-    for key in ("CH_LST_CR", "TAU_CH_LST_CR"):
+    for key in ch_lst_keys:
         cat_block = ch_cfg.get(key) or {}
         for base_name, cat_def in cat_block.items():
             lep_flavs = list(cat_def.get("lep_flav_lst", []) or [None])
             jet_lst = cat_def.get("jet_lst", [])
-            labels = out.setdefault(base_name, set())
+            labels = out.setdefault(base_name, [])
+            seen = seen_by_base.setdefault(base_name, set(labels))
 
             for jet_cat in jet_lst:
                 jet_key = _jet_cat_to_key(jet_cat)
@@ -89,48 +121,200 @@ def build_channel_labels_from_ch_cfg(ch_cfg: dict) -> dict:
                         label = _construct_cat_name(
                             lep_chan, njet_str=jet_key, flav_str=lep_flav
                         )
-                        labels.add(label)
+                        if label in seen:
+                            continue
+                        seen.add(label)
+                        labels.append(label)
 
     return out
 
 
-def main():
-    with CH_LST_PATH.open() as f:
-        ch_cfg = json.load(f)
-    with META_YAML_PATH.open() as f:
-        meta_cfg = yaml.safe_load(f)
+def _collect_region_data(region_name, ch_cfg, meta_cfg):
+    spec = REGION_SPECS[region_name]
+    ch_lst_keys = _resolve_ch_lst_keys(region_name, ch_cfg)
+    proc_map = build_channel_labels_from_ch_cfg(ch_cfg, ch_lst_keys)
 
-    proc_map = build_channel_labels_from_ch_cfg(ch_cfg)
+    yaml_key = spec["yaml_key"]
+    if yaml_key not in meta_cfg:
+        raise KeyError(f"Missing expected YAML key '{yaml_key}'")
+
+    yaml_block = meta_cfg.get(yaml_key) or {}
+    yaml_labels_by_base = {
+        base: list(labels or []) for base, labels in yaml_block.items()
+    }
 
     proc_labels = sorted({lab for labs in proc_map.values() for lab in labs})
     yaml_labels = sorted(
-        {lab for labels in meta_cfg["CR_CHAN_DICT"].values() for lab in labels}
+        {lab for labels in yaml_labels_by_base.values() for lab in labels}
     )
 
     proc_set = set(proc_labels)
     yaml_set = set(yaml_labels)
 
-    only_in_processor = sorted(proc_set - yaml_set)
-    only_in_yaml = sorted(yaml_set - proc_set)
+    return {
+        "region": region_name,
+        "yaml_key": yaml_key,
+        "ch_lst_keys": ch_lst_keys,
+        "proc_map": proc_map,
+        "yaml_map": yaml_labels_by_base,
+        "proc_labels": proc_labels,
+        "yaml_labels": yaml_labels,
+        "only_in_processor": sorted(proc_set - yaml_set),
+        "only_in_yaml": sorted(yaml_set - proc_set),
+    }
+
+
+def _print_region_report(region_data):
+    region = region_data["region"]
+    yaml_key = region_data["yaml_key"]
 
     print(
-        "=== CR channel labels that the PROCESSOR can build, but are MISSING in YAML CR_CHAN_DICT ==="
+        f"=== {region} channel labels that the PROCESSOR can build, but are MISSING in YAML {yaml_key} ==="
     )
-    for lab in only_in_processor:
+    for lab in region_data["only_in_processor"]:
         print(f"  - {lab}")
 
     print(
-        "\n=== YAML CR_CHAN_DICT labels that the PROCESSOR would NEVER produce ==="
+        f"\n=== YAML {yaml_key} labels that the PROCESSOR would NEVER produce ==="
     )
-    for lab in only_in_yaml:
+    for lab in region_data["only_in_yaml"]:
         print(f"  - {lab}")
 
-    print("\n=== Debug: processor CR bases and their first few channels ===")
-    for base, labs in sorted(proc_map.items()):
+    print(f"\n=== Debug: processor {region} bases and their first few channels ===")
+    for base, labs in sorted(region_data["proc_map"].items()):
         labs_sorted = sorted(labs)
         preview = ", ".join(labs_sorted[:5])
         more = "" if len(labs_sorted) <= 5 else f" ... (+{len(labs_sorted)-5} more)"
         print(f"  {base}: {preview}{more}")
+
+
+def _augment_channel_dict(proc_map, yaml_block):
+    updated = copy.deepcopy(yaml_block)
+    labels_added = 0
+    bases_created = 0
+
+    for base, proc_labels in proc_map.items():
+        if base not in updated:
+            updated[base] = list(proc_labels)
+            bases_created += 1
+            labels_added += len(proc_labels)
+            continue
+
+        existing = list(updated.get(base) or [])
+        existing_set = set(existing)
+        additions = [label for label in proc_labels if label not in existing_set]
+        if additions:
+            existing.extend(additions)
+            updated[base] = existing
+            labels_added += len(additions)
+
+    return updated, labels_added, bases_created
+
+
+def _exit_with_error(message):
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def _read_json(path: Path):
+    try:
+        with path.open() as f:
+            return json.load(f)
+    except OSError as exc:
+        _exit_with_error(f"unable to read JSON from {path}: {exc}")
+    except json.JSONDecodeError as exc:
+        _exit_with_error(f"invalid JSON in {path}: {exc}")
+
+
+def _read_yaml(path: Path):
+    try:
+        with path.open() as f:
+            return yaml.safe_load(f)
+    except OSError as exc:
+        _exit_with_error(f"unable to read YAML from {path}: {exc}")
+    except yaml.YAMLError as exc:
+        _exit_with_error(f"invalid YAML in {path}: {exc}")
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Audit CR/SR channel labels from ch_lst.json against the YAML metadata."
+        )
+    )
+    parser.add_argument(
+        "--ch-lst",
+        default=str(CH_LST_PATH),
+        help="Path to ch_lst.json (default: topeft/channels/ch_lst.json)",
+    )
+    parser.add_argument(
+        "--meta-yaml",
+        default=str(META_YAML_PATH),
+        help="Path to cr_sr_plots_metadata.yml (default: topeft/params/cr_sr_plots_metadata.yml)",
+    )
+    parser.add_argument(
+        "--out-meta-yaml",
+        default=None,
+        help="Output path for the augmented YAML (required with --write-augmented-yaml)",
+    )
+    parser.add_argument(
+        "--regions",
+        choices=("CR", "SR", "both"),
+        default="both",
+        help="Which region(s) to audit (default: both)",
+    )
+    parser.add_argument(
+        "--write-augmented-yaml",
+        action="store_true",
+        help="Write an augmented YAML with missing labels filled in",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = _parse_args()
+
+    if args.write_augmented_yaml and not args.out_meta_yaml:
+        raise ValueError("--out-meta-yaml is required with --write-augmented-yaml")
+
+    ch_lst_path = Path(args.ch_lst)
+    meta_yaml_path = Path(args.meta_yaml)
+
+    ch_cfg = _read_json(ch_lst_path)
+    meta_cfg = _read_yaml(meta_yaml_path)
+
+    regions = ["CR", "SR"] if args.regions == "both" else [args.regions]
+
+    region_data = []
+    for region in regions:
+        data = _collect_region_data(region, ch_cfg, meta_cfg)
+        region_data.append(data)
+        _print_region_report(data)
+
+    if not args.write_augmented_yaml:
+        return
+
+    out_meta = copy.deepcopy(meta_cfg)
+    for data in region_data:
+        yaml_key = data["yaml_key"]
+        updated, labels_added, bases_created = _augment_channel_dict(
+            data["proc_map"], out_meta.get(yaml_key, {})
+        )
+        out_meta[yaml_key] = updated
+
+        proc_count = sum(len(labels) for labels in data["proc_map"].values())
+        yaml_count = sum(len(labels) for labels in data["yaml_map"].values())
+        print(f"\n=== Augmented YAML summary ({data['region']}) ===")
+        print(f"  processor labels: {proc_count}")
+        print(f"  yaml labels: {yaml_count}")
+        print(f"  labels added: {labels_added}")
+        print(f"  bases created: {bases_created}")
+
+    out_path = Path(args.out_meta_yaml)
+    with out_path.open("w") as f:
+        yaml.safe_dump(out_meta, f, sort_keys=False)
+
+    print(f"\nWrote augmented YAML to {out_path}")
 
 
 if __name__ == "__main__":

--- a/tools/audit_cr_channels_from_processor.py
+++ b/tools/audit_cr_channels_from_processor.py
@@ -30,6 +30,11 @@ SR_TAG_GROUP_RULES = {
         "require": [],
         "forbid": ["fwd"],
     },
+    "2lss_fwd": {
+        "base": "2l",
+        "require": ["fwd"],
+        "forbid": [],
+    },
     "2lss_1tau_onZ": {
         "base": "2lss_1tau",
         "require": ["onZ"],
@@ -71,6 +76,60 @@ SR_TAG_GROUP_RULES = {
         "forbid": [],
     },
 }
+
+
+def _split_group_by_btags(sr_dict, key, btags=("1b", "2b")):
+    """
+    Replace sr_dict[key] with key_1b / key_2b variants, based on substrings
+    in the channel labels.
+    """
+    labels = sr_dict.pop(key, None)
+    if not labels:
+        return
+
+    for btag in btags:
+        tag = f"_{btag}_"
+        sublabels = [lab for lab in labels if tag in lab]
+        if not sublabels:
+            continue
+        new_key = f"{key}_{btag}"
+        if new_key in sr_dict:
+            raise ValueError(f"Key {new_key} already exists in SR_CHAN_DICT")
+        sr_dict[new_key] = sublabels
+
+
+def _postprocess_sr_groups(sr_dict):
+    """
+    Apply higher-level physics/plotting conventions to SR_CHAN_DICT:
+      * rename 3l_fwd -> 3l_onZ_fwd (it only contains onZ channels);
+      * drop global base groups that are fully covered by more semantic ones;
+      * split selected 3l groups into explicit 1b / 2b categories.
+
+    This function must NOT drop any unique channel labels: only rename or
+    redistribute them into more specific groups.
+    """
+    sr_dict = copy.deepcopy(sr_dict)
+
+    # 1) Rename 3l_fwd -> 3l_onZ_fwd (it only contains onZ channels)
+    if "3l_fwd" in sr_dict:
+        if "3l_onZ_fwd" in sr_dict:
+            raise ValueError(
+                "3l_onZ_fwd already exists when trying to rename 3l_fwd"
+            )
+        sr_dict["3l_onZ_fwd"] = sr_dict.pop("3l_fwd")
+
+    # 2) Drop global / redundant SR bases which are now covered by semantic groups.
+    #    We now also drop '2l' after introducing the 2lss_fwd semantic group,
+    #    so that every 2l(SS) channel lives in exactly one high-level category.
+    for key in ("3l", "4l", "2los_1tau", "2l"):
+        sr_dict.pop(key, None)
+
+    # 3) Split key 3l groups into 1b / 2b variants.
+    #    These groups are known to contain only _1b_ / _2b_ channels.
+    for key in ("3l_onZ_SR", "3l_offZ_SR", "3l_onZ_fwd", "3l_offZ_fwd"):
+        _split_group_by_btags(sr_dict, key)
+
+    return sr_dict
 
 
 def _construct_cat_name(chan_str, njet_str=None, flav_str=None):
@@ -378,6 +437,9 @@ def main():
                 updated[name] = chans
             for obsolete in ("4l_2j", "4l_3j", "4l_4j"):
                 updated.pop(obsolete, None)
+            # Apply higher-level SR post-processing: rename, split, and clean up groups
+            # according to plotting/physics conventions (onZ/offZ, 1b/2b, fwd, etc.).
+            updated = _postprocess_sr_groups(updated)
         out_meta[yaml_key] = updated
 
         proc_count = sum(len(labels) for labels in data["proc_map"].values())

--- a/tools/audit_cr_channels_from_processor.py
+++ b/tools/audit_cr_channels_from_processor.py
@@ -470,4 +470,8 @@ def main():
     with out_path.open("w") as f:
         yaml.safe_dump(out_meta, f, sort_keys=False)
 
-    print(f"\
+    print(f"\nWrote augmented YAML to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/audit_cr_channels_from_processor.py
+++ b/tools/audit_cr_channels_from_processor.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+
+import yaml
+
+CH_LST_PATH = Path("topeft/channels/ch_lst.json")
+META_YAML_PATH = Path("topeft/params/cr_sr_plots_metadata.yml")
+
+
+def _construct_cat_name(chan_str, njet_str=None, flav_str=None):
+    """Match analysis_processor.construct_cat_name for channel labels."""
+
+    nlep_str = chan_str.split("_")[0]
+    chan_str = "_".join(chan_str.split("_")[1:])
+    if chan_str == "":
+        chan_str = None
+    if njet_str is not None:
+        njet_str = njet_str[-2:]
+        if "j" not in njet_str:
+            raise ValueError(
+                f"Invalid njet string '{njet_str}' derived from '{njet_str}'"
+            )
+
+    ret_str = nlep_str
+    for component in [flav_str, chan_str, njet_str]:
+        if component is None:
+            continue
+        ret_str = "_".join([ret_str, component])
+    return ret_str
+
+
+def _jet_cat_to_key(jet_cat):
+    jet_cat = str(jet_cat)
+    if jet_cat.startswith("="):
+        jettag = "exactly_"
+    elif jet_cat.startswith("<"):
+        jettag = "atmost_"
+    elif jet_cat.startswith(">"):
+        jettag = "atleast_"
+    else:
+        raise ValueError(f"jet_cat {jet_cat} misses =,<,>!")
+
+    return jettag + jet_cat.replace("=", "").replace("<", "").replace(">", "") + "j"
+
+
+def _iter_channel_defs(cat_def):
+    lep_chan_lst = cat_def.get("lep_chan_lst", [])
+    for entry in lep_chan_lst:
+        if isinstance(entry, (list, tuple)):
+            if entry:
+                yield entry[0]
+        else:
+            yield entry
+
+
+def build_channel_labels_from_ch_cfg(ch_cfg: dict) -> dict:
+    """
+    Reverse-engineered from topeft/analysis_processor.py, but implemented here.
+
+    Returns a mapping:
+        base_name -> set of full channel labels
+
+    Only for CR definitions coming from:
+      - CH_LST_CR
+      - TAU_CH_LST_CR
+    in ch_lst.json.
+
+    The returned labels must match the histogram channel labels
+    that CR_CHAN_DICT refers to, e.g.:
+      - 3l_eee_CR_0j
+      - 2los_ee_1tau_Ftau_2j
+      - 1l_m_dy_tautau_CR_4j
+    """
+
+    out = {}
+
+    for key in ("CH_LST_CR", "TAU_CH_LST_CR"):
+        cat_block = ch_cfg.get(key) or {}
+        for base_name, cat_def in cat_block.items():
+            lep_flavs = list(cat_def.get("lep_flav_lst", []) or [None])
+            jet_lst = cat_def.get("jet_lst", [])
+            labels = out.setdefault(base_name, set())
+
+            for jet_cat in jet_lst:
+                jet_key = _jet_cat_to_key(jet_cat)
+                for lep_chan in _iter_channel_defs(cat_def):
+                    for lep_flav in lep_flavs:
+                        label = _construct_cat_name(
+                            lep_chan, njet_str=jet_key, flav_str=lep_flav
+                        )
+                        labels.add(label)
+
+    return out
+
+
+def main():
+    with CH_LST_PATH.open() as f:
+        ch_cfg = json.load(f)
+    with META_YAML_PATH.open() as f:
+        meta_cfg = yaml.safe_load(f)
+
+    proc_map = build_channel_labels_from_ch_cfg(ch_cfg)
+
+    proc_labels = sorted({lab for labs in proc_map.values() for lab in labs})
+    yaml_labels = sorted(
+        {lab for labels in meta_cfg["CR_CHAN_DICT"].values() for lab in labels}
+    )
+
+    proc_set = set(proc_labels)
+    yaml_set = set(yaml_labels)
+
+    only_in_processor = sorted(proc_set - yaml_set)
+    only_in_yaml = sorted(yaml_set - proc_set)
+
+    print(
+        "=== CR channel labels that the PROCESSOR can build, but are MISSING in YAML CR_CHAN_DICT ==="
+    )
+    for lab in only_in_processor:
+        print(f"  - {lab}")
+
+    print(
+        "\n=== YAML CR_CHAN_DICT labels that the PROCESSOR would NEVER produce ==="
+    )
+    for lab in only_in_yaml:
+        print(f"  - {lab}")
+
+    print("\n=== Debug: processor CR bases and their first few channels ===")
+    for base, labs in sorted(proc_map.items()):
+        labs_sorted = sorted(labs)
+        preview = ", ".join(labs_sorted[:5])
+        more = "" if len(labs_sorted) <= 5 else f" ... (+{len(labs_sorted)-5} more)"
+        print(f"  {base}: {preview}{more}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/audit_cr_channels_from_processor.py
+++ b/tools/audit_cr_channels_from_processor.py
@@ -23,6 +23,55 @@ REGION_SPECS = {
     },
 }
 
+# Semantic SR groups derived from fully flavour-split channels.
+SR_TAG_GROUP_RULES = {
+    "2lss_SR": {
+        "base": "2lss",
+        "require": [],
+        "forbid": ["fwd"],
+    },
+    "2lss_1tau_onZ": {
+        "base": "2lss_1tau",
+        "require": ["onZ"],
+        "forbid": [],
+    },
+    "2lss_1tau_offZ": {
+        "base": "2lss_1tau",
+        "require": ["offZ"],
+        "forbid": [],
+    },
+    "2los_onZ_1tau": {
+        "base": "2los_1tau",
+        "require": ["onZ", "1tau"],
+        "forbid": [],
+    },
+    "3l_onZ_SR": {
+        "base": "3l",
+        "require": ["onZ"],
+        "forbid": ["1tau", "fwd"],
+    },
+    "3l_offZ_SR": {
+        "base": "3l",
+        "require": ["offZ"],
+        "forbid": ["1tau", "fwd"],
+    },
+    "3l_1tau_1b": {
+        "base": "3l",
+        "require": ["1tau", "_1b_"],
+        "forbid": ["fwd"],
+    },
+    "3l_1tau_2b": {
+        "base": "3l",
+        "require": ["1tau", "_2b_"],
+        "forbid": ["fwd"],
+    },
+    "4l_SR": {
+        "base": "4l",
+        "require": [],
+        "forbid": [],
+    },
+}
+
 
 def _construct_cat_name(chan_str, njet_str=None, flav_str=None):
     """Match analysis_processor.construct_cat_name for channel labels."""
@@ -92,6 +141,11 @@ def _resolve_ch_lst_keys(region_name, ch_cfg):
     )
 
 
+def _matches_tags(ch, require=(), forbid=()):
+    """Return True when all require tags are present and no forbid tags match."""
+    return all(tag in ch for tag in require) and not any(tag in ch for tag in forbid)
+
+
 def build_channel_labels_from_ch_cfg(ch_cfg: dict, ch_lst_keys) -> OrderedDict:
     """
     Reverse-engineered from topeft/analysis_processor.py, but implemented here.
@@ -127,6 +181,24 @@ def build_channel_labels_from_ch_cfg(ch_cfg: dict, ch_lst_keys) -> OrderedDict:
                         labels.append(label)
 
     return out
+
+
+def _build_semantic_sr_groups(sr_proc_bases):
+    groups = {}
+    for group_name, rule in SR_TAG_GROUP_RULES.items():
+        base = rule["base"]
+        if base not in sr_proc_bases:
+            continue
+        base_channels = sr_proc_bases[base]
+        require = tuple(rule.get("require", ()))
+        forbid = tuple(rule.get("forbid", ()))
+        matches = [
+            ch
+            for ch in base_channels
+            if _matches_tags(ch, require=require, forbid=forbid)
+        ]
+        groups[group_name] = sorted(matches)
+    return groups
 
 
 def _collect_region_data(region_name, ch_cfg, meta_cfg):
@@ -300,6 +372,12 @@ def main():
         updated, labels_added, bases_created = _augment_channel_dict(
             data["proc_map"], out_meta.get(yaml_key, {})
         )
+        if data["region"] == "SR":
+            semantic_groups = _build_semantic_sr_groups(data["proc_map"])
+            for name, chans in semantic_groups.items():
+                updated[name] = chans
+            for obsolete in ("4l_2j", "4l_3j", "4l_4j"):
+                updated.pop(obsolete, None)
         out_meta[yaml_key] = updated
 
         proc_count = sum(len(labels) for labels in data["proc_map"].values())

--- a/tools/audit_cr_channels_from_processor.py
+++ b/tools/audit_cr_channels_from_processor.py
@@ -24,6 +24,8 @@ REGION_SPECS = {
 }
 
 # Semantic SR groups derived from fully flavour-split channels.
+# 1b/2b categorization has been removed: we now group all 3l+1tau
+# channels together regardless of b-tag multiplicity.
 SR_TAG_GROUP_RULES = {
     "2lss_SR": {
         "base": "2lss",
@@ -60,14 +62,10 @@ SR_TAG_GROUP_RULES = {
         "require": ["offZ"],
         "forbid": ["1tau", "fwd"],
     },
-    "3l_1tau_1b": {
+    # New combined group replacing separate 3l_1tau_1b / 3l_1tau_2b:
+    "3l_1tau": {
         "base": "3l",
-        "require": ["1tau", "_1b_"],
-        "forbid": ["fwd"],
-    },
-    "3l_1tau_2b": {
-        "base": "3l",
-        "require": ["1tau", "_2b_"],
+        "require": ["1tau"],
         "forbid": ["fwd"],
     },
     "4l_SR": {
@@ -78,32 +76,11 @@ SR_TAG_GROUP_RULES = {
 }
 
 
-def _split_group_by_btags(sr_dict, key, btags=("1b", "2b")):
-    """
-    Replace sr_dict[key] with key_1b / key_2b variants, based on substrings
-    in the channel labels.
-    """
-    labels = sr_dict.pop(key, None)
-    if not labels:
-        return
-
-    for btag in btags:
-        tag = f"_{btag}_"
-        sublabels = [lab for lab in labels if tag in lab]
-        if not sublabels:
-            continue
-        new_key = f"{key}_{btag}"
-        if new_key in sr_dict:
-            raise ValueError(f"Key {new_key} already exists in SR_CHAN_DICT")
-        sr_dict[new_key] = sublabels
-
-
 def _postprocess_sr_groups(sr_dict):
     """
     Apply higher-level physics/plotting conventions to SR_CHAN_DICT:
       * rename 3l_fwd -> 3l_onZ_fwd (it only contains onZ channels);
-      * drop global base groups that are fully covered by more semantic ones;
-      * split selected 3l groups into explicit 1b / 2b categories.
+      * drop global base groups that are fully covered by more semantic ones.
 
     This function must NOT drop any unique channel labels: only rename or
     redistribute them into more specific groups.
@@ -124,21 +101,20 @@ def _postprocess_sr_groups(sr_dict):
     for key in ("3l", "4l", "2los_1tau", "2l"):
         sr_dict.pop(key, None)
 
-    # 3) Split key 3l groups into 1b / 2b variants.
-    #    These groups are known to contain only _1b_ / _2b_ channels.
-    for key in ("3l_onZ_SR", "3l_offZ_SR", "3l_onZ_fwd", "3l_offZ_fwd"):
-        _split_group_by_btags(sr_dict, key)
-
     return sr_dict
 
 
-def _construct_cat_name(chan_str, njet_str=None, flav_str=None):
-    """Match analysis_processor.construct_cat_name for channel labels."""
+def _construct_cat_name(chan_str, njet_str=None):
+    """Match analysis_processor.construct_cat_name for channel labels.
 
+    We assume the pkl file was produced WITHOUT --split-lep-flavor,
+    so we do not include lepton flavor in the label.
+    """
     nlep_str = chan_str.split("_")[0]
     chan_str = "_".join(chan_str.split("_")[1:])
     if chan_str == "":
         chan_str = None
+
     if njet_str is not None:
         njet_str = njet_str[-2:]
         if "j" not in njet_str:
@@ -147,7 +123,7 @@ def _construct_cat_name(chan_str, njet_str=None, flav_str=None):
             )
 
     ret_str = nlep_str
-    for component in [flav_str, chan_str, njet_str]:
+    for component in [chan_str, njet_str]:
         if component is None:
             continue
         ret_str = "_".join([ret_str, component])
@@ -209,6 +185,10 @@ def build_channel_labels_from_ch_cfg(ch_cfg: dict, ch_lst_keys) -> OrderedDict:
     """
     Reverse-engineered from topeft/analysis_processor.py, but implemented here.
 
+    We assume the pkl file has been produced WITHOUT using --split-lep-flavor,
+    so we do NOT expand over lep_flav_lst and we do NOT include lepton flavor
+    in the channel label.
+
     Returns a mapping:
         base_name -> ordered list of full channel labels
 
@@ -222,7 +202,6 @@ def build_channel_labels_from_ch_cfg(ch_cfg: dict, ch_lst_keys) -> OrderedDict:
     for key in ch_lst_keys:
         cat_block = ch_cfg.get(key) or {}
         for base_name, cat_def in cat_block.items():
-            lep_flavs = list(cat_def.get("lep_flav_lst", []) or [None])
             jet_lst = cat_def.get("jet_lst", [])
             labels = out.setdefault(base_name, [])
             seen = seen_by_base.setdefault(base_name, set(labels))
@@ -230,14 +209,14 @@ def build_channel_labels_from_ch_cfg(ch_cfg: dict, ch_lst_keys) -> OrderedDict:
             for jet_cat in jet_lst:
                 jet_key = _jet_cat_to_key(jet_cat)
                 for lep_chan in _iter_channel_defs(cat_def):
-                    for lep_flav in lep_flavs:
-                        label = _construct_cat_name(
-                            lep_chan, njet_str=jet_key, flav_str=lep_flav
-                        )
-                        if label in seen:
-                            continue
-                        seen.add(label)
-                        labels.append(label)
+                    label = _construct_cat_name(
+                        lep_chan,
+                        njet_str=jet_key,
+                    )
+                    if label in seen:
+                        continue
+                    seen.add(label)
+                    labels.append(label)
 
     return out
 
@@ -428,18 +407,32 @@ def main():
     out_meta = copy.deepcopy(meta_cfg)
     for data in region_data:
         yaml_key = data["yaml_key"]
+
+        # Do NOT modify CR_CHAN_DICT: keep it identical to the input YAML.
+        if data["region"] != "SR":
+            out_meta[yaml_key] = meta_cfg.get(yaml_key, {})
+            print(
+                f"\n=== Skipping augmentation for {data['region']} "
+                f"(leaving {yaml_key} unchanged) ==="
+            )
+            continue
+
+        # For SR, augment + apply semantic/post-processing rules.
         updated, labels_added, bases_created = _augment_channel_dict(
             data["proc_map"], out_meta.get(yaml_key, {})
         )
-        if data["region"] == "SR":
-            semantic_groups = _build_semantic_sr_groups(data["proc_map"])
-            for name, chans in semantic_groups.items():
-                updated[name] = chans
-            for obsolete in ("4l_2j", "4l_3j", "4l_4j"):
-                updated.pop(obsolete, None)
-            # Apply higher-level SR post-processing: rename, split, and clean up groups
-            # according to plotting/physics conventions (onZ/offZ, 1b/2b, fwd, etc.).
-            updated = _postprocess_sr_groups(updated)
+
+        semantic_groups = _build_semantic_sr_groups(data["proc_map"])
+        for name, chans in semantic_groups.items():
+            updated[name] = chans
+
+        for obsolete in ("4l_2j", "4l_3j", "4l_4j"):
+            updated.pop(obsolete, None)
+
+        # Apply higher-level SR post-processing: rename and clean up groups
+        # according to plotting/physics conventions (onZ/offZ, fwd, etc.).
+        updated = _postprocess_sr_groups(updated)
+
         out_meta[yaml_key] = updated
 
         proc_count = sum(len(labels) for labels in data["proc_map"].values())

--- a/topeft/modules/yield_tools.py
+++ b/topeft/modules/yield_tools.py
@@ -34,12 +34,12 @@ class YieldTools():
         # A dictionary mapping names of processes in the processes axis to a short version of the name
         self.PROC_MAP = {
 
-            "ttlnu" : ["ttW_centralUL16APV"    ,"ttW_centralUL16"    ,"ttW_centralUL17" ,"ttW_centralUL18" , "ttlnuJet_privateUL18" , "ttlnuJet_privateUL17" , "ttlnuJet_privateUL16" , "ttlnuJet_privateUL16APV", "ttW_central2022",  "ttlnuJet_private2022"],
-            "ttll"  : ["ttZ_centralUL16APV"    ,"ttZ_centralUL16"    ,"ttZ_centralUL17" ,"ttZ_centralUL18" , "ttllJet_privateUL18"  , "ttllJet_privateUL17"  , "ttllJet_privateUL16"  , "ttllJet_privateUL16APV",  "TTLL_MLL-50_central2022", "TTLL_MLL-4to50_central2022" ,"TTLL_MLL-50_central2022EE", "TTLL_MLL-4to50_central2022EE"],
-            "ttH"   : ["ttHJet_centralUL16APV" ,"ttHJet_centralUL16" ,"ttH_centralUL17" ,"ttH_centralUL18" , "ttHJet_privateUL18"   , "ttHJet_privateUL17"   , "ttHJet_privateUL16"   , "ttHJet_privateUL16APV", "ttHnobb-1Jets_central2022",  "ttHnobb-1Jets_central2022EE"],
-            "tllq"  : ["tZq_centralUL16APV"    ,"tZq_centralUL16"    ,"tZq_centralUL17" ,"tZq_centralUL18" , "tllq_privateUL18"     , "tllq_privateUL17"     , "tllq_privateUL16"     , "tllq_privateUL16APV", "tZq_central2022", "tllq_private2022"],
-            "tHq"   : ["tHq_centralUL16APV"    ,"tHq_centralUL16"    ,"tHq_centralUL17" ,"tHq_centralUL18" , "tHq_privateUL18"      , "tHq_privateUL17"      , "tHq_privateUL16"      , "tHq_privateUL16APV", "tHq_central2022", "tHq_private2022"],
-            "tttt"  : ["tttt_centralUL16APV"   ,"tttt_centralUL16"   ,"tttt_centralUL17","tttt_centralUL18", "tttt_privateUL18"     , "tttt_privateUL17"     , "tttt_privateUL16"     , "tttt_privateUL16APV", "TTTT_central2022", "TTTT_central2022EE"],
+            "ttlnu" : ["ttW_centralUL16APV"    ,"ttW_centralUL16"    ,"ttW_centralUL17" ,"ttW_centralUL18" , "ttlnuJet_privateUL18" , "ttlnuJet_privateUL17" , "ttlnuJet_privateUL16" , "ttlnuJet_privateUL16APV", "ttW_central2022", "ttW_central2022EE", "ttW_central2023", "ttW_central2023BPix", "ttlnu_private2022", "ttlnu_private2022EE", "ttlnu_private2023", "ttlnu_private2023BPix"],
+            "ttll"  : ["ttZ_centralUL16APV"    ,"ttZ_centralUL16"    ,"ttZ_centralUL17" ,"ttZ_centralUL18" , "ttllJet_privateUL18"  , "ttllJet_privateUL17"  , "ttllJet_privateUL16"  , "ttllJet_privateUL16APV",  "TTLL_MLL-50_central2022", "TTLL_MLL-4to50_central2022" ,"TTLL_MLL-50_central2022EE", "TTLL_MLL-4to50_central2022EE", "TTLL_MLL-50_central2023", "TTLL_MLL-4to50_central2023", "TTLL_MLL-50_central2023BPix", "TTLL_MLL-4to50_central2023BPix", "ttll_private2022", "ttll_private2022EE", "ttll_private2023", "ttll_private2023BPix"],
+            "ttH"   : ["ttHJet_centralUL16APV" ,"ttHJet_centralUL16" ,"ttH_centralUL17" ,"ttH_centralUL18" , "ttHJet_privateUL18"   , "ttHJet_privateUL17"   , "ttHJet_privateUL16"   , "ttHJet_privateUL16APV", "ttHnobb-1Jets_central2022",  "ttHnobb-1Jets_central2022EE", "ttHnobb-1Jets_central2023", "ttHnobb-1Jets_central2023BPix", "ttH_private2022", "ttH_private2022EE", "ttH_private2023", "ttH_private2023BPix"],
+            "tllq"  : ["tZq_centralUL16APV"    ,"tZq_centralUL16"    ,"tZq_centralUL17" ,"tZq_centralUL18" , "tllq_privateUL18"     , "tllq_privateUL17"     , "tllq_privateUL16"     , "tllq_privateUL16APV", "tZq_central2022", "tZq_central2022EE", "tZq_central2023", "tZq_central2023BPix", "tllq_private2022", "tllq_private2022EE", "tllq_private2023", "tllq_private2023BPix"],
+            "tHq"   : ["tHq_centralUL16APV"    ,"tHq_centralUL16"    ,"tHq_centralUL17" ,"tHq_centralUL18" , "tHq_privateUL18"      , "tHq_privateUL17"      , "tHq_privateUL16"      , "tHq_privateUL16APV", "tHq_central2022", "tHq_central2022EE", "tHq_central2023", "tHq_central2023BPix", "tHq_private2022", "tHq_private2022EE", "tHq_private2023", "tHq_private2023BPix"],
+            "tttt"  : ["tttt_centralUL16APV"   ,"tttt_centralUL16"   ,"tttt_centralUL17","tttt_centralUL18", "tttt_privateUL18"     , "tttt_privateUL17"     , "tttt_privateUL16"     , "tttt_privateUL16APV", "TTTT_central2022", "TTTT_central2022EE", "TTTT_central2023", "TTTT_central2023BPix", "tttt_private2022", "tttt_private2022EE", "tttt_private2023", "tttt_private2023BPix"],
 
             "flips" : [
                 canonicalize_process_name(proc_name)
@@ -67,7 +67,7 @@ class YieldTools():
                     "NonPrompt2023BPix",
                 )
             ],
-            "conv"  : ["TTGamma_centralUL16"  ,"TTGamma_centralUL16APV"  ,"TTGamma_centralUL17"  ,"TTGamma_centralUL18"  ,"TTGamma_central2022"],
+            "conv"  : ["TTGamma_centralUL16"  ,"TTGamma_centralUL16APV"  ,"TTGamma_centralUL17"  ,"TTGamma_centralUL18"  ,"TTGamma_central2022", "TTGamma_central2022EE", "TTGamma_central2023", "TTGamma_central2023BPix"],
             "WW"    : ["WWTo2L2Nu_centralUL16","WWTo2L2Nu_centralUL16APV","WWTo2L2Nu_centralUL17","WWTo2L2Nu_centralUL18","WWTo2L2Nu_central2022", "WWTo2L2Nu_central2022EE", "WWTo2L2Nu_central2023", "WWTo2L2Nu_central2023BPix"],
             "WZ"    : ["WZTo3LNu_centralUL16" ,"WZTo3LNu_centralUL16APV" ,"WZTo3LNu_centralUL17" ,"WZTo3LNu_centralUL18","WZTo3LNu_central2022","WZTo3LNu_central2022EE", "WZTo3LNu_central2023", "WZTo3LNu_central2023BPix"],
             "ZZ"    : ["ZZTo4L_centralUL16"   ,"ZZTo4L_centralUL16APV"   ,"ZZTo4L_centralUL17"   ,"ZZTo4L_centralUL18"   ,"ZZTo4L_central2022", "ZZTo4L_central2022EE",  "ZZTo4L_central2023",  "ZZTo4L_central2023BPix"],
@@ -77,11 +77,11 @@ class YieldTools():
             "ZZZ"   : ["ZZZ_centralUL16"      ,"ZZZ_centralUL16APV"      ,"ZZZ_centralUL17"      ,"ZZZ_centralUL18"      ,"ZZZ_central2022","ZZZ_central2022EE", "ZZZ_central2023", "ZZZ_central2023BPix"],
             "tWZ"   : ["TWZToLL_centralUL16"  ,"TWZToLL_centralUL16APV"  ,"TWZToLL_centralUL17"  ,"TWZToLL_centralUL18"  ,"TWZToLL_central2022", "TWZ_TtoLNu_Wto2Q_Zto2L_central2022","TWZ_TtoLNu_Wto2Q_Zto2L_central2022EE", "TWZ_TtoLNu_Wto2Q_Zto2L_central2023", "TWZ_TtoLNu_Wto2Q_Zto2L_central2023BPix"],
 
-            "ttZlowMll"   : ["TTZToLL_M1to10_centralUL16"  ,"TTZToLL_M1to10_centralUL16APV"  ,"TTZToLL_M1to10_centralUL17"  ,"TTZToLL_M1to10_centralUL18"  ,"TTZToLL_M1to10_central2022"],
+            "ttZlowMll"   : ["TTZToLL_M1to10_centralUL16"  ,"TTZToLL_M1to10_centralUL16APV"  ,"TTZToLL_M1to10_centralUL17"  ,"TTZToLL_M1to10_centralUL18"  ,"TTZToLL_M1to10_central2022", "TTZToLL_M1to10_central2022EE", "TTZToLL_M1to10_central2023", "TTZToLL_M1to10_central2023BPix"],
             "ttbarll" : ["TTTo2L2Nu_centralUL16", "TTTo2L2Nu_centralUL16APV", "TTTo2L2Nu_centralUL17", "TTTo2L2Nu_centralUL18", "TTTo2L2Nu_central2022", "TTto2L2Nu_central2022EE", "TTto2L2Nu_central2023", "TTto2L2Nu_central2023BPix"],
-            "ttbarsl" : ["TTToSemiLeptonic_centralUL16", "TTToSemiLeptonic_centralUL16APV", "TTToSemiLeptonic_centralUL17", "TTToSemiLeptonic_centralUL18","TTToSemiLeptonic_central2022"],
+            "ttbarsl" : ["TTToSemiLeptonic_centralUL16", "TTToSemiLeptonic_centralUL16APV", "TTToSemiLeptonic_centralUL17", "TTToSemiLeptonic_centralUL18","TTToSemiLeptonic_central2022", "TTToSemiLeptonic_central2022EE", "TTToSemiLeptonic_central2023", "TTToSemiLeptonic_central2023BPix"],
 
-            "data"   : ["dataUL16","dataUL16APV","dataUL17","dataUL18","data2022"],
+            "data"   : ["dataUL16","dataUL16APV","dataUL17","dataUL18","data2022", "data2022EE", "data2023", "data2023BPix"],
         }
 
 

--- a/topeft/params/cr_sr_plots_metadata.yml
+++ b/topeft/params/cr_sr_plots_metadata.yml
@@ -1,386 +1,479 @@
 DATA_ERR_OPS:
   linestyle: none
-  marker: '.'
+  marker: .
   markersize: 10.0
   color: k
   elinewidth: 1
 MC_ERROR_OPS:
-  label: 'Stat. Unc.'
-  hatch: '////'
+  label: Stat. Unc.
+  hatch: ////
   facecolor: none
-  edgecolor: [0,0,0,0.5]
+  edgecolor:
+  - 0
+  - 0
+  - 0
+  - 0.5
   linewidth: 0
 DATA_DRIVEN_PREFIXES:
-  - nonprompt
-  - flips
+- nonprompt
+- flips
 CR_CHAN_DICT:
   cr_2los_Z:
-    - 2los_ee_CRZ_0j
-    - 2los_mm_CRZ_0j
+  - 2los_ee_CRZ_0j
+  - 2los_mm_CRZ_0j
   cr_2los_Z_ee:
-    - 2los_ee_CRZ_0j
+  - 2los_ee_CRZ_0j
   cr_2los_Z_mm:
-    - 2los_mm_CRZ_0j
+  - 2los_mm_CRZ_0j
   cr_2los_tt:
-    - 2los_em_CRtt_2j
+  - 2los_em_CRtt_2j
   cr_2lss:
-    - 2lss_ee_CR_1j
-    - 2lss_em_CR_1j
-    - 2lss_mm_CR_1j
-    - 2lss_ee_CR_2j
-    - 2lss_em_CR_2j
-    - 2lss_mm_CR_2j
-    - 2lss_ee_CR_3j
-    - 2lss_em_CR_3j
-    - 2lss_mm_CR_3j
+  - 2lss_ee_CR_1j
+  - 2lss_em_CR_1j
+  - 2lss_mm_CR_1j
+  - 2lss_ee_CR_2j
+  - 2lss_em_CR_2j
+  - 2lss_mm_CR_2j
+  - 2lss_ee_CR_3j
+  - 2lss_em_CR_3j
+  - 2lss_mm_CR_3j
   cr_2lss_ee:
-    - 2lss_ee_CR_1j
-    - 2lss_ee_CR_2j
-    - 2lss_ee_CR_3j
+  - 2lss_ee_CR_1j
+  - 2lss_ee_CR_2j
+  - 2lss_ee_CR_3j
   cr_2lss_em:
-    - 2lss_em_CR_1j
-    - 2lss_em_CR_2j
-    - 2lss_em_CR_3j
+  - 2lss_em_CR_1j
+  - 2lss_em_CR_2j
+  - 2lss_em_CR_3j
   cr_2lss_mm:
-    - 2lss_mm_CR_1j
-    - 2lss_mm_CR_2j
-    - 2lss_mm_CR_3j
+  - 2lss_mm_CR_1j
+  - 2lss_mm_CR_2j
+  - 2lss_mm_CR_3j
   cr_2lss_flip:
-    - 2lss_ee_CRflip_3j
+  - 2lss_ee_CRflip_3j
   cr_3l:
-    - 3l_eee_CR_0j
-    - 3l_eem_CR_0j
-    - 3l_emm_CR_0j
-    - 3l_mmm_CR_0j
-    - 3l_eee_CR_1j
-    - 3l_eem_CR_1j
-    - 3l_emm_CR_1j
-    - 3l_mmm_CR_1j
+  - 3l_eee_CR_0j
+  - 3l_eem_CR_0j
+  - 3l_emm_CR_0j
+  - 3l_mmm_CR_0j
+  - 3l_eee_CR_1j
+  - 3l_eem_CR_1j
+  - 3l_emm_CR_1j
+  - 3l_mmm_CR_1j
   cr_3l_eee:
-    - 3l_eee_CR_0j
-    - 3l_eee_CR_1j
+  - 3l_eee_CR_0j
+  - 3l_eee_CR_1j
   cr_3l_mixed:
-    - 3l_eem_CR_0j
-    - 3l_emm_CR_0j
-    - 3l_eem_CR_1j
-    - 3l_emm_CR_1j
+  - 3l_eem_CR_0j
+  - 3l_emm_CR_0j
+  - 3l_eem_CR_1j
+  - 3l_emm_CR_1j
   cr_3l_mmm:
-    - 3l_mmm_CR_0j
-    - 3l_mmm_CR_1j
+  - 3l_mmm_CR_0j
+  - 3l_mmm_CR_1j
   cr_2los_1tau_Ftau:
-    - 2los_ee_1tau_Ftau_2j
-    - 2los_ee_1tau_Ftau_3j
-    - 2los_ee_1tau_Ftau_4j
-    - 2los_em_1tau_Ftau_2j
-    - 2los_em_1tau_Ftau_3j
-    - 2los_em_1tau_Ftau_4j
-    - 2los_mm_1tau_Ftau_2j
-    - 2los_mm_1tau_Ftau_3j
-    - 2los_mm_1tau_Ftau_4j
+  - 2los_ee_1tau_Ftau_2j
+  - 2los_ee_1tau_Ftau_3j
+  - 2los_ee_1tau_Ftau_4j
+  - 2los_em_1tau_Ftau_2j
+  - 2los_em_1tau_Ftau_3j
+  - 2los_em_1tau_Ftau_4j
+  - 2los_mm_1tau_Ftau_2j
+  - 2los_mm_1tau_Ftau_3j
+  - 2los_mm_1tau_Ftau_4j
   cr_2los_1tau_Ttau:
-    - 2los_ee_1tau_Ttau_2j
-    - 2los_ee_1tau_Ttau_3j
-    - 2los_ee_1tau_Ttau_4j
-    - 2los_em_1tau_Ttau_2j
-    - 2los_em_1tau_Ttau_3j
-    - 2los_em_1tau_Ttau_4j
-    - 2los_mm_1tau_Ttau_2j
-    - 2los_mm_1tau_Ttau_3j
-    - 2los_mm_1tau_Ttau_4j
+  - 2los_ee_1tau_Ttau_2j
+  - 2los_ee_1tau_Ttau_3j
+  - 2los_ee_1tau_Ttau_4j
+  - 2los_em_1tau_Ttau_2j
+  - 2los_em_1tau_Ttau_3j
+  - 2los_em_1tau_Ttau_4j
+  - 2los_mm_1tau_Ttau_2j
+  - 2los_mm_1tau_Ttau_3j
+  - 2los_mm_1tau_Ttau_4j
   cr_1l_1tau:
-    - 1l_e_1tau_CR_2j
-    - 1l_e_1tau_CR_3j
-    - 1l_e_1tau_CR_4j
-    - 1l_m_1tau_CR_2j
-    - 1l_m_1tau_CR_3j
-    - 1l_m_1tau_CR_4j
+  - 1l_e_1tau_CR_2j
+  - 1l_e_1tau_CR_3j
+  - 1l_e_1tau_CR_4j
+  - 1l_m_1tau_CR_2j
+  - 1l_m_1tau_CR_3j
+  - 1l_m_1tau_CR_4j
   cr_1l_1tau_e:
-    - 1l_e_1tau_CR_2j
-    - 1l_e_1tau_CR_3j
-    - 1l_e_1tau_CR_4j
+  - 1l_e_1tau_CR_2j
+  - 1l_e_1tau_CR_3j
+  - 1l_e_1tau_CR_4j
   cr_1l_1tau_m:
-    - 1l_m_1tau_CR_2j
-    - 1l_m_1tau_CR_3j
-    - 1l_m_1tau_CR_4j
+  - 1l_m_1tau_CR_2j
+  - 1l_m_1tau_CR_3j
+  - 1l_m_1tau_CR_4j
   cr_dy_tautau:
-    - 1l_e_dy_tautau_CR_2j
-    - 1l_e_dy_tautau_CR_3j
-    - 1l_e_dy_tautau_CR_4j
-    - 1l_m_dy_tautau_CR_2j
-    - 1l_m_dy_tautau_CR_3j
-    - 1l_m_dy_tautau_CR_4j
+  - 1l_e_dy_tautau_CR_2j
+  - 1l_e_dy_tautau_CR_3j
+  - 1l_e_dy_tautau_CR_4j
+  - 1l_m_dy_tautau_CR_2j
+  - 1l_m_dy_tautau_CR_3j
+  - 1l_m_dy_tautau_CR_4j
   cr_dy_tautau_e:
-    - 1l_e_dy_tautau_CR_2j
-    - 1l_e_dy_tautau_CR_3j
-    - 1l_e_dy_tautau_CR_4j
+  - 1l_e_dy_tautau_CR_2j
+  - 1l_e_dy_tautau_CR_3j
+  - 1l_e_dy_tautau_CR_4j
   cr_dy_tautau_m:
-    - 1l_m_dy_tautau_CR_2j
-    - 1l_m_dy_tautau_CR_3j
-    - 1l_m_dy_tautau_CR_4j
+  - 1l_m_dy_tautau_CR_2j
+  - 1l_m_dy_tautau_CR_3j
+  - 1l_m_dy_tautau_CR_4j
 SR_CHAN_DICT:
   2lss_SR:
-    - 2lss_4t_m_4j
-    - 2lss_4t_m_5j
-    - 2lss_4t_m_6j
-    - 2lss_4t_m_7j
-    - 2lss_4t_p_4j
-    - 2lss_4t_p_5j
-    - 2lss_4t_p_6j
-    - 2lss_4t_p_7j
-    - 2lss_m_4j
-    - 2lss_m_5j
-    - 2lss_m_6j
-    - 2lss_m_7j
-    - 2lss_p_4j
-    - 2lss_p_5j
-    - 2lss_p_6j
-    - 2lss_p_7j
+  - 2lss_4t_m_4j
+  - 2lss_4t_m_5j
+  - 2lss_4t_m_6j
+  - 2lss_4t_m_7j
+  - 2lss_4t_p_4j
+  - 2lss_4t_p_5j
+  - 2lss_4t_p_6j
+  - 2lss_4t_p_7j
+  - 2lss_m_4j
+  - 2lss_m_5j
+  - 2lss_m_6j
+  - 2lss_m_7j
+  - 2lss_p_4j
+  - 2lss_p_5j
+  - 2lss_p_6j
+  - 2lss_p_7j
   3l_offZ_SR:
-    - 3l_m_offZ_1b_2j
-    - 3l_m_offZ_1b_3j
-    - 3l_m_offZ_1b_4j
-    - 3l_m_offZ_1b_5j
-    - 3l_m_offZ_2b_2j
-    - 3l_m_offZ_2b_3j
-    - 3l_m_offZ_2b_4j
-    - 3l_m_offZ_2b_5j
-    - 3l_p_offZ_1b_2j
-    - 3l_p_offZ_1b_3j
-    - 3l_p_offZ_1b_4j
-    - 3l_p_offZ_1b_5j
-    - 3l_p_offZ_2b_2j
-    - 3l_p_offZ_2b_3j
-    - 3l_p_offZ_2b_4j
-    - 3l_p_offZ_2b_5j
+  - 3l_m_offZ_1b_2j
+  - 3l_m_offZ_1b_3j
+  - 3l_m_offZ_1b_4j
+  - 3l_m_offZ_1b_5j
+  - 3l_m_offZ_2b_2j
+  - 3l_m_offZ_2b_3j
+  - 3l_m_offZ_2b_4j
+  - 3l_m_offZ_2b_5j
+  # - 3l_m_offZ_high_1b_1j
+  # - 3l_m_offZ_high_1b_2j
+  # - 3l_m_offZ_high_1b_3j
+  # - 3l_m_offZ_high_1b_4j
+  # - 3l_m_offZ_high_1b_5j
+  # - 3l_m_offZ_high_2b_1j
+  # - 3l_m_offZ_high_2b_2j
+  # - 3l_m_offZ_high_2b_3j
+  # - 3l_m_offZ_high_2b_4j
+  # - 3l_m_offZ_high_2b_5j
+  # - 3l_m_offZ_low_1b_1j
+  # - 3l_m_offZ_low_1b_2j
+  # - 3l_m_offZ_low_1b_3j
+  # - 3l_m_offZ_low_1b_4j
+  # - 3l_m_offZ_low_1b_5j
+  # - 3l_m_offZ_low_2b_1j
+  # - 3l_m_offZ_low_2b_2j
+  # - 3l_m_offZ_low_2b_3j
+  # - 3l_m_offZ_low_2b_4j
+  # - 3l_m_offZ_low_2b_5j
+  # - 3l_m_offZ_none_1b_1j
+  # - 3l_m_offZ_none_1b_2j
+  # - 3l_m_offZ_none_1b_3j
+  # - 3l_m_offZ_none_1b_4j
+  # - 3l_m_offZ_none_1b_5j
+  # - 3l_m_offZ_none_2b_1j
+  # - 3l_m_offZ_none_2b_2j
+  # - 3l_m_offZ_none_2b_3j
+  # - 3l_m_offZ_none_2b_4j
+  # - 3l_m_offZ_none_2b_5j
+  - 3l_p_offZ_1b_2j
+  - 3l_p_offZ_1b_3j
+  - 3l_p_offZ_1b_4j
+  - 3l_p_offZ_1b_5j
+  - 3l_p_offZ_2b_2j
+  - 3l_p_offZ_2b_3j
+  - 3l_p_offZ_2b_4j
+  - 3l_p_offZ_2b_5j
+  # - 3l_p_offZ_high_1b_1j
+  # - 3l_p_offZ_high_1b_2j
+  # - 3l_p_offZ_high_1b_3j
+  # - 3l_p_offZ_high_1b_4j
+  # - 3l_p_offZ_high_1b_5j
+  # - 3l_p_offZ_high_2b_1j
+  # - 3l_p_offZ_high_2b_2j
+  # - 3l_p_offZ_high_2b_3j
+  # - 3l_p_offZ_high_2b_4j
+  # - 3l_p_offZ_high_2b_5j
+  # - 3l_p_offZ_low_1b_1j
+  # - 3l_p_offZ_low_1b_2j
+  # - 3l_p_offZ_low_1b_3j
+  # - 3l_p_offZ_low_1b_4j
+  # - 3l_p_offZ_low_1b_5j
+  # - 3l_p_offZ_low_2b_1j
+  # - 3l_p_offZ_low_2b_2j
+  # - 3l_p_offZ_low_2b_3j
+  # - 3l_p_offZ_low_2b_4j
+  # - 3l_p_offZ_low_2b_5j
+  # - 3l_p_offZ_none_1b_1j
+  # - 3l_p_offZ_none_1b_2j
+  # - 3l_p_offZ_none_1b_3j
+  # - 3l_p_offZ_none_1b_4j
+  # - 3l_p_offZ_none_1b_5j
+  # - 3l_p_offZ_none_2b_1j
+  # - 3l_p_offZ_none_2b_2j
+  # - 3l_p_offZ_none_2b_3j
+  # - 3l_p_offZ_none_2b_4j
+  # - 3l_p_offZ_none_2b_5j
   3l_onZ_SR:
-    - 3l_onZ_1b_2j
-    - 3l_onZ_1b_3j
-    - 3l_onZ_1b_4j
-    - 3l_onZ_1b_5j
-    - 3l_onZ_2b_2j
-    - 3l_onZ_2b_3j
-    - 3l_onZ_2b_4j
-    - 3l_onZ_2b_5j
+  - 3l_onZ_1b_1j
+  - 3l_onZ_1b_2j
+  - 3l_onZ_1b_3j
+  - 3l_onZ_1b_4j
+  - 3l_onZ_1b_5j
+  - 3l_onZ_2b_1j
+  - 3l_onZ_2b_2j
+  - 3l_onZ_2b_3j
+  - 3l_onZ_2b_4j
+  - 3l_onZ_2b_5j
   4l_SR:
-    - 4l_2j
-    - 4l_3j
-    - 4l_4j
-  4l_2j:
-    - 4l_2j
-  4l_3j:
-    - 4l_3j
-  4l_4j:
-    - 4l_4j
+  - 4l_2j
+  - 4l_3j
+  - 4l_4j
   2lss_1tau_onZ:
-    - 2lss_m_1tau_onZ_3j
-    - 2lss_m_1tau_onZ_4j
-    - 2lss_m_1tau_onZ_5j
-    - 2lss_m_1tau_onZ_6j
-    - 2lss_p_1tau_onZ_3j
-    - 2lss_p_1tau_onZ_4j
-    - 2lss_p_1tau_onZ_5j
-    - 2lss_p_1tau_onZ_6j
+  - 2lss_m_1tau_onZ_3j
+  - 2lss_m_1tau_onZ_4j
+  - 2lss_m_1tau_onZ_5j
+  - 2lss_m_1tau_onZ_6j
+  - 2lss_p_1tau_onZ_3j
+  - 2lss_p_1tau_onZ_4j
+  - 2lss_p_1tau_onZ_5j
+  - 2lss_p_1tau_onZ_6j
   2lss_1tau_offZ:
-    - 2lss_m_1tau_offZ_3j
-    - 2lss_m_1tau_offZ_4j
-    - 2lss_m_1tau_offZ_5j
-    - 2lss_m_1tau_offZ_6j
-    - 2lss_p_1tau_offZ_3j
-    - 2lss_p_1tau_offZ_4j
-    - 2lss_p_1tau_offZ_5j
-    - 2lss_p_1tau_offZ_6j
+  - 2lss_m_1tau_offZ_3j
+  - 2lss_m_1tau_offZ_4j
+  - 2lss_m_1tau_offZ_5j
+  - 2lss_m_1tau_offZ_6j
+  - 2lss_p_1tau_offZ_3j
+  - 2lss_p_1tau_offZ_4j
+  - 2lss_p_1tau_offZ_5j
+  - 2lss_p_1tau_offZ_6j
   2los_onZ_1tau:
-    - 2los_onZ_1tau_5j
-  3l_1tau_1b:
-    - 3l_1tau_1b_2j
-    - 3l_1tau_1b_3j
-    - 3l_1tau_1b_4j
-    - 3l_1tau_1b_5j
-  3l_1tau_2b:
-    - 3l_1tau_2b_2j
-    - 3l_1tau_2b_3j
-    - 3l_1tau_2b_4j
-    - 3l_1tau_2b_5j
+  - 2los_onZ_1tau_5j
+  2lss_1tau:
+  - 2lss_m_1tau_onZ_3j
+  - 2lss_p_1tau_offZ_3j
+  - 2lss_m_1tau_offZ_3j
+  - 2lss_p_1tau_onZ_3j
+  - 2lss_m_1tau_onZ_4j
+  - 2lss_p_1tau_offZ_4j
+  - 2lss_m_1tau_offZ_4j
+  - 2lss_p_1tau_onZ_4j
+  - 2lss_m_1tau_onZ_5j
+  - 2lss_p_1tau_offZ_5j
+  - 2lss_m_1tau_offZ_5j
+  - 2lss_p_1tau_onZ_5j
+  - 2lss_m_1tau_onZ_6j
+  - 2lss_p_1tau_offZ_6j
+  - 2lss_m_1tau_offZ_6j
+  - 2lss_p_1tau_onZ_6j
+  3l_offZ_fwd:
+  - 3l_m_offZ_1b_fwd_1j
+  - 3l_p_offZ_1b_fwd_1j
+  - 3l_m_offZ_2b_fwd_1j
+  - 3l_p_offZ_2b_fwd_1j
+  - 3l_m_offZ_1b_fwd_2j
+  - 3l_p_offZ_1b_fwd_2j
+  - 3l_m_offZ_2b_fwd_2j
+  - 3l_p_offZ_2b_fwd_2j
+  - 3l_m_offZ_1b_fwd_3j
+  - 3l_p_offZ_1b_fwd_3j
+  - 3l_m_offZ_2b_fwd_3j
+  - 3l_p_offZ_2b_fwd_3j
+  - 3l_m_offZ_1b_fwd_4j
+  - 3l_p_offZ_1b_fwd_4j
+  - 3l_m_offZ_2b_fwd_4j
+  - 3l_p_offZ_2b_fwd_4j
+  2lss:
+  - 2lss_p_4j
+  - 2lss_m_4j
+  - 2lss_4t_p_4j
+  - 2lss_4t_m_4j
+  - 2lss_p_5j
+  - 2lss_m_5j
+  - 2lss_4t_p_5j
+  - 2lss_4t_m_5j
+  - 2lss_p_6j
+  - 2lss_m_6j
+  - 2lss_4t_p_6j
+  - 2lss_4t_m_6j
+  - 2lss_p_7j
+  - 2lss_m_7j
+  - 2lss_4t_p_7j
+  - 2lss_4t_m_7j
+  2lss_fwd:
+  - 2lss_fwd_m_4j
+  - 2lss_fwd_m_5j
+  - 2lss_fwd_m_6j
+  - 2lss_fwd_m_7j
+  - 2lss_fwd_p_4j
+  - 2lss_fwd_p_5j
+  - 2lss_fwd_p_6j
+  - 2lss_fwd_p_7j
+  3l_1tau:
+  - 3l_1tau_1b_1j
+  - 3l_1tau_1b_2j
+  - 3l_1tau_1b_3j
+  - 3l_1tau_1b_4j
+  - 3l_1tau_1b_5j
+  - 3l_1tau_2b_1j
+  - 3l_1tau_2b_2j
+  - 3l_1tau_2b_3j
+  - 3l_1tau_2b_4j
+  - 3l_1tau_2b_5j
+  3l_onZ_fwd:
+  - 3l_onZ_1b_fwd_1j
+  - 3l_onZ_2b_fwd_1j
+  - 3l_onZ_1b_fwd_2j
+  - 3l_onZ_2b_fwd_2j
+  - 3l_onZ_1b_fwd_3j
+  - 3l_onZ_2b_fwd_3j
+  - 3l_onZ_1b_fwd_4j
+  - 3l_onZ_2b_fwd_4j
 CR_GRP_MAP:
   Data:
     color: black
     patterns:
-      - data
+    - data
   DY:
     color: tab:blue
     patterns:
-      - DY
+    - DY
   Ttbar:
     color: darkgreen
     patterns:
-      - TTTo
-      - TTto
+    - TTTo
+    - TTto
   ZGamma:
     color: tab:orange
     patterns:
-      - ZG
+    - ZG
   Diboson:
     color: tab:cyan
     patterns:
-      - WWTo2L2Nu
-      - ZZTo4L
-      - WZTo3LNu
-      - WZto3LNu
-      - ZZTo4mu
-      - ZZTo4tau
-      - ZZTo4e
-      - ZZTo2mu2tau
-      - ZZTo2e2tau
-      - ZZTo2e2mu
+    - WWTo2L2Nu
+    - ZZTo4L
+    - WZTo3LNu
+    - WZto3LNu
+    - ZZTo4mu
+    - ZZTo4tau
+    - ZZTo4e
+    - ZZTo2mu2tau
+    - ZZTo2e2tau
+    - ZZTo2e2mu
   Triboson:
     color: tab:purple
     patterns:
-      - WWW
-      - WWZ
-      - WZZ
-      - ZZZ
-  'Single top':
+    - WWW
+    - WWZ
+    - WZZ
+    - ZZZ
+  Single top:
     color: tab:pink
     patterns:
-      - ST
-      - tW
-      - tbarW
-      - TZQB-Zto2L
+    - ST
+    - tW
+    - tbarW
+    - TZQB-Zto2L
   tWZ:
     color: tab:gray
     patterns:
-      - TWZ
+    - TWZ
   Singleboson:
     color: tan
     patterns:
-      - WJets
+    - WJets
   Conv:
     color: mediumseagreen
     patterns:
-      - TTG
+    - TTG
   Nonprompt:
     color: tab:red
     patterns:
-      - nonprompt
+    - nonprompt
   Flips:
     color: brown
     patterns:
-      - flips
+    - flips
   Signal:
     color: yellowgreen
     patterns:
-      - ttH
-      - ttlnu
-      - TTLL
-      - ttll
-      - tllq
-      - tHq
-      - tttt
-      - TTZToLL_M1to10
-      - TTTT
-      - ttLNu
-  # WWTo2L2Nu:
-  #   color: brown
-  #   patterns:
-  #     - WWTo2L2Nu
-  # ZZTo4L:
-  #   color: goldenrod
-  #   patterns:
-  #     - ZZTo4L
-  # WZTo3LNu:
-  #   color: yellow
-  #   patterns:
-  #     - WZto3LNu
-  #     - WZTo3LNu
-  # ZZTo4mu:
-  #   color: darkviolet
-  #   patterns:
-  #     - ZZTo4mu
-  # ZZTo4tau:
-  #   color: olive
-  #   patterns:
-  #     - ZZTo4tau
-  # ZZTo4e:
-  #   color: coral
-  #   patterns:
-  #     - ZZTo4e
-  # ZZTo2mu2tau:
-  #   color: navy
-  #   patterns:
-  #     - ZZTo2mu2tau
-  # ZZTo2e2tau:
-  #   color: yellowgreen
-  #   patterns:
-  #     - ZZTo2e2tau
-  # ZZTo2e2mu:
-  #   color: aquamarine
-  #   patterns:
-  #     - ZZTo2e2mu
+    - ttH
+    - ttlnu
+    - TTLL
+    - ttll
+    - tllq
+    - tHq
+    - tttt
+    - TTZToLL_M1to10
+    - TTTT
+    - ttLNu
 SR_GRP_MAP:
   Data:
     color: black
     patterns:
-      - data
+    - data
   Nonprompt:
     color: tab:red
     patterns:
-      - nonprompt
+    - nonprompt
   Flips:
     color: brown
     patterns:
-      - flips
+    - flips
   ttH:
     color: tab:orange
     patterns:
-      - ttH
+    - ttH
   ttlnu:
     color: tab:cyan
     patterns:
-      - ttlnu
+    - ttlnu
   ttll:
     color: tab:purple
     patterns:
-      - ttll
-      - TTZToLL_M1to10
-      - TTToSemiLeptonic
-      - TTTo2L2Nu
+    - ttll
+    - TTZToLL_M1to10
+    - TTToSemiLeptonic
+    - TTTo2L2Nu
   tXq:
     color: tab:pink
     patterns:
-      - tllq
-      - tHq
+    - tllq
+    - tHq
   tttt:
     color: tan
     patterns:
-      - tttt
+    - tttt
   Conv:
     color: mediumseagreen
     patterns:
-      - TTG
+    - TTG
   Triboson:
     color: tab:purple
     patterns:
-      - WWW
-      - WWZ
-      - WZZ
-      - ZZZ
+    - WWW
+    - WWZ
+    - WZZ
+    - ZZZ
   tWZ:
     color: tab:gray
     patterns:
-      - TWZ
+    - TWZ
   Diboson:
     color: tab:cyan
     patterns:
-      - WWTo2L2Nu
-      - ZZTo4L
-      - WZTo3LNu
-      - WZto3LNu
-      - ZZTo4mu
-      - ZZTo4tau
-      - ZZTo4e
-      - ZZTo2mu2tau
-      - ZZTo2e2tau
-      - ZZTo2e2mu
+    - WWTo2L2Nu
+    - ZZTo4L
+    - WZTo3LNu
+    - WZto3LNu
+    - ZZTo4mu
+    - ZZTo4tau
+    - ZZTo4e
+    - ZZTo2mu2tau
+    - ZZTo2e2tau
+    - ZZTo2e2mu
 WCPT_EXAMPLE:
   ctW: -0.74
   ctZ: -0.86
@@ -409,26 +502,46 @@ WCPT_EXAMPLE:
   cQt8: -2.89
   cQt1: -1.24
 LUMI_COM_PAIRS:
-  '2016': ['35.9', '13']
-  '2016APV': ['19.5', '13']
-  '2017': ['41.5', '13']
-  '2018': ['59.8', '13']
-  '2022': ['7.98', '13.6']
-  '2022EE': ['26.67', '13.6']
-  '2023': ['17.79', '13.6']
-  '2023BPix': ['9.451', '13.6']
+  '2016':
+  - '35.9'
+  - '13'
+  2016APV:
+  - '19.5'
+  - '13'
+  '2017':
+  - '41.5'
+  - '13'
+  '2018':
+  - '59.8'
+  - '13'
+  '2022':
+  - '7.98'
+  - '13.6'
+  2022EE:
+  - '26.67'
+  - '13.6'
+  '2023':
+  - '17.79'
+  - '13.6'
+  2023BPix:
+  - '9.451'
+  - '13.6'
 PROC_WITHOUT_PDF_RATE_SYST:
-  - tttt
-  - ttll
-  - ttlnu
-  - Triboson
-  - tWZ
-  - convs
+- tttt
+- ttll
+- ttlnu
+- Triboson
+- tWZ
+- convs
 STACKED_RATIO_STYLE:
   defaults:
     figure:
-      figsize: [10, 8]
-      height_ratios: [4, 1]
+      figsize:
+      - 10
+      - 8
+      height_ratios:
+      - 4
+      - 1
       hspace: 0.07
     cms:
       fontsize: 18.0
@@ -442,14 +555,16 @@ STACKED_RATIO_STYLE:
       spine_width: 1.0
       y_offset: -0.07
       offset_fontsize: 18
-      ratio_label: "Ratio"
+      ratio_label: Ratio
       ratio_label_fontsize: 18
       ratio_label_margin: 0.002
       ticklabel_format:
         style: scientific
-        scilimits: [0, 6]
+        scilimits:
+        - 0
+        - 6
         useMathText: true
-      overflow_label: ">500"
+      overflow_label: '>500'
       apply_secondary_ticks:
         x: true
         y: true
@@ -460,14 +575,18 @@ STACKED_RATIO_STYLE:
       columnspacing: 0.8
       handletextpad: 0.6
       loc: upper center
-      bbox_to_anchor: [0.5, 1.0]
+      bbox_to_anchor:
+      - 0.5
+      - 1.0
       borderaxespad: 0.15
       top_margin_min: 0.01
       top_margin_scale: 0.25
       overlap_margin: 0.01
     uncertainty_legend:
       loc: upper right
-      bbox_to_anchor: [0.98, 0.98]
+      bbox_to_anchor:
+      - 0.98
+      - 0.98
       fontsize: 10
       ncol: 2
       columnspacing: 1.0
@@ -481,87 +600,57 @@ STACKED_RATIO_STYLE:
   per_region: {}
 REGION_PLOTTING:
   CR:
-    variable_label: "Var name"
+    variable_label: Var name
     skip_sparse_2d: false
-    # channel_mode selects how the plotting loop interprets the channel axis for
-    # every histogram that belongs to this region.  "aggregate" means that the
-    # per-category channel list from CR_CHAN_DICT is collapsed into a single
-    # combined template before the figure is rendered, reproducing the legacy
-    # behaviour where CR plots integrate over all flavours/jet bins inside a
-    # category.  Switching to "per-channel" (used by SR below) leaves the
-    # channel axis intact so that each entry in the region channel map generates
-    # its own figure.  Only these two literal values are supported; any other
-    # string will raise during RegionContext construction.
     channel_mode: aggregate
     skip_variables: []
     channel_transformations:
-      # channel_transformations provides an ordered recipe for rewriting the raw
-      # channel labels that come out of the histogram before any matching is
-      # performed.  The resolved instruction list is the concatenation of:
-      #   * default: unconditional transforms applied to every variable.
-      #   * variables: overrides keyed by the histogram name; the list given for
-      #     "njets" below strips jet-multiplicity suffixes only when we are
-      #     plotting the njets histogram.
-      #   * conditional: rules guarded by a boolean named condition.  Each entry
-      #     specifies a metadata flag (e.g. "not_split_by_lepflav") that maps to
-      #     an evaluator inside YieldTools.  When the condition returns true for
-      #     the histogram currently being processed, its "apply" list is appended
-      #     to the transformation sequence.  In the example we drop lepton-flavour
-      #     suffixes whenever the dataset is not split by flavour, ensuring that
-      #     the CR channel patterns still match the provided CR_CHAN_DICT keys.
       default: []
       variables:
         njets:
-          - njets
+        - njets
       conditional:
-        - when: not_split_by_lepflav
-          apply:
-            - lepflav
+      - when: not_split_by_lepflav
+        apply:
+        - lepflav
     sample_removals:
-      - categories:
-          prefixes:
-            - cr_2los_tt
-            - cr_2los_Z
-        groups:
-          - Nonprompt
+    - categories:
+        prefixes:
+        - cr_2los_tt
+        - cr_2los_Z
+      groups:
+      - Nonprompt
     category_skips:
-      - categories:
-          equals:
-            - cr_2los_Z
-        variable_includes:
-          - j0
-        variable_excludes:
-          - lj0pt
-      - categories:
-          equals:
-            - cr_2lss_flip
-        variable_includes:
-          - j0
-        variable_excludes:
-          - lj0pt
+    - categories:
+        equals:
+        - cr_2los_Z
+      variable_includes:
+      - j0
+      variable_excludes:
+      - lj0pt
+    - categories:
+        equals:
+        - cr_2lss_flip
+      variable_includes:
+      - j0
+      variable_excludes:
+      - lj0pt
     sumw2_remove_signal: true
     sumw2_remove_signal_when_blinded: false
     debug_channel_lists: false
     use_mc_as_data_when_blinded: false
   SR:
-    variable_label: "Variable"
+    variable_label: Variable
     skip_sparse_2d: true
-    # See the CR block above for the semantics of channel_mode.  SR keeps the
-    # channel axis explicit so every channel listed in SR_CHAN_DICT is rendered
-    # individually.
     channel_mode: per-channel
     skip_variables:
-      - ptz
-      - njets
+    - ptz
+    - njets
     channel_transformations:
-      # No SR-specific rewrites are required today, but the same rules described
-      # in the CR section above can be enabled here if future SR plots need to
-      # rename, strip, or otherwise rewrite channel labels before matching them
-      # to SR_CHAN_DICT.
       default: []
       variables:
         njets:
-          - njets
+        - njets
       conditional: []
     sample_removals: []
     category_skips: []

--- a/topeft/params/cr_sr_plots_metadata.yml
+++ b/topeft/params/cr_sr_plots_metadata.yml
@@ -559,7 +559,9 @@ REGION_PLOTTING:
       # rename, strip, or otherwise rewrite channel labels before matching them
       # to SR_CHAN_DICT.
       default: []
-      variables: {}
+      variables:
+        njets:
+          - njets
       conditional: []
     sample_removals: []
     category_skips: []


### PR DESCRIPTION
## Summary

This PR tightens the Run-2/Run-3 CR/SR plotting and configuration pipeline along three main axes:

- **Fix SR `njets` channel transforms to match CR behavior** so that validation, zero-yield scans, and aggregate plots all see a consistent channel basis.
- **Harden zero-yield reporting and process grouping**:
  - restrict plots and zero-yield scans to processes covered by the configured group map,
  - treat unmatched samples as “skipped” instead of silently creating ad-hoc groups,
  - make zero-yield reporting variable-aware and aligned with the per-region plotting metadata (including `skip_variables`).
- **Update Run-3 signal and background configuration**:
  - switch Run-3 signal cfgs to the new `samples_jsons` layout,
  - extend `YieldTools` mappings and lumi entries to cover `2022EE`, `2023`, and `2023BPix`,
  - modestly retune the coffea executor settings in `run_analysis.py` for more predictable memory and chunk handling.

A small **audit tool** is also added under `tools/` to cross-check CR/SR channel labels between `ch_lst.json` and `cr_sr_plots_metadata.yml`, and to (re)generate the SR metadata in a controlled way.

---

## Motivation

Recent tests around SR `njets` channels and zero-yield summaries exposed a few coupled issues:

- The **SR `njets` channel aggregation** was not aligned with CR behavior:
  - CRs use a dedicated `njets` transformation to collapse per-jet-bin channels into a combined template when plotting `njets`.
  - SRs did not consistently apply the same logic, leading to:
    - `validate_channel_group` checks that disagreed between CR and SR,
    - zero-yield summaries that flagged channels/bins in surprising ways.
- The **zero-yield reporting** logic was too global:
  - it did not track which processes are actually covered by the configured group map,
  - `skip_variables` in the YAML were not fully honoured for SR,
  - unmatched samples would leak into the scan as their own effective “groups”.
- For **Run-3**, the signal and background configuration had started to diverge:
  - new `2022EE` / `2023(BPix)` samples live under the `samples_jsons` layout and new naming,
  - `YieldTools` still only covered the earlier Run-2/early-Run-3 variants, so yield summaries and grouped plots did not fully reflect the Run-3 setup.
- Finally, **manual edits to SR channel metadata** are tedious and error-prone. Given that the processor already knows how to construct CR/SR channel labels, it’s cheaper to derive the YAML channel lists (and higher-level SR groups) from that source of truth.

This PR addresses these pain points while keeping analysis logic unchanged: it refines how we **organise and visualise** existing histograms, and how we **describe** channels/config in metadata.

---

## Implementation details

### A) SR/CR plotting and zero-yield semantics

**1. Group-aware process filtering**

- New helpers in `analysis/topeft_run2/make_cr_and_sr_plots.py`:

  - `_resolve_grouped_processes(group_map)`:
    - flattens the configured process group map into an ordered tuple of process names, de-duplicating along the way.
  - `_filter_process_axis(histogram, allowed_processes)`:
    - returns a histogram with any process *not* in `allowed_processes` removed,
    - no-ops when there is no `process` axis.

- In `_prepare_variable_payload(...)`:
  - after the nominal MC/data histograms (and optional `sumw2` clone) are built, they are **filtered** through the group map:
    - we resolve `allowed_processes` from `region_ctx.group_map`,
    - we apply `_filter_process_axis` to `hist_mc`, `hist_data`, and `hist_mc_sumw2_orig` (if present).
  - Effect: both plotting and zero-yield scans only see processes that are part of a configured group, reducing noise and avoiding ad-hoc single-process stacks.

**2. Unmatched processes: warn once, then skip**

- `populate_group_map(...)` changes semantics for unmatched samples:
  - Previously:
    - any sample that did not match a pattern was added as its own fallback group, with a per-sample warning.
    - this polluted the group map and made stacks/zero-yield output harder to interpret.
  - Now:
    - unmatched processes are collected in `unmatched`,
    - at the end we emit a single warning listing all unmatched names,
    - **no fallback groups are created**; these processes are simply omitted from grouping and downstream plots/zero-yield scans.
- Tests updated and renamed accordingly:
  - `test_unmatched_sample_is_skipped_from_group_map(...)` asserts:
    - `mysteryProcess` is **not** added to `group_map`,
    - the warning message includes the sample name and the word “skipping”,
    - stacked MC totals are computed from the matched/kept process only.

**3. Zero-yield summarisation becomes variable-aware**

- `_summarize_zero_yield_processes(...)` gains optional `region_ctx` and `variables` arguments.
  - When `region_ctx` is provided, we delegate to a new helper:

    ```python
    _summarize_zero_yield_processes_by_variable(
        dict_of_hists,
        region_ctx=region_ctx,
        variables=variables,
    )
    ```

- `_summarize_zero_yield_processes_by_variable(...)`:
  - resolves the list of variables to scan using `_resolve_requested_variables(...)` and the provided `variables` override,
  - respects `region_ctx.skip_variables` for both CR and SR,
  - uses `_prepare_variable_payload(..., metadata_only=True, ...)` per variable to obtain:
    - available channels,
    - channel transformations,
    - a consistent view of grouped processes,
  - for each variable:
    - for each SR/CR category, it:
      - **applies channel transforms** to map configured bin labels to available channel labels,
      - splits between `selected_bins` and `missing_bins`,
      - integrates per-process histograms over the selected bins and “nominal” systematic,
      - records processes with no content as zero-yield, distinguishing data-driven processes.
  - The resulting summary:
    - tracks `zero_process_total`, `data_driven_zero_total`,
    - collects per-channel, per-variable entries with both `missing_bins` and `zero_processes`,
    - tracks which data-driven prefixes were never seen.

- `_emit_zero_yield_summary(...)`:
  - when `detailed=True`, the output now includes the **variable name**:
    - entries are labelled as `region::channel [variable]` instead of just `region::channel`,
    - this makes it much easier to connect a zero-yield or missing-bin report to a specific histogram.

- New tests cover SR/CR variability and aggregation:

  - `test_sr_njets_channel_transform_matches_cr_behavior`:
    - builds a dummy `njets` hist with SR-like channel labels,
    - checks that SR `njets` channel transforms are present in the payload and validated by `validate_channel_group(...)`, mirroring CR semantics.
  - `test_sr_zero_yield_summary_respects_njets_aggregation`:
    - ensures that zero-yield scanning for SR `njets` respects the aggregated channel list and does not artificially mark bins as missing.
  - `test_sr_zero_yield_summary_flags_missing_channels_for_lj0pt`:
    - asserts that missing `njets` sub-bins (e.g. `2lss_4t_m_6j`) are correctly surfaced in `missing_bins` while present ones are not.
  - `test_sr_zero_yield_summary_respects_skip_variables` and
    `test_cr_zero_yield_summary_respects_skip_variables`:
    - confirm that `skip_variables` in `REGION_PLOTTING` are honoured during the scan.
  - `test_cr_zero_yield_summary_reports_variable_and_missing_bins`:
    - exercises the per-variable reporting and missing-bins logic in a CR context.
  - `test_sr_zero_yield_skips_unmatched_processes` and
    `test_cr_zero_yield_skips_unmatched_processes`:
    - verify that unmatched samples (w.r.t. group patterns) are warned about but **not** included in the zero-yield tally.

**4. SR `njets` and SR metadata wiring**

- In `REGION_PLOTTING["SR"]`:
  - `channel_transformations.variables` now defines a dedicated rule for `"njets"`:
    - this mirrors the CR configuration and ensures that when plotting `njets`, we collapse the jet-bin suffixes in a controlled way.
  - `skip_variables` for SR now explicitly includes:
    - `ptz` and `njets` (for standard SR plots),
    - and is **always honoured**, independent of the `enable_category_skips` flag that controls the more specialised `category_skips`.
- `build_region_context(...)`:
  - `skip_variables` are now always derived from the YAML, without being gated by `enable_category_skips`.
  - This allows us to selectively opt variables out of both plotting and zero-yield scans via metadata alone.

**5. Blinded SR aggregates use MC when data is structurally empty**

- In `_render_variable_category(...)`, both for:
  - the sparse 2D plot path, and
  - the stacked/ratio 1D plot path,
  we now compute:

  ```python
  hist_data_like = (
      hist_data_nominal_or_integrated
      if (unblind_flag or not region_ctx.use_mc_as_data_when_blinded)
      else hist_mc_nominal_or_integrated
  )
  ```

- We then:
  - require that **either** MC **or** data-like has content before attempting to plot,
  - feed `hist_data_like` (rather than raw data) into `make_sparse2d_fig(...)` and `make_region_stacked_ratio_fig(...)`.
- New test:
  - `test_sr_aggregate_blinded_uses_mc_when_data_empty(...)`:
    - builds an SR-like `njets` histogram with non-zero MC and structurally zero data,
    - runs `run_plots_for_region(...)` with `unblind=False`,
    - asserts that the expected SR aggregate directory exists and that an `*_njets.png` file is produced.

---

### B) CR/SR channel audit tool and SR metadata regeneration

**1. `tools/audit_cr_channels_from_processor.py`**

A new standalone script that acts as a bridge between:

- the **processor’s** channel construction logic (`ch_lst.json`), and
- the **plotting metadata** (`topeft/params/cr_sr_plots_metadata.yml`).

Key components:

- Region specs:

  ```python
  REGION_SPECS = {
      "CR": {
          "ch_lst_keys": ("CH_LST_CR", "TAU_CH_LST_CR"),
          "yaml_key": "CR_CHAN_DICT",
          "split_lep_flavor": True,
      },
      "SR": {
          "ch_lst_keys": (),
          "ch_lst_match": "CH_LST_SR",
          "yaml_key": "SR_CHAN_DICT",
          "split_lep_flavor": False,
      },
  }
  ```

- Channel construction:
  - `_construct_cat_name(...)` and `_jet_cat_to_key(...)` implement the same naming scheme as `AnalysisProcessor.construct_cat_name`, including:
    - flavour expansion (for CR),
    - jet category encodings (`exactly_Xj`, `atmost_Xj`, `atleast_Xj`).
  - `build_channel_labels_from_ch_cfg(...)`:
    - reconstructs, per region, the full set of channel labels that the processor can produce, grouped by “base” category.

- SR semantic groups:
  - `SR_TAG_GROUP_RULES` defines high-level, physics-driven SR categories like:
    - `2lss_SR`, `2lss_fwd`, `2lss_1tau_onZ`, `2lss_1tau_offZ`,
    - `3l_onZ_SR`, `3l_offZ_SR`, `3l_1tau`, `3l_onZ_fwd`,
    - `4l_SR`, `2los_onZ_1tau`,
  - `_build_semantic_sr_groups(...)` maps base channels into these groups using simple `require` / `forbid` tag rules.

- Comparison and reporting:
  - `_collect_region_data(...)`:
    - compares the processor’s channel labels to the YAML’s `CR_CHAN_DICT` / `SR_CHAN_DICT`,
    - computes labels **only in processor**, **only in YAML**, and per-base summaries.
  - `_print_region_report(...)`:
    - prints a human-readable report, helping spot missing or stale entries.

- YAML augmentation:
  - `_augment_channel_dict(...)` merges processor-known labels into the YAML block, tracking how many labels and bases were added.
  - `_postprocess_sr_groups(...)`:
    - renames `3l_fwd` → `3l_onZ_fwd` (the content is on-Z only),
    - drops redundant global bases (`3l`, `4l`, `2los_1tau`, and now `2l`), which are fully covered by more semantic groups.
  - `main()` supports:
    - read-only audit mode (default),
    - and an augmentation mode:
      - CR: leaves `CR_CHAN_DICT` untouched (audit only),
      - SR: augments `SR_CHAN_DICT` from processor + semantic groups + cleanup, and writes to `--out-meta-yaml`.

**2. Metadata changes in `cr_sr_plots_metadata.yml`**

The YAML diff reflects:

- **No behavioural change for CR**:
  - `CR_CHAN_DICT` is preserved (apart from formatting/indentation),
  - `CR_GRP_MAP`, `DATA_ERR_OPS`, etc. are re-formatted but semantically identical.

- **SR channel dictionary refined and extended**:
  - `SR_CHAN_DICT` now reflects the script-derived channel lists and semantic groupings, including:
    - robust definitions for `2lss_SR`, `3l_onZ_SR`, `3l_offZ_SR`, `4l_SR`,
    - a new **combined** `2lss_1tau` group (no 1b/2b split at the group level),
    - refined forward/leptonic groups like `2lss_fwd`, `3l_onZ_fwd`, `3l_offZ_fwd`,
    - a combined `3l_1tau` group.
  - Obsolete fixed-jet groups like `4l_2j`, `4l_3j`, `4l_4j` are removed in favour of `4l_SR`.

- **Lumi and style metadata updates**:
  - `LUMI_COM_PAIRS` now includes entries for:
    - `2022EE`, `2023`, `2023BPix`,
  - YAML has been normalised (explicit lists and scalars), but the plotting style (`STACKED_RATIO_STYLE`, `CR_GRP_MAP`, `SR_GRP_MAP`) is unchanged except for these small lumi and grouping extensions.

---

### C) Run-3 samples, `YieldTools` process mapping, and lumi coverage

**1. Signal sample cfgs: `input_samples/cfgs/NDSkim_*_signal_samples.cfg`**

For each of:

- `NDSkim_2022_signal_samples.cfg`
- `NDSkim_2022EE_signal_samples.cfg`
- `NDSkim_2023_signal_samples.cfg`
- `NDSkim_2023BPix_signal_samples.cfg`

we:

- **comment out** the old `ND_skim20XX[...]` entries under `input_samples/sample_jsons/signal_samples/...`,
- **replace** them with the new `samples_jsons` layout and naming, e.g.:

  ```text
  ../../input_samples/samples_jsons/signal_samples/ND_skim2022/2022_tHq.json
  ../../input_samples/samples_jsons/signal_samples/ND_skim2022/2022_tllq.json
  ../../input_samples/samples_jsons/signal_samples/ND_skim2022/2022_ttH.json
  ../../input_samples/samples_jsons/signal_samples/ND_skim2022/2022_ttll.json
  ../../input_samples/samples_jsons/signal_samples/ND_skim2022/2022_ttlnu.json
  ../../input_samples/samples_jsons/signal_samples/ND_skim2022/2022_tttt.json
  ```

- This keeps the Run-3 signal cfgs aligned with the current ND skims and dataset names for `tHq`, `tllq`, `ttH`, `ttll`, `ttlnu`, `tttt` across `2022`, `2022EE`, `2023`, and `2023BPix`.

**2. `topeft/modules/yield_tools.py`: `PROC_MAP` updates**

The grouped process mapping is extended to cover the new Run-3 variants and to stay in sync with the `samples_jsons` naming. Highlights:

- Signal-like top processes now include:

  - `ttlnu`:
    - legacy UL16/UL17/UL18 and private UL samples,
    - plus `ttW_central2022`, `ttW_central2022EE`, `ttW_central2023`, `ttW_central2023BPix`,
    - plus `ttlnu_private2022`, `ttlnu_private2022EE`, `ttlnu_private2023`, `ttlnu_private2023BPix`.
  - `ttll`:
    - UL + private samples,
    - `TTLL_MLL-[4to50,50]_central2022/2022EE/2023/2023BPix`,
    - and `ttll_private20XX(EE/BPix)`.
  - `ttH`, `tllq`, `tHq`, `tttt`:
    - same pattern: UL (central + private) plus `central2022`, `central2022EE`, `central2023`, `central2023BPix` and `private20XX(EE/BPix)`.

- EW processes and backgrounds:

  - `conv`:
    - `TTGamma_central2022EE`, `TTGamma_central2023`, `TTGamma_central2023BPix`.
  - `WW`, `WZ`, `ZZ`, `WWW`, `WWZ`, `WZZ`, `ZZZ`, `tWZ`:
    - extended to include `2022EE`, `2023`, `2023BPix`.
  - `ttZlowMll`, `ttbarll`, `ttbarsl`:
    - extended with `central2022EE`, `central2023`, `central2023BPix` variants.
  - `data`:
    - now covers `data2022`, `data2022EE`, `data2023`, `data2023BPix`.

This ensures that:

- yield summaries and grouped SR/CR plots treat all Run-3 central/private samples consistently with Run-2,
- no Run-3 dataset gets silently dropped or mis-grouped because it was missing from `PROC_MAP`.

**3. Lumi map**

- `LUMI_COM_PAIRS` is updated to include:

  ```yaml
  '2022':    ['7.98',   '13.6']
  2022EE:    ['26.67',  '13.6']
  '2023':    ['17.79',  '13.6']
  2023BPix:  ['9.451',  '13.6']
  ```

so the per-year plots for Run-3 use the correct COM energy and integrated lumi.

---

### D) Executor tuning and `AnalysisProcessor` plumbing

**1. `run_analysis.py` executor config**

Within the coffea `work_queue` / executor configuration:

- `compression` is tightened from `8` → `9` for the chunks results, which:
  - slightly improves disk usage for large result trees,
  - at the cost of a marginally higher CPU cost during serialization (acceptable for the current workload).
- Tree reduction settings are adjusted:

  - legacy:

    ```python
    "treereduction": 10,
    ```

  - new:

    ```python
    # "treereduction": 10,
    "chunks_per_accum": 25,
    "chunks_accum_in_mem": 2,
    ```

- This moves us to a more explicit chunk-accumulation model:
  - caps the number of chunks per accumulation step (25),
  - limits how many accumulations are kept in memory at once (2),
  - improving memory predictability while still allowing decent batching for performance.

**2. `analysis_processor.AnalysisProcessor` constructor**

- Constructor signature extended with an `all_analysis` flag:

  ```python
  def __init__(..., fwd_analysis=False, all_analysis=False, useRun3MVA=True, ...)
  ```

- Stored as `self.all_analysis`, alongside the existing `tau_h_analysis` / `fwd_analysis` flags.
- This mirrors higher-level run modes and keeps the processor ready for configurations that want to drive all (SR/CR/forward/tau) analyses from a single knob.

---

## Testing

Ran (targeted):

- `python -m compileall analysis/topeft_run2 topeft/modules tools`
- `pytest -q tests/test_make_cr_and_sr_plots.py`

Notes:

- The new tests are intentionally scoped to `make_cr_and_sr_plots` and the grouping/zero-yield logic; they do not exercise the full analysis chain or the full Run-3 sample configuration.
- A full test sweep (including heavy hist tests) may require the usual environment setup (CMSSW / coffea / awkward / full sample JSONs) and may take significantly longer to run.

---

## Review notes

- **Analysis logic is unchanged**: no selection cuts or event weights are modified. All changes either:
  - adjust how existing histograms are grouped/plotted,
  - or update configuration for known Run-3 datasets.
- The **new audit tool** is self-contained under `tools/`:
  - it reads `ch_lst.json` and `cr_sr_plots_metadata.yml`,
  - and only writes an output YAML when invoked with `--write-augmented-yaml` and `--out-meta-yaml`.
  - It is not used at runtime.
- The **SR/CR plotting changes** are guarded by unit tests:
  - unmatched processes are now warned-about but skipped, not grouped,
  - SR `njets` transforms and zero-yield summaries are validated explicitly,
  - SR/CR `skip_variables` behaviour is tested.
- Please pay particular attention to:
  - the `SR_CHAN_DICT` content (now derived + semantic groups),
  - the Run-3 `NDSkim_*_signal_samples.cfg` paths,
  - and the expanded `PROC_MAP` entries in `YieldTools`, to confirm they match the current naming conventions on ND skims.
