### PR TITLE
Refactor: polish HistEFT usage and eliminate remaining legacy patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ summarises the setup steps and links to the TaskVine environment packaging guide
 All CLI entry points validate that the `topcoffea` branch matches
 `ch_update_calcoffea` (or the release tag you specify via `TOPCOFFEA_BRANCH`).
 
-### Legacy HistEFT support
+### HistEFT support
 
 The repository now expects the `topcoffea` package to be installed in the active
 environment instead of shipping a partial vendor copy. The upstream project still
-exposes the legacy `HistEFT` helpers via `topcoffea.modules.HistEFT`, so existing
+exposes `HistEFT` via `topcoffea.modules.histEFT`, so existing
 imports keep working once the dependency is installed. CI includes a smoke test
 that asserts `import topcoffea` resolves outside the `topeft` checkout—remove any
 stray `topcoffea/` directories under this repository and reinstall the sibling

--- a/analysis/training/intro_coffea.hist.ipynb
+++ b/analysis/training/intro_coffea.hist.ipynb
@@ -746,7 +746,7 @@
     "import coffea\n",
     "from coffea import hist\n",
     "import topcoffea\n",
-    "HistEFT = topcoffea.modules.HistEFT.HistEFT\n",
+    "HistEFT = topcoffea.modules.histEFT.HistEFT\n",
     "efth = topcoffea.modules.eft_helper\n",
     "import gzip #read zipped pickle file\n",
     "import matplotlib.pyplot as plt #plot histograms\n",
@@ -1134,7 +1134,7 @@
     }
    },
    "source": [
-    "# topcoffea.modules.HistEFT"
+    "# topcoffea.modules.histEFT"
    ]
   },
   {

--- a/docs/run_analysis_configuration.md
+++ b/docs/run_analysis_configuration.md
@@ -269,7 +269,7 @@ switching executors once the run is ready to scale beyond the local machine.
   paths were provided.  Always invoke ``run_analysis.py`` from the repository
   root or supply absolute paths.
 * If histogram handling fails with an ``ImportError`` noting that
-  ``topcoffea.modules.histEFT``/``topcoffea.modules.HistEFT`` is missing, confirm
+  ``topcoffea.modules.histEFT`` is missing, confirm
   that your sibling ``topcoffea`` checkout is on the ``ch_update_calcoffea``
   branch (or matching tag) and reinstall it with ``pip install -e ../topcoffea``
   before retrying the run.

--- a/tests/test_analysis_processor_jetmet_cacheless.py
+++ b/tests/test_analysis_processor_jetmet_cacheless.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from coffea.nanoevents import BaseSchema, NanoEventsFactory
 
-_hist_eft_stub = types.ModuleType("topcoffea.modules.HistEFT")
+_hist_eft_stub = types.ModuleType("topcoffea.modules.histEFT")
 
 
 class _DummyHistEFT:
@@ -21,8 +21,8 @@ class _DummyHistEFT:
 _hist_eft_stub.HistEFT = _DummyHistEFT
 importlib.import_module("topcoffea")
 modules_pkg = importlib.import_module("topcoffea.modules")
-modules_pkg.HistEFT = _hist_eft_stub  # type: ignore[attr-defined]
-sys.modules["topcoffea.modules.HistEFT"] = _hist_eft_stub
+modules_pkg.histEFT = _hist_eft_stub  # type: ignore[attr-defined]
+sys.modules["topcoffea.modules.histEFT"] = _hist_eft_stub
 sys.modules["topcoffea.modules.histEFT"] = _hist_eft_stub
 
 import analysis.topeft_run2.analysis_processor as ap

--- a/tests/test_analysis_processor_variations.py
+++ b/tests/test_analysis_processor_variations.py
@@ -5,7 +5,7 @@ import awkward as ak
 import numpy as np
 import pytest
 
-_hist_eft_stub = types.ModuleType("topcoffea.modules.HistEFT")
+_hist_eft_stub = types.ModuleType("topcoffea.modules.histEFT")
 
 
 class _DummyHistEFT:
@@ -19,8 +19,8 @@ class _DummyHistEFT:
 _hist_eft_stub.HistEFT = _DummyHistEFT
 importlib.import_module("topcoffea")
 modules_pkg = importlib.import_module("topcoffea.modules")
-modules_pkg.HistEFT = _hist_eft_stub  # type: ignore[attr-defined]
-sys.modules["topcoffea.modules.HistEFT"] = _hist_eft_stub
+modules_pkg.histEFT = _hist_eft_stub  # type: ignore[attr-defined]
+sys.modules["topcoffea.modules.histEFT"] = _hist_eft_stub
 sys.modules["topcoffea.modules.histEFT"] = _hist_eft_stub
 
 _corrected_jets_stub = types.ModuleType("topcoffea.modules.CorrectedJetsFactory")

--- a/tests/test_flavor_split_histograms.py
+++ b/tests/test_flavor_split_histograms.py
@@ -215,17 +215,17 @@ def _install_test_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
     _maybe_install_stub(monkeypatch, "awkward", _awkward_factory)
 
     def _hist_eft_factory() -> types.ModuleType:
-        module = types.ModuleType("topcoffea.modules.HistEFT")
+        module = types.ModuleType("topcoffea.modules.histEFT")
         module.HistEFT = _DummyHistEFT
         return module
 
     hist_eft_module = _hist_eft_factory()
-    _install_module(monkeypatch, "topcoffea.modules.HistEFT", hist_eft_module)
+    _install_module(monkeypatch, "topcoffea.modules.histEFT", hist_eft_module)
     _install_module(monkeypatch, "topcoffea.modules.histEFT", hist_eft_module)
 
     topcoffea_pkg = importlib.import_module("topcoffea")
     modules_pkg = importlib.import_module("topcoffea.modules")
-    modules_pkg.HistEFT = hist_eft_module  # type: ignore[attr-defined]
+    modules_pkg.histEFT = hist_eft_module  # type: ignore[attr-defined]
     modules_pkg.histEFT = hist_eft_module  # type: ignore[attr-defined]
     topcoffea_pkg.modules = modules_pkg  # type: ignore[attr-defined]
 

--- a/tests/test_histeft_contract_usage.py
+++ b/tests/test_histeft_contract_usage.py
@@ -1,16 +1,22 @@
+from __future__ import annotations
+
 from pathlib import Path
 import re
 import subprocess
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-PRODUCTION_ROOTS = ("analysis", "topeft/modules")
+CANONICAL_HISTEFT_IMPORT = "from topcoffea.modules.histEFT import HistEFT"
+LEGACY_MODULE_TOKEN = "Hist" + "EFT"
+LEGACY_CLASS_PATH = "topcoffea.modules." + "HistEFT.HistEFT"
+TRACKED_TEXT_SUFFIXES = {".py", ".md", ".rst", ".txt", ".ipynb"}
+TRACKED_SOURCE_ROOTS = ("analysis", "topeft/modules")
+
 FORBIDDEN_PATTERNS = (
-    re.compile(r"topcoffea\.modules\.HistEFT\.HistEFT"),
-    re.compile(r"from\s+topcoffea\.modules\.HistEFT\b"),
-    re.compile(r"topcoffea\.modules\.HistEFT\b"),
-    re.compile(r"\bHistEFT_add\b"),
-    re.compile(r"\btest_HistEFT\b"),
+    re.compile(r"topcoffea\.modules\." + LEGACY_MODULE_TOKEN + r"(?:\." + LEGACY_MODULE_TOKEN + r")?"),
+    re.compile(r"from\s+topcoffea\.modules\." + LEGACY_MODULE_TOKEN + r"\b"),
+    re.compile(r"\b" + ("Hist" + "EFT_add") + r"\b"),
+    re.compile(r"\btest_" + ("Hist" + "EFT") + r"(?:_add)?\b"),
 )
 
 
@@ -18,18 +24,35 @@ def _read(relpath: str) -> str:
     return (REPO_ROOT / relpath).read_text(encoding="utf-8")
 
 
-def _iter_tracked_production_py_files():
+def _iter_tracked_files():
     result = subprocess.run(
-        ["git", "ls-files", *PRODUCTION_ROOTS],
+        ["git", "ls-files"],
         cwd=REPO_ROOT,
         check=True,
         capture_output=True,
         text=True,
     )
     for relpath in result.stdout.splitlines():
-        if not relpath.endswith(".py"):
-            continue
         yield REPO_ROOT / relpath
+
+
+def _iter_tracked_text_files():
+    for path in _iter_tracked_files():
+        if path.suffix.lower() in TRACKED_TEXT_SUFFIXES:
+            yield path
+
+
+def _iter_tracked_source_py_files():
+    result = subprocess.run(
+        ["git", "ls-files", *TRACKED_SOURCE_ROOTS],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    for relpath in result.stdout.splitlines():
+        if relpath.endswith(".py"):
+            yield REPO_ROOT / relpath
 
 
 def test_production_modules_import_canonical_histeft_path():
@@ -43,18 +66,32 @@ def test_production_modules_import_canonical_histeft_path():
         "topeft/modules/yield_tools.py",
     ]:
         source = _read(relpath)
-        assert "from topcoffea.modules.histEFT import HistEFT" in source
-        assert "topcoffea.modules.HistEFT.HistEFT" not in source
+        assert CANONICAL_HISTEFT_IMPORT in source
+        assert LEGACY_CLASS_PATH not in source
 
 
-def test_no_legacy_histeft_references_in_production_roots():
+def test_no_legacy_histeft_references_in_tracked_repo_files():
     violations = []
-    for path in _iter_tracked_production_py_files():
+    for path in _iter_tracked_text_files():
+        relpath = path.relative_to(REPO_ROOT)
         for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
             for pattern in FORBIDDEN_PATTERNS:
                 if pattern.search(line):
-                    violations.append(f"{path.relative_to(REPO_ROOT)}:{lineno}: {line.strip()}")
+                    violations.append(f"{relpath}:{lineno}: {line.strip()}")
     assert not violations, "Legacy HistEFT references found:\n" + "\n".join(violations)
+
+
+def test_no_legacy_histeft_references_in_source_python_files():
+    """Production sources should remain clear even if docs are edited separately."""
+
+    violations = []
+    for path in _iter_tracked_source_py_files():
+        relpath = path.relative_to(REPO_ROOT)
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            for pattern in FORBIDDEN_PATTERNS:
+                if pattern.search(line):
+                    violations.append(f"{relpath}:{lineno}: {line.strip()}")
+    assert not violations, "Legacy HistEFT references found in source roots:\n" + "\n".join(violations)
 
 
 def test_group_bins_uses_modern_sparsehist_group_signature():

--- a/tests/test_jets_layout.py
+++ b/tests/test_jets_layout.py
@@ -5,7 +5,7 @@ import types
 import awkward as ak
 import numpy as np
 
-_hist_eft_stub = types.ModuleType("topcoffea.modules.HistEFT")
+_hist_eft_stub = types.ModuleType("topcoffea.modules.histEFT")
 
 
 class _DummyHistEFT:
@@ -19,8 +19,8 @@ class _DummyHistEFT:
 _hist_eft_stub.HistEFT = _DummyHistEFT
 importlib.import_module("topcoffea")
 modules_pkg = importlib.import_module("topcoffea.modules")
-modules_pkg.HistEFT = _hist_eft_stub  # type: ignore[attr-defined]
-sys.modules["topcoffea.modules.HistEFT"] = _hist_eft_stub
+modules_pkg.histEFT = _hist_eft_stub  # type: ignore[attr-defined]
+sys.modules["topcoffea.modules.histEFT"] = _hist_eft_stub
 sys.modules["topcoffea.modules.histEFT"] = _hist_eft_stub
 
 import analysis.topeft_run2.analysis_processor as ap

--- a/tests/test_mc_validation_plot_utils.py
+++ b/tests/test_mc_validation_plot_utils.py
@@ -12,6 +12,11 @@ try:  # pragma: no cover - optional dependency in CI
 except ModuleNotFoundError:  # pragma: no cover - fallback used when topcoffea is absent
     topcoffea = None  # type: ignore[assignment]
 
+try:  # pragma: no cover - optional dependency in CI
+    from topcoffea.modules.histEFT import HistEFT as _HistEFT
+except Exception:  # pragma: no cover - fallback used when HistEFT is unavailable
+    _HistEFT = None  # type: ignore[assignment]
+
 from analysis.mc_validation.plot_utils import (
     build_dataset_histograms,
     component_labels,
@@ -20,12 +25,6 @@ from analysis.mc_validation.plot_utils import (
     require_tuple_histogram_items,
     tuple_histogram_items,
 )
-
-if topcoffea is not None:  # pragma: no branch - optional dependency in CI
-    _HistEFT = getattr(topcoffea.modules.HistEFT, "HistEFT", None)
-else:  # pragma: no cover - fallback used when topcoffea is absent
-    _HistEFT = None
-
 
 def _supports_histeft_contract() -> bool:
     if _HistEFT is None:

--- a/tests/test_metadata_single_source.py
+++ b/tests/test_metadata_single_source.py
@@ -11,7 +11,7 @@ _STUBBED_MODULE_NAMES = (
     "topcoffea.modules.utils",
     "topcoffea.modules.remote_environment",
     "topcoffea.modules.dynamic_data_reduction",
-    "topcoffea.modules.HistEFT",
+    "topcoffea.modules.histEFT",
     "topcoffea.modules.get_param_from_jsons",
     "topcoffea.modules.HTMLGenerator",
     "topcoffea.scripts",
@@ -51,9 +51,9 @@ def _install_topcoffea_stub() -> None:
     modules_pkg.utils = utils_mod
     modules_pkg.remote_environment = remote_env_mod
     modules_pkg.dynamic_data_reduction = ModuleType("topcoffea.modules.dynamic_data_reduction")
-    hist_mod = ModuleType("topcoffea.modules.HistEFT")
+    hist_mod = ModuleType("topcoffea.modules.histEFT")
     hist_mod.HistEFT = type("HistEFT", (), {})
-    modules_pkg.HistEFT = hist_mod
+    modules_pkg.histEFT = hist_mod
     get_param_mod = ModuleType("topcoffea.modules.get_param_from_jsons")
     get_param_mod.GetParam = lambda *args, **kwargs: lambda key: 1.0
     modules_pkg.get_param_from_jsons = get_param_mod
@@ -77,7 +77,7 @@ def _install_topcoffea_stub() -> None:
     sys.modules["topcoffea.modules.utils"] = utils_mod
     sys.modules["topcoffea.modules.remote_environment"] = remote_env_mod
     sys.modules["topcoffea.modules.dynamic_data_reduction"] = modules_pkg.dynamic_data_reduction
-    sys.modules["topcoffea.modules.HistEFT"] = hist_mod
+    sys.modules["topcoffea.modules.histEFT"] = hist_mod
     sys.modules["topcoffea.modules.get_param_from_jsons"] = get_param_mod
     sys.modules["topcoffea.modules.HTMLGenerator"] = html_mod
     sys.modules["topcoffea.scripts"] = scripts_pkg

--- a/tests/test_nanoevents_without_caches.py
+++ b/tests/test_nanoevents_without_caches.py
@@ -8,7 +8,7 @@ from coffea.nanoevents import BaseSchema, NanoEventsFactory
 from analysis.topeft_run2.nanoevents_helpers import ensure_factory_mode
 
 
-_hist_eft_stub = types.ModuleType("topcoffea.modules.HistEFT")
+_hist_eft_stub = types.ModuleType("topcoffea.modules.histEFT")
 
 
 class _DummyHistEFT:
@@ -22,8 +22,8 @@ class _DummyHistEFT:
 _hist_eft_stub.HistEFT = _DummyHistEFT
 importlib.import_module("topcoffea")
 modules_pkg = importlib.import_module("topcoffea.modules")
-modules_pkg.HistEFT = _hist_eft_stub  # type: ignore[attr-defined]
-sys.modules["topcoffea.modules.HistEFT"] = _hist_eft_stub
+modules_pkg.histEFT = _hist_eft_stub  # type: ignore[attr-defined]
+sys.modules["topcoffea.modules.histEFT"] = _hist_eft_stub
 sys.modules["topcoffea.modules.histEFT"] = _hist_eft_stub
 
 import analysis.topeft_run2.analysis_processor as ap

--- a/tests/test_runner_output_imports.py
+++ b/tests/test_runner_output_imports.py
@@ -15,7 +15,7 @@ def _module(name: str) -> types.ModuleType:
 
 
 def _reload_runner_output(monkeypatch, module_map: dict[str, types.ModuleType]):
-    for stale_name in ("topcoffea.modules.HistEFT", "topcoffea.modules.histEFT"):
+    for stale_name in ("topcoffea.modules.histEFT",):
         monkeypatch.delitem(sys.modules, stale_name, raising=False)
     for key, value in module_map.items():
         monkeypatch.setitem(sys.modules, key, value)

--- a/tests/test_simple_processor_hooks.py
+++ b/tests/test_simple_processor_hooks.py
@@ -107,10 +107,10 @@ def _install_test_stubs(monkeypatch: pytest.MonkeyPatch):
         def fill(self, **__):
             pass
 
-    hist_eft_module = types.ModuleType("topcoffea.modules.HistEFT")
+    hist_eft_module = types.ModuleType("topcoffea.modules.histEFT")
     hist_eft_module.HistEFT = _DummyHistEFT
-    monkeypatch.setitem(sys.modules, "topcoffea.modules.HistEFT", hist_eft_module)
-    modules_pkg.HistEFT = hist_eft_module  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "topcoffea.modules.histEFT", hist_eft_module)
+    modules_pkg.histEFT = hist_eft_module  # type: ignore[attr-defined]
 
     hist_eft_lower_module = types.ModuleType("topcoffea.modules.histEFT")
     hist_eft_lower_module.HistEFT = _DummyHistEFT

--- a/tests/test_training_tuple_output.py
+++ b/tests/test_training_tuple_output.py
@@ -74,11 +74,11 @@ def _install_training_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
             converted.setdefault("quadratic_term", np.zeros(length, dtype=int))
             return super().fill(**converted)
 
-    hist_eft_module = types.ModuleType("topcoffea.modules.HistEFT")
+    hist_eft_module = types.ModuleType("topcoffea.modules.histEFT")
     hist_eft_module.HistEFT = _DummyHistEFT
-    monkeypatch.setitem(sys.modules, "topcoffea.modules.HistEFT", hist_eft_module)
     monkeypatch.setitem(sys.modules, "topcoffea.modules.histEFT", hist_eft_module)
-    modules_pkg.HistEFT = hist_eft_module  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "topcoffea.modules.histEFT", hist_eft_module)
+    modules_pkg.histEFT = hist_eft_module  # type: ignore[attr-defined]
     modules_pkg.histEFT = hist_eft_module  # type: ignore[attr-defined]
 
 

--- a/topeft/tests/test_processor_logging.py
+++ b/topeft/tests/test_processor_logging.py
@@ -160,7 +160,7 @@ def _install_stubs(monkeypatch):
     topcoffea_modules_pkg.remote_environment = remote_env_module  # type: ignore[attr-defined]
 
     # HistEFT stub
-    hist_module = _module("topcoffea.modules.HistEFT")
+    hist_module = _module("topcoffea.modules.histEFT")
 
     class _DummyHistEFT:
         def __init__(self, *axes, wc_names=None, label=None, **kwargs):
@@ -181,7 +181,7 @@ def _install_stubs(monkeypatch):
             return f"DummyHistEFT(sumw={self._sumw}, fills={len(self._fills)})"
 
     hist_module.HistEFT = _DummyHistEFT
-    topcoffea_modules_pkg.HistEFT = hist_module  # type: ignore[attr-defined]
+    topcoffea_modules_pkg.histEFT = hist_module  # type: ignore[attr-defined]
 
     hist_planner_module = _module("topcoffea.modules.histEFT_planner")
 


### PR DESCRIPTION
## Description

This PR is a follow-up “optional polish / completeness sweep” after the main HistEFT + plotting alignment work that landed in `format_update_anpicci_calcoffea` (commit `ccf3f615`). It ensures the repo is **fully consistent** with the canonical HistEFT module path and adds stronger enforcement to prevent future regressions.

### What changed

#### 1) Docs and training material now reference the canonical module path
- `README.md`: retitled “Legacy HistEFT support” → “HistEFT support” and updated wording to reflect the canonical import location (`topcoffea.modules.histEFT`) instead of the legacy `topcoffea.modules.HistEFT`.
- `docs/run_analysis_configuration.md`: removed the confusing dual-path troubleshooting hint (`histEFT/HistEFT`) and kept only the canonical path in the ImportError guidance.
- `analysis/training/intro_coffea.hist.ipynb`: updated the notebook’s example line and header to reference `topcoffea.modules.histEFT` consistently (so copy/paste from the training material no longer propagates legacy imports).

#### 2) Test stubs now emulate the canonical `topcoffea.modules.histEFT` module correctly
Several unit tests stub out `topcoffea` internals (to run in CI without a full dependency stack). Those stubs previously created `types.ModuleType("topcoffea.modules.HistEFT")` and registered it as `modules_pkg.HistEFT`. This PR updates them to:
- create `types.ModuleType("topcoffea.modules.histEFT")`
- register it as `modules_pkg.histEFT`
- ensure `sys.modules["topcoffea.modules.histEFT"]` is set (and avoid reintroducing the legacy name)

Files updated include:
- `tests/test_analysis_processor_jetmet_cacheless.py`
- `tests/test_analysis_processor_variations.py`
- `tests/test_jets_layout.py`
- `tests/test_nanoevents_without_caches.py`
- `tests/test_flavor_split_histograms.py`
- `tests/test_metadata_single_source.py`
- `tests/test_simple_processor_hooks.py`
- `tests/test_training_tuple_output.py`
- `topeft/tests/test_processor_logging.py`

#### 3) Stronger enforcement: tracked-repo scan + source-root scan for legacy HistEFT tokens
`tests/test_histeft_contract_usage.py` was expanded from a “production roots only” check into a stricter, more durable set of guardrails:

- Introduces explicit constants:
  - `CANONICAL_HISTEFT_IMPORT = "from topcoffea.modules.histEFT import HistEFT"`
  - `LEGACY_CLASS_PATH = "topcoffea.modules.HistEFT.HistEFT"` (constructed in a way that avoids accidental self-matching)
- Adds tracked repo-wide scanning for legacy tokens across:
  - `.py`, `.md`, `.rst`, `.txt`, `.ipynb`
- Keeps a dedicated scan for tracked Python source roots (`analysis/`, `topeft/modules/`) so “real code” stays clean even if docs evolve.
- Produces actionable `path:line: content` output on failures.

This is intentionally strict: legacy tokens in docs/notebooks are a common source of regressions via copy/paste.

#### 4) Minor follow-ups for consistent optional-import probing and module reload hygiene
- `tests/test_mc_validation_plot_utils.py`: switches the HistEFT optional import probe to the canonical import form (`from topcoffea.modules.histEFT import HistEFT`) rather than introspecting `topcoffea.modules.HistEFT`.
- `tests/test_runner_output_imports.py`: module reload now evicts only `topcoffea.modules.histEFT` from `sys.modules` (dropping the stale legacy name entirely).

### Files changed

- Docs / training:
  - `README.md`
  - `docs/run_analysis_configuration.md`
  - `analysis/training/intro_coffea.hist.ipynb`

- Enforcement / tests:
  - `tests/test_histeft_contract_usage.py`
  - `tests/test_mc_validation_plot_utils.py`
  - `tests/test_runner_output_imports.py`
  - `tests/test_analysis_processor_jetmet_cacheless.py`
  - `tests/test_analysis_processor_variations.py`
  - `tests/test_flavor_split_histograms.py`
  - `tests/test_jets_layout.py`
  - `tests/test_metadata_single_source.py`
  - `tests/test_nanoevents_without_caches.py`
  - `tests/test_simple_processor_hooks.py`
  - `tests/test_training_tuple_output.py`
  - `topeft/tests/test_processor_logging.py`

### Verification

```bash
cd /users/apiccine/work/ChUpdate/topeft
PYTHON_ENV="/users/apiccine/work/miniconda3/envs/coffea2025/bin/python"

$PYTHON_ENV -m compileall topeft/modules analysis tests
$PYTHON_ENV -m pytest -q
```

Outcome:
- `pytest -q` → `208 passed, 6 skipped, 8 warnings`

### Commit

- `1e2c4560` — `refactor: polish HistEFT usage and remove remaining legacy patterns`