### PR TITLE
Env: prevent NumPy ABI breakage from PYTHONPATH contamination

### DIFF
--- a/docs/environment_packaging.md
+++ b/docs/environment_packaging.md
@@ -12,12 +12,14 @@ resolve `topcoffea.modules` without manual `PYTHONPATH` tweaks.  Once the import
 works, walk through the standard refresh steps:
 
 To avoid accidental NumPy ABI breakage from CVMFS/system site-packages, the
-environment now clears `PYTHONPATH` and sets `PYTHONNOUSERSITE=1` (plus
-`PYTHONSAFEPATH=1` on Python versions that honor it). A quick diagnosis is:
+environment now clears `PYTHONPATH` and sets `PYTHONNOUSERSITE=1`. A quick
+diagnosis is:
 
        python -c "import numpy; print(numpy.__file__)"
 
 This should point inside the active conda env, not `/usr/lib*` or `/cvmfs`.
+The regression guardrail lives in `tests/test_numpy_abi_import.py` and enforces
+this path-based check with extra diagnostics if it fails.
 
 1. Recreate the local Conda environment so the lock file matches the new pins::
 

--- a/docs/environment_packaging.md
+++ b/docs/environment_packaging.md
@@ -12,16 +12,26 @@ resolve `topcoffea.modules` without manual `PYTHONPATH` tweaks.  Once the import
 works, walk through the standard refresh steps:
 
 To avoid accidental NumPy ABI breakage from CVMFS/system site-packages, the
-environment now clears `PYTHONPATH` and sets `PYTHONNOUSERSITE=1`. These
-variables are applied by conda on **environment activation**, so you must
-update/recreate the env and re-activate it for changes to take effect.
+environment now clears `PYTHONPATH` and sets `PYTHONNOUSERSITE=1` in the
+`environment.yml` `variables:` block. These variables are applied by conda on
+**environment activation**, so you must update/recreate the env and
+re-activate it for changes to take effect.
+
+Environment spec policy: `environment.yml` is the single source of truth for
+the conda environment definition. Any `conda_spec.yml` file is a generated
+artifact (if present locally) and is ignored; do not edit it manually and do
+not expect it to be versioned in git.
 
 Copy/paste refresh steps:
 
        conda env update -f environment.yml --prune
        conda activate coffea2025
 
-A quick diagnosis is:
+How to diagnose (recommended):
+
+       PYTHONPATH="" PYTHONNOUSERSITE=1 $PYTHON_ENV scripts/diagnose_numpy_env.py
+
+If you need a quick inlined check instead:
 
        python -c "import numpy, sys; print(sys.executable); print(sys.prefix); print(numpy.__file__)"
 

--- a/docs/environment_packaging.md
+++ b/docs/environment_packaging.md
@@ -11,6 +11,14 @@ The CI workflow runs the same smoke test to confirm downstream scripts can
 resolve `topcoffea.modules` without manual `PYTHONPATH` tweaks.  Once the import
 works, walk through the standard refresh steps:
 
+To avoid accidental NumPy ABI breakage from CVMFS/system site-packages, the
+environment now clears `PYTHONPATH` and sets `PYTHONNOUSERSITE=1` (plus
+`PYTHONSAFEPATH=1` on Python versions that honor it). A quick diagnosis is:
+
+       python -c "import numpy; print(numpy.__file__)"
+
+This should point inside the active conda env, not `/usr/lib*` or `/cvmfs`.
+
 1. Recreate the local Conda environment so the lock file matches the new pins::
 
        conda env update -f environment.yml --prune

--- a/docs/environment_packaging.md
+++ b/docs/environment_packaging.md
@@ -12,14 +12,28 @@ resolve `topcoffea.modules` without manual `PYTHONPATH` tweaks.  Once the import
 works, walk through the standard refresh steps:
 
 To avoid accidental NumPy ABI breakage from CVMFS/system site-packages, the
-environment now clears `PYTHONPATH` and sets `PYTHONNOUSERSITE=1`. A quick
-diagnosis is:
+environment now clears `PYTHONPATH` and sets `PYTHONNOUSERSITE=1`. These
+variables are applied by conda on **environment activation**, so you must
+update/recreate the env and re-activate it for changes to take effect.
 
-       python -c "import numpy; print(numpy.__file__)"
+Copy/paste refresh steps:
+
+       conda env update -f environment.yml --prune
+       conda activate coffea2025
+
+A quick diagnosis is:
+
+       python -c "import numpy, sys; print(sys.executable); print(sys.prefix); print(numpy.__file__)"
 
 This should point inside the active conda env, not `/usr/lib*` or `/cvmfs`.
 The regression guardrail lives in `tests/test_numpy_abi_import.py` and enforces
 this path-based check with extra diagnostics if it fails.
+
+For reproducible verification, run from the repo root or use absolute paths:
+
+       cd /users/apiccine/work/ChUpdate/topeft
+       PYTHONPATH="" PYTHONNOUSERSITE=1 $PYTHON_ENV -m pytest -q \
+         /users/apiccine/work/ChUpdate/topeft/tests/test_numpy_abi_import.py
 
 1. Recreate the local Conda environment so the lock file matches the new pins::
 

--- a/environment.yml
+++ b/environment.yml
@@ -20,4 +20,3 @@ dependencies:
 variables:
   PYTHONPATH: ""
   PYTHONNOUSERSITE: "1"
-  PYTHONSAFEPATH: "1"

--- a/environment.yml
+++ b/environment.yml
@@ -17,3 +17,7 @@ dependencies:
   - pip
   - pip:
       - dynamic_data_reduction>=2025.12.1
+variables:
+  PYTHONPATH: ""
+  PYTHONNOUSERSITE: "1"
+  PYTHONSAFEPATH: "1"

--- a/scripts/diagnose_numpy_env.py
+++ b/scripts/diagnose_numpy_env.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Diagnose NumPy import location and PYTHONPATH contamination.
+
+This checks that NumPy is imported from the active conda environment and not
+from system/CVMFS locations that can trigger ABI mismatches. It prints key
+environment details and exits non-zero on violations.
+
+Example:
+  PYTHONPATH="" PYTHONNOUSERSITE=1 $PYTHON_ENV scripts/diagnose_numpy_env.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+def _real(path: str) -> str:
+    return os.path.realpath(path)
+
+
+def _line(label: str, value: object) -> None:
+    print(f"{label}={value}")
+
+
+def main() -> int:
+    exe = sys.executable
+    prefix = sys.prefix
+    exe_real = _real(exe)
+    prefix_real = _real(prefix)
+    numpy_import_error = None
+    try:
+        import numpy as np  # pylint: disable=import-error
+    except Exception as exc:
+        numpy_import_error = f"{type(exc).__name__}: {exc}"
+        numpy_version = "(import failed)"
+        numpy_file = "(import failed)"
+        numpy_real = "(import failed)"
+    else:
+        numpy_version = np.__version__
+        numpy_file = np.__file__
+        numpy_real = _real(numpy_file)
+    pythonpath = os.environ.get("PYTHONPATH") or "(unset)"
+
+    _line("sys.executable", exe)
+    _line("sys.executable_realpath", exe_real)
+    _line("sys.prefix", prefix)
+    _line("sys.prefix_realpath", prefix_real)
+    _line("PYTHONPATH", pythonpath)
+    _line("sys.path[:20]", sys.path[:20])
+    _line("numpy.__version__", numpy_version)
+    _line("numpy.__file__", numpy_file)
+    _line("numpy.__file__realpath", numpy_real)
+
+    disallowed_prefixes = ("/usr/lib", "/usr/lib64", "/cvmfs")
+    errors: list[str] = []
+    if numpy_import_error is not None:
+        errors.append(f"numpy import failed ({numpy_import_error})")
+    if numpy_import_error is None:
+        if numpy_real.startswith(disallowed_prefixes):
+            errors.append(
+                "numpy loaded from disallowed system path "
+                f"(prefixes={disallowed_prefixes}, path={numpy_real})"
+            )
+        if not numpy_real.startswith(prefix_real + os.sep):
+            errors.append(
+                "numpy is not under the active sys.prefix "
+                f"(prefix={prefix_real}, path={numpy_real})"
+            )
+
+    if errors:
+        _line("validation", "FAIL")
+        for err in errors:
+            _line("error", err)
+        return 1
+
+    _line("validation", "OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_numpy_abi_import.py
+++ b/tests/test_numpy_abi_import.py
@@ -1,14 +1,25 @@
 import os
+import sys
 
 import numpy as np
+
+
+def _diagnostics() -> str:
+    return "\n".join(
+        [
+            f"numpy.__file__={np.__file__}",
+            f"numpy.__version__={np.__version__}",
+            f"sys.executable={sys.executable}",
+            f"sys.prefix={sys.prefix}",
+            f"sys.path[:15]={sys.path[:15]}",
+        ]
+    )
 
 
 def test_numpy_import_uses_env_site_packages():
     path = os.path.realpath(np.__file__)
     disallowed_prefixes = ("/usr/lib", "/usr/lib64", "/cvmfs")
     assert not path.startswith(disallowed_prefixes), (
-        f"numpy loaded from disallowed system path: {path}"
-    )
-    assert not np.__version__.startswith("1."), (
-        f"unexpected numpy version: {np.__version__}"
+        "numpy loaded from disallowed system path:\n"
+        f"  path={path}\n{_diagnostics()}"
     )

--- a/tests/test_numpy_abi_import.py
+++ b/tests/test_numpy_abi_import.py
@@ -4,13 +4,16 @@ import sys
 import numpy as np
 
 
-def _diagnostics() -> str:
+def _diagnostics(prefix_realpath: str, np_path: str) -> str:
     return "\n".join(
         [
             f"numpy.__file__={np.__file__}",
             f"numpy.__version__={np.__version__}",
             f"sys.executable={sys.executable}",
             f"sys.prefix={sys.prefix}",
+            f"prefix_realpath={prefix_realpath}",
+            f"np_path_realpath={np_path}",
+            f"np_path_under_prefix={np_path.startswith(prefix_realpath + os.sep)}",
             f"sys.path[:15]={sys.path[:15]}",
         ]
     )
@@ -18,8 +21,13 @@ def _diagnostics() -> str:
 
 def test_numpy_import_uses_env_site_packages():
     path = os.path.realpath(np.__file__)
+    prefix_realpath = os.path.realpath(sys.prefix)
     disallowed_prefixes = ("/usr/lib", "/usr/lib64", "/cvmfs")
     assert not path.startswith(disallowed_prefixes), (
         "numpy loaded from disallowed system path:\n"
-        f"  path={path}\n{_diagnostics()}"
+        f"  path={path}\n{_diagnostics(prefix_realpath, path)}"
+    )
+    assert path.startswith(prefix_realpath + os.sep), (
+        "numpy is not coming from the active environment prefix:\n"
+        f"  path={path}\n{_diagnostics(prefix_realpath, path)}"
     )

--- a/tests/test_numpy_abi_import.py
+++ b/tests/test_numpy_abi_import.py
@@ -1,0 +1,14 @@
+import os
+
+import numpy as np
+
+
+def test_numpy_import_uses_env_site_packages():
+    path = os.path.realpath(np.__file__)
+    disallowed_prefixes = ("/usr/lib", "/usr/lib64", "/cvmfs")
+    assert not path.startswith(disallowed_prefixes), (
+        f"numpy loaded from disallowed system path: {path}"
+    )
+    assert not np.__version__.startswith("1."), (
+        f"unexpected numpy version: {np.__version__}"
+    )


### PR DESCRIPTION
### Summary

This PR fixes a recurring NumPy ABI/import crash caused by **system/CVMFS Python site-packages being injected ahead of the active conda environment** (via `PYTHONPATH`). When that happens, Python 3.13 can import an incompatible system NumPy (e.g. from `/usr/lib64/python3.9/...`) and fail at import time.

The fix is **environment isolation (no code shims)** plus a small regression guardrail and a helper diagnostic script.

### What changed

* **Conda env guardrails**

  * `environment.yml`: add activation variables:

    * `PYTHONPATH: ""`
    * `PYTHONNOUSERSITE: "1"`
  * This ensures conda’s site-packages take precedence and prevents accidental leakage from system/CVMFS locations.

* **Diagnostics**

  * New `scripts/diagnose_numpy_env.py`:

    * Prints key runtime/env details (`sys.executable`, `sys.prefix`, `sys.path`, NumPy path/version).
    * **Fails non-zero** if NumPy is imported from disallowed prefixes (`/usr/lib*`, `/cvmfs`) or outside `sys.prefix`.

* **Regression test**

  * New `tests/test_numpy_abi_import.py`:

    * Asserts NumPy is **not** imported from `/usr/lib*` or `/cvmfs`.
    * Asserts NumPy is **under the active `sys.prefix`**.
    * Includes rich diagnostics on failure.

* **Documentation**

  * `docs/environment_packaging.md`:

    * Explains why the guardrails exist and that conda `variables:` apply on **environment activation** (recreate/update + re-activate required).
    * States policy: `environment.yml` is the **single source of truth**; any `conda_spec.yml` is **generated/ignored** and not expected to be versioned.
    * Adds recommended diagnostic and reproducible verification commands.

### How to verify locally

After updating/recreating and re-activating the env:

```bash
conda env update -f environment.yml --prune
conda activate coffea2025
```

Run the diagnostic helper:

```bash
python scripts/diagnose_numpy_env.py
```

Run the regression test:

```bash
python -m pytest -q tests/test_numpy_abi_import.py
```

### Why this approach

* Fixes the **actual root cause** (path contamination) at the environment level.
* Adds **fast, explicit guardrails** to prevent regressions.
* Avoids long-lived compatibility shims or wrappers.

### Notes

* The helper and test are intentionally **path-based** (no strict version pinning), focusing on ensuring imports come from the active environment.
* If you attempt to execute the helper as `scripts/diagnose_numpy_env.py` directly, ensure it is executable; otherwise run it via `python scripts/diagnose_numpy_env.py`.

### Files changed

* `environment.yml`
* `docs/environment_packaging.md`
* `scripts/diagnose_numpy_env.py` *(new)*
* `tests/test_numpy_abi_import.py` *(new)*
