### PR TITLE
Docs and CLI hygiene: add script docstrings, clarify pytest workflow, and fix help-time imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,13 +179,15 @@ where `pytest-cov` is only used if you want to locally check the code coverage.
 
 The `pytest` commands are run automatically in the CI. If you would like to run them locally, you can simply run:
 ```bash
-pytest
+python -m pytest -q
 ```
-from the main topcoffea directory. This will run _all_ the tests, which will take ~20 minutes. To run a subset, use e.g.:
+from the `topeft` repository root. To run a focused subset, use e.g.:
 ```bash
-pytest -k test_futures
+python -m pytest -q tests/test_logging_policy.py
 ```
-where `test_futures` is the file/test you would like to run (check the `tests` directory for all the available tests, or write your own and push it!). If you would also like to see how the coverage changes, you can add `--cov=./ --cov-report=html` to `pytest` commands. This will create an `html` directory that you can then copy to any folder which you have web access to (e.g. `~/www/` on Earth) For a better printout of what passed and failed, add `-rP` to the `pytest` commands.
+where the targeted file can be replaced with any test under `tests/`. If you would also like to see how the coverage changes, you can add `--cov=./ --cov-report=html` to the `python -m pytest` commands. This will create an `html` directory that you can then copy to any folder which you have web access to (e.g. `~/www/` on Earth). For a better printout of what passed and failed, add `-rP` to the command.
+
+More test workflow details are documented in [`tests/README.md`](tests/README.md).
 
 
 

--- a/analysis/btagMCeff/run.py
+++ b/analysis/btagMCeff/run.py
@@ -30,7 +30,7 @@ import numpy as np
 import coffea.processor as processor
 from coffea.nanoevents import NanoAODSchema
 
-import btagMCeff
+from analysis.btagMCeff import btagMCeff
 from topeft.modules.runner_output import normalise_runner_output, tuple_dict_stats
 
 if __name__ == '__main__':
@@ -172,5 +172,4 @@ if __name__ == '__main__':
     with gzip.open(outpath + outname + ".pkl.gz", "wb") as fout:
         cloudpickle.dump(serialised_output, fout)
     print('Done!')
-
 

--- a/analysis/btagMCeff/run.py
+++ b/analysis/btagMCeff/run.py
@@ -1,4 +1,25 @@
 #!/usr/bin/env python
+"""Run the b-tagging MC-efficiency Coffea processor.
+
+Purpose:
+Launch ``btagMCeff.AnalysisProcessor`` over JSON/CFG sample manifests to build
+histograms used for b-tagging efficiency studies.
+
+Inputs/outputs:
+- Input: one or more sample JSON/CFG files plus optional redirector prefix.
+- Output: a gzip-compressed cloudpickle histogram artifact in ``--outpath``
+  (default filename base: ``btagMCeff``).
+
+Side effects:
+- Reads sample metadata files and remote/local ROOT files.
+- Executes Coffea runners (futures executor) and writes output files.
+- Creates the output directory when needed.
+
+How to run:
+- ``python analysis/btagMCeff/run.py input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json``
+- ``python analysis/btagMCeff/run.py input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json --test --outpath histos``
+"""
+
 import json
 import time
 import cloudpickle
@@ -17,16 +38,18 @@ if __name__ == '__main__':
     configure_topeft_logging("INFO")
 
     import argparse
-    parser = argparse.ArgumentParser(description='You can customize your run')
-    parser.add_argument('jsonFiles'        , nargs='?', default='', help = 'Json file(s) containing files and metadata')
-    parser.add_argument('--prefix', '-r'   , nargs='?', default='', help = 'Prefix or redirector to look for the files')
-    parser.add_argument('--test','-t'       , action='store_true'  , help = 'To perform a test, run over a few events in a couple of chunks')
-    parser.add_argument('--nworkers','-n'   , default=8  , help = 'Number of workers')
+    parser = argparse.ArgumentParser(
+        description="Run the b-tag MC-efficiency processor and write histogram output."
+    )
+    parser.add_argument('jsonFiles'        , nargs='?', default='', help = 'JSON or CFG file(s) containing sample metadata')
+    parser.add_argument('--prefix', '-r'   , nargs='?', default='', help = 'Redirector prefix prepended to each input file path')
+    parser.add_argument('--test','-t'       , action='store_true'  , help = 'Run a fast smoke test with reduced chunks/workers')
+    parser.add_argument('--nworkers','-n'   , default=8  , help = 'Number of local workers')
     parser.add_argument('--chunksize','-s'   , default=500000  , help = 'Number of events per chunk')
-    parser.add_argument('--nchunks','-c'   , default=None  , help = 'You can choose to run only a number of chunks')
-    parser.add_argument('--outname','-o'   , default='btagMCeff', help = 'Name of the output file with histograms')
-    parser.add_argument('--outpath','-p'   , default='histos', help = 'Name of the output directory')
-    parser.add_argument('--treename'   , default='Events', help = 'Name of the tree inside the files')
+    parser.add_argument('--nchunks','-c'   , default=None  , help = 'Limit the number of chunks processed')
+    parser.add_argument('--outname','-o'   , default='btagMCeff', help = 'Base name for the output histogram file')
+    parser.add_argument('--outpath','-p'   , default='histos', help = 'Directory where output files are written')
+    parser.add_argument('--treename'   , default='Events', help = 'Tree name inside each input ROOT file')
 
     args = parser.parse_args()
     jsonFiles  = args.jsonFiles
@@ -149,6 +172,5 @@ if __name__ == '__main__':
     with gzip.open(outpath + outname + ".pkl.gz", "wb") as fout:
         cloudpickle.dump(serialised_output, fout)
     print('Done!')
-
 
 

--- a/analysis/extreme_events_study/run_extreme_events.py
+++ b/analysis/extreme_events_study/run_extreme_events.py
@@ -1,3 +1,24 @@
+"""Run the extreme-events study processor over sample manifests.
+
+Purpose:
+Execute the ``extreme_events`` analysis processor with configurable executor
+settings to inspect high-value event tails.
+
+Inputs/outputs:
+- Input: JSON/CFG sample manifests and optional redirector overrides.
+- Output: a gzip-compressed cloudpickle histogram file in ``--outpath``
+  (default base name: ``flipTopEFT``).
+
+Side effects:
+- Reads local/remote ROOT files listed in input manifests.
+- May submit distributed tasks (futures or TaskVine) and stage worker envs.
+- Writes output histogram artifacts and runtime metadata.
+
+How to run:
+- ``python analysis/extreme_events_study/run_extreme_events.py input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json``
+- ``python analysis/extreme_events_study/run_extreme_events.py input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json --executor futures --max-files 2``
+"""
+
 import argparse
 import cloudpickle
 import gzip
@@ -28,7 +49,7 @@ update_cfg = tc_utils.update_cfg
 
 
 parser = argparse.ArgumentParser(
-    description='You can customize your run',
+    description='Run the extreme-events processor and write histogram output.',
     formatter_class=argparse.RawDescriptionHelpFormatter,
     epilog=(
         "TaskVine workers can be launched with:\n"
@@ -37,14 +58,14 @@ parser = argparse.ArgumentParser(
         "Adjust the resources and manager to match your deployment."
     ),
 )
-parser.add_argument('inputFiles'            , nargs='?', default='', help = 'Json or cfg file(s) containing files and metadata')
+parser.add_argument('inputFiles'            , nargs='?', default='', help = 'JSON or CFG file(s) containing sample metadata')
 parser.add_argument('--chunksize','-s'      , default=100000, type=int, help = 'Number of events per chunk')
-parser.add_argument('--max-files','-N'      , default=0, type=int, help = 'If specified, limit the number of root files per sample. Useful for testing')
-parser.add_argument('--nchunks','-c'        , default=0, type=int, help = 'You can choose to run only a number of chunks')
-parser.add_argument('--outname','-o'        , default='flipTopEFT', help = 'Name of the output file with histograms')
-parser.add_argument('--outpath','-p'        , default='histos', help = 'Name of the output directory')
-parser.add_argument('--treename'            , default='Events', help = 'Name of the tree inside the files')
-parser.add_argument('--xrd'                 , default='', help = 'The XRootD redirector to use when reading directly from json files')
+parser.add_argument('--max-files','-N'      , default=0, type=int, help = 'Limit the number of ROOT files per sample (useful for testing)')
+parser.add_argument('--nchunks','-c'        , default=0, type=int, help = 'Limit the number of chunks processed')
+parser.add_argument('--outname','-o'        , default='flipTopEFT', help = 'Base name for the output histogram file')
+parser.add_argument('--outpath','-p'        , default='histos', help = 'Directory where output files are written')
+parser.add_argument('--treename'            , default='Events', help = 'Tree name inside each input ROOT file')
+parser.add_argument('--xrd'                 , default='', help = 'Redirector prefix applied when reading files from JSON inputs')
 EXECUTOR_CLI = ExecutorCLIHelper(
     remote_environment=remote_environment,
     futures_spec=FuturesArgumentSpec(

--- a/analysis/flip_measurement/flip_ar_plotter.py
+++ b/analysis/flip_measurement/flip_ar_plotter.py
@@ -1,4 +1,21 @@
-"""Plotter for tuple-keyed flip application region histograms."""
+"""Plot comparison figures for flip application-region histograms.
+
+Purpose:
+Load tuple-keyed histogram output and produce per-variable comparison plots for
+the ``ssz`` and ``osz`` channels used in the flip application workflow.
+
+Inputs/outputs:
+- Input: a pickle/gzip histogram artifact produced by the flip workflow.
+- Output: PNG image files saved under ``--outpath``.
+
+Side effects:
+- Reads histogram files from disk.
+- Creates output directories/files and writes plot images.
+
+How to run:
+- ``python analysis/flip_measurement/flip_ar_plotter.py histos/flipTopEFT.pkl.gz``
+- ``python analysis/flip_measurement/flip_ar_plotter.py histos/flipTopEFT.pkl.gz --outpath plots/flip_ar``
+"""
 
 from __future__ import annotations
 
@@ -76,13 +93,15 @@ def main() -> None:
     from topeft.modules.logging_config import configure_topeft_logging
     configure_topeft_logging("INFO")
 
-    parser = argparse.ArgumentParser(description="Plot flip application histograms")
+    parser = argparse.ArgumentParser(
+        description="Plot ssz/osz comparisons from flip application-region histograms."
+    )
     parser.add_argument(
         "filepath",
         default="histos/flipTopEFT.pkl.gz",
-        help="path of file with histograms",
+        help="Path to the histogram pickle produced by the flip workflow",
     )
-    parser.add_argument("--outpath", "-o", default=".", help="Path to the output directory")
+    parser.add_argument("--outpath", "-o", default=".", help="Directory where plot images are written")
     args = parser.parse_args()
 
     tuple_histograms = load_histograms(args.filepath)

--- a/analysis/flip_measurement/flip_mr_plotter.py
+++ b/analysis/flip_measurement/flip_mr_plotter.py
@@ -1,4 +1,20 @@
-"""Plotter for the flip measurement tuple-keyed histogram output."""
+"""Build flip-rate maps from flip-measurement histograms.
+
+Purpose:
+Aggregate tuple-keyed flip measurement histograms by year and derive
+``truthFlip / (truthFlip + truthNoFlip)`` maps for each Run-2 campaign.
+
+Inputs/outputs:
+- Input: a pickle/gzip histogram artifact from the flip measurement workflow.
+- Output: per-year ROOT payloads and PNG 2D plots.
+
+Side effects:
+- Reads and deserializes histogram files from disk.
+- Writes ROOT and image files in the current working directory.
+
+How to run:
+- ``python analysis/flip_measurement/flip_mr_plotter.py histos/flipMR_TopEFT.pkl.gz``
+"""
 
 from __future__ import annotations
 
@@ -94,11 +110,13 @@ def main() -> None:
     from topeft.modules.logging_config import configure_topeft_logging
     configure_topeft_logging("INFO")
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        description="Compute and save per-year flip-rate maps from measurement histograms."
+    )
     parser.add_argument(
         "filepath",
         default="histos/flipMR_TopEFT.pkl.gz",
-        help="path of file with histograms",
+        help="Path to the histogram pickle produced by the flip measurement workflow",
     )
     args = parser.parse_args()
 

--- a/analysis/flip_measurement/run_flip.py
+++ b/analysis/flip_measurement/run_flip.py
@@ -1,3 +1,21 @@
+"""Entrypoint for flip-measurement processors (MR and AR workflows).
+
+Purpose:
+- Run the flip measurement processors over configured samples and write
+  tuple-keyed histogram outputs for downstream plotting.
+
+Inputs/outputs:
+- Reads JSON/CFG sample manifests and optional executor/runtime settings.
+- Writes gzip+pickle runner outputs in the configured output directory.
+
+Side effects:
+- Creates output files/directories and can submit tasks to futures/TaskVine.
+
+How to run:
+- ``python analysis/flip_measurement/run_flip.py --help``
+- ``python analysis/flip_measurement/run_flip.py input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json`` 
+"""
+
 from __future__ import annotations
 
 import argparse

--- a/analysis/mc_validation/mc_validation_gen_plotter.py
+++ b/analysis/mc_validation/mc_validation_gen_plotter.py
@@ -1,6 +1,19 @@
-# This script makes plots to compare private and central GEN level distributions
-#   - Should be run on the output of the mc_validation_gen_processor.py processor
-#   - Was used during the June 2022 MC validation studies (for TOP-22-006 pre approval checks)
+"""Compare private vs central GEN-level samples in validation plots.
+
+Purpose:
+- Produce GEN-level overlay/ratio plots for private-vs-central MC validation.
+
+Inputs/outputs:
+- Reads histogram pickles from the GEN validation workflow.
+- Writes plot images and optional helper pickles for derived scale factors.
+
+Side effects:
+- Creates output directories/files and optional ``index.html`` pages.
+
+How to run:
+- ``python analysis/mc_validation/mc_validation_gen_plotter.py --help``
+- ``python analysis/mc_validation/mc_validation_gen_plotter.py -f histos/gen_validation.pkl.gz -o plots/mc_validation_gen`` 
+"""
 
 import os
 import datetime

--- a/analysis/mc_validation/mc_validation_plotter.py
+++ b/analysis/mc_validation/mc_validation_plotter.py
@@ -1,6 +1,20 @@
-# This script makes plots to compare private and central RECO level distributions
-#   - Should be run on the output of the topeft processor
-#   - Was used during the June 2022 MC validation studies (for TOP-22-006 pre approval checks)
+"""Compare private vs central RECO-level samples in validation plots.
+
+Purpose:
+- Build overlay/ratio plots for MC-validation checks using tuple-keyed
+  histogram outputs from the main Run-2 workflow.
+
+Inputs/outputs:
+- Reads one histogram pickle plus optional plotting configuration flags.
+- Writes comparison plots (and optional ``index.html``) to the output path.
+
+Side effects:
+- Creates output directories/files and may read auxiliary ROOT correction files.
+
+How to run:
+- ``python analysis/mc_validation/mc_validation_plotter.py --help``
+- ``python analysis/mc_validation/mc_validation_plotter.py -f histos/plotsTopEFT.pkl.gz -o plots/mc_validation`` 
+"""
 
 import numpy as np
 import os

--- a/analysis/topeft_run2/comp.py
+++ b/analysis/topeft_run2/comp.py
@@ -1,10 +1,22 @@
-'''
-Script for comparing two pkl files
-example:
-`python comp.py histos/example_name_np.pkl.gz ~/../../k/kmohrman/Public/fullR2_files/pkl_files/feb15_fullRun2_withSys_anatest25_np.pkl.gz --newHist1`
---newHist1 tells it the first pkl file is using the new histEFT based on scikithep hist
---newHist2 would tell it the second pkl file is using the new histEFT based on scikithep hist
-'''
+"""Compare two histogram pickle outputs from Run-2 workflows.
+
+Purpose:
+Load two ``.pkl.gz`` histogram artifacts, compare yields bin-by-bin across
+process/channel/application/systematic axes, and report mismatches.
+
+Inputs/outputs:
+- Input: two histogram pickle paths plus optional format flags and metadata.
+- Output: console diagnostics, ``comp_log.txt``, and JSON dumps of compared
+  yields derived from each input file.
+
+Side effects:
+- Reads compressed pickle histogram payloads from disk.
+- Writes ``comp_log.txt`` and per-input JSON summaries in the working directory.
+
+How to run:
+- ``python analysis/topeft_run2/comp.py histos/run_a_np.pkl.gz histos/run_b_np.pkl.gz --newHist1 --newHist2``
+- ``python analysis/topeft_run2/comp.py histos/run_a_np.pkl.gz histos/run_b_np.pkl.gz --tolerance 1e-3``
+"""
 import pickle
 import gzip
 import numpy as np
@@ -363,12 +375,14 @@ if __name__ == '__main__':
     yields1={}
     yields2={}
 
-    parser = argparse.ArgumentParser(description='You can select which file to run over')
-    parser.add_argument('fin1'   , default='analysis/topEFT/histos/mar03_central17_pdf_np.pkl.gz' , help = 'Variable to run over')
-    parser.add_argument('fin2'   , default='analysis/topEFT/histos/mar03_central17_pdf_np.pkl.gz' , help = 'Variable to run over')
-    parser.add_argument('--newHist1', action='store_true', help='First file was made with the new histEFT')
-    parser.add_argument('--newHist2', action='store_true', help='Second file was made with the new histEFT')
-    parser.add_argument('--tolerance', '-t', default='1e-3', help='Tolerance for warnings')
+    parser = argparse.ArgumentParser(
+        description="Compare two Run-2 histogram pickle files and report yield differences."
+    )
+    parser.add_argument('fin1', help='Path to the first input histogram pickle (.pkl.gz)')
+    parser.add_argument('fin2', help='Path to the second input histogram pickle (.pkl.gz)')
+    parser.add_argument('--newHist1', action='store_true', help='Flag the first file as the modern HistEFT-backed format')
+    parser.add_argument('--newHist2', action='store_true', help='Flag the second file as the modern HistEFT-backed format')
+    parser.add_argument('--tolerance', '-t', default='1e-3', help='Relative-difference threshold used for mismatch warnings')
     parser.add_argument(
         '--metadata',
         default=None,

--- a/analysis/topeft_run2/comp_yields.py
+++ b/analysis/topeft_run2/comp_yields.py
@@ -1,3 +1,22 @@
+"""Compare two yield JSON files and report differences.
+
+Purpose:
+- Diff nested yield dictionaries and print absolute/percent differences with
+  optional latex table output.
+
+Inputs/outputs:
+- Reads one required yield JSON and one optional comparison JSON/reference tag.
+- Prints comparison tables to stdout and exits non-zero when tolerance checks
+  fail.
+
+Side effects:
+- No file writes by default; process exit code reflects comparison status.
+
+How to run:
+- ``python analysis/topeft_run2/comp_yields.py --help``
+- ``python analysis/topeft_run2/comp_yields.py yields_new.json test/ref_yields.json`` 
+"""
+
 import argparse
 import json
 import sys
@@ -8,11 +27,6 @@ from topeft.modules.yield_tools import YieldTools
 
 mlt = topcoffea.modules.MakeLatexTable
 utils = topcoffea.modules.utils
-
-# This script takes two json files of yields, and prints out information about how they compare
-#   - The second file is optional, will default to the reference yield file
-#   - You can compare to the TOP-19-001 yields by specifying "TOP-19-001" as the filename
-#   - Example usage: python comp_yields.py your_yields_file.json TOP-19-001
 
 def main():
     from topeft.modules.logging_config import configure_topeft_logging

--- a/analysis/topeft_run2/datacards_post_processing.py
+++ b/analysis/topeft_run2/datacards_post_processing.py
@@ -1,3 +1,21 @@
+"""Post-process and validate datacard/template production outputs.
+
+Purpose:
+- Inspect card/template directories, summarize condor logs, and stage subsets
+  used by standard scenario workflows.
+
+Inputs/outputs:
+- Reads datacard and template directories plus optional condor log files.
+- Writes copied template subsets and JSON summaries in output directories.
+
+Side effects:
+- Performs filesystem copies and can remove/recreate destination directories.
+
+How to run:
+- ``python analysis/topeft_run2/datacards_post_processing.py --help``
+- ``python analysis/topeft_run2/datacards_post_processing.py cards_out -s``
+"""
+
 import os
 import shutil
 import argparse
@@ -7,10 +25,6 @@ from typing import Iterable, List, Tuple
 
 from analysis.topeft_run2 import metadata_authority
 from topeft.modules.channel_metadata import ChannelMetadataHelper
-
-# This script does some basic checks of the cards and templates produced by the `make_cards.py` script.
-#   - It also can parse the condor log files and dump a summary of the contents
-#   - Additionally, it can also grab the right set of ptz and lj0pt templates (for the right categories) used in TOP-22-006
 
 # Lines that show up in the condor err files that we want to ignore
 IGNORE_LINES = [

--- a/analysis/topeft_run2/get_datacard_yields.py
+++ b/analysis/topeft_run2/get_datacard_yields.py
@@ -1,3 +1,21 @@
+"""Summarize datacard yields into printable tables.
+
+Purpose:
+- Parse Combine datacards and report SM/data yields in plain text and latex
+  table formats used for validation notes.
+
+Inputs/outputs:
+- Reads one datacard directory (or file list) plus optional scenario settings.
+- Writes optional JSON summaries and prints formatted tables to stdout.
+
+Side effects:
+- Creates timestamped output files when save options are enabled.
+
+How to run:
+- ``python analysis/topeft_run2/get_datacard_yields.py --help``
+- ``python analysis/topeft_run2/get_datacard_yields.py cards_out/ptz-lj0pt_withSys --unblind``
+"""
+
 import os
 import copy
 import datetime

--- a/analysis/topeft_run2/get_yield_json.py
+++ b/analysis/topeft_run2/get_yield_json.py
@@ -1,3 +1,21 @@
+"""Extract category yields from histogram pickles and save JSON outputs.
+
+Purpose:
+- Read tuple-keyed histogram pickles and emit year/category yield summaries for
+  regression checks and datacard preparation.
+
+Inputs/outputs:
+- Reads one histogram pickle (default ``histos/plotsTopEFT.pkl.gz``).
+- Writes a JSON yield file (timestamped by default) and optional table output.
+
+Side effects:
+- Creates JSON files in the current working directory.
+
+How to run:
+- ``python analysis/topeft_run2/get_yield_json.py --help``
+- ``python analysis/topeft_run2/get_yield_json.py -f histos/plotsTopEFT.pkl.gz -y 2018``
+"""
+
 import argparse
 import json
 import datetime
@@ -8,10 +26,6 @@ from topeft.modules.yield_tools import YieldTools
 
 mlt = topcoffea.modules.MakeLatexTable
 utils = topcoffea.modules.utils
-
-# This script takes a pkl file, finds the yields in the analysis categories, saves the yields to a json
-#   - If you do not specify a pkl file path, will default to "hists/plotsTopEFT.pkl.gz"
-#   - Example usage: python get_yield_json.py -f histos/plotsTopEFT.pkl.gz
 
 def main():
     from topeft.modules.logging_config import configure_topeft_logging

--- a/analysis/topeft_run2/make_1d_quad_plots.py
+++ b/analysis/topeft_run2/make_1d_quad_plots.py
@@ -1,3 +1,22 @@
+"""Prototype utility for plotting 1D EFT quadratic fits from NanoAOD events.
+
+Purpose:
+- Build per-WC quadratic-fit summaries from one input sample and write quick
+  diagnostic plots.
+
+Inputs/outputs:
+- Reads one NanoAOD ROOT file (local path + optional redirector).
+- Writes PNG plots and optional ``index.html`` in the output directory.
+
+Side effects:
+- Creates output directories/files and performs remote file reads when a
+  redirector is provided.
+
+How to run:
+- ``python analysis/topeft_run2/make_1d_quad_plots.py --help``
+- ``python analysis/topeft_run2/make_1d_quad_plots.py -i /store/.../sample.root -o quad_plots`` 
+"""
+
 import os
 import argparse
 import datetime
@@ -10,12 +29,6 @@ from topeft.modules.topcoffea_imports import require_script
 qft = topcoffea.modules.quad_fit_tools
 utils = topcoffea.modules.utils
 make_html = require_script("make_html").make_html
-
-# This is more or less a placeholder script
-#   - It shows  an example of how we might want to access the quadratic fit information using topcoffea.modules.quad_fit_tools
-#   - Currently the script doesn't do much (just processes a single ttH file, prints where fits cross a threshold, and makes 1d quadratic plots)
-#   - So this is probably not all that useful right now, but might give us a place to build from in the future
-#   - Example usage: python make_1d_quad_plots.py -o ~/www/some/dir/in/your/web/area
 
 def main():
     from topeft.modules.logging_config import configure_topeft_logging

--- a/analysis/topeft_run2/make_1d_quad_plots_from_template_histos.py
+++ b/analysis/topeft_run2/make_1d_quad_plots_from_template_histos.py
@@ -1,17 +1,21 @@
-# About this script:
-#     - This script takes as input the information from the template histograms
-#     - The goal is to reconstruct the quadratic parameterizations from the templates
-#     - The script extracts the full 26-dimensional quadratic, but currently just plots the 1d quadratics
-# About the input to this script:
-#     - The relevant templates are the ones produced by topcoffea's datacard_maker.py, which should be passed
-#       to EFTFit's look_at_templates.C (which opens the templates, optionally extrapolates the up/down beyond +-1sigma,
-#       and dumps the info into a python dictionary), so it is the output of look_at_templates.C that this script runs on
-#     - It would probably be better for look_at_templates.C to dump the info into e.g. a json, but right now it just prints
-#       the info to the screen in the form of a python dictionary, so this script assumes that dictionary has been pasted
-#       into a .py file and we can just directly import the dictionary
-#     - That dictionary that we import is a global variable called IN_DICT in the script
-#     - Note that so far this script assumes the templates are just njets (i.e. none of the naming and conventions etc. are
-#       currently set up to work with e.g. bins in lj0pt)
+"""Reconstruct EFT quadratic fits from template histogram decompositions.
+
+Purpose:
+- Convert decomposed template values (SM/linear/quadratic/mixed terms) into
+  full quadratic parameterizations and produce 1D diagnostic plots.
+
+Inputs/outputs:
+- Reads a python module that defines the template dictionary (``IN_DICT``) as
+  exported from template-inspection tooling.
+- Writes reconstructed-fit plots and optional summary artifacts.
+
+Side effects:
+- Creates output plots/files and imports the provided template dictionary module.
+
+How to run:
+- ``python analysis/topeft_run2/make_1d_quad_plots_from_template_histos.py --help``
+- ``python analysis/topeft_run2/make_1d_quad_plots_from_template_histos.py -i templates_dump.py -o quad_plots`` 
+"""
 
 # Some notes on the naming conventions for the decomposed and reconstructed quadratic parameterization
 # This is based on Eqn 5 of CMS AN-20-204 ("EFT model for SMP measurements")

--- a/analysis/topeft_run2/make_cards.py
+++ b/analysis/topeft_run2/make_cards.py
@@ -1,3 +1,21 @@
+"""Build datacards/templates from tuple-keyed histogram outputs.
+
+Purpose:
+- Consume histogram pickles and materialize Combine-compatible datacards and
+  ROOT templates for selected channels/variables.
+
+Inputs/outputs:
+- Reads one or more histogram pickle files plus optional scenario metadata.
+- Writes datacard text files, template ROOT files, and optional condor payloads.
+
+Side effects:
+- Creates output directories/files and may generate condor submit scripts.
+
+How to run:
+- ``python analysis/topeft_run2/make_cards.py --help``
+- ``python analysis/topeft_run2/make_cards.py histos/plotsTopEFT.pkl.gz -d cards_out``
+"""
+
 import os
 import sys
 import time

--- a/analysis/topeft_run2/make_cr_and_sr_plots.py
+++ b/analysis/topeft_run2/make_cr_and_sr_plots.py
@@ -1,3 +1,21 @@
+"""Produce control/signal-region plots from tuple-keyed histogram pickles.
+
+Purpose:
+- Build CR/SR plots, uncertainty bands, and optional web-friendly outputs from
+  Run-2 histogram artifacts.
+
+Inputs/outputs:
+- Reads a histogram pickle plus optional metadata/scenario configuration.
+- Writes plot images (and optional html indices) into the chosen output path.
+
+Side effects:
+- Creates directories/files and may overwrite existing plots with same names.
+
+How to run:
+- ``python analysis/topeft_run2/make_cr_and_sr_plots.py --help``
+- ``python analysis/topeft_run2/make_cr_and_sr_plots.py -f histos/plotsTopEFT.pkl.gz -o plots/cr_sr`` 
+"""
+
 import numpy as np
 import os
 import copy
@@ -26,14 +44,6 @@ get_tc_param = GetParam(topcoffea_path("params/params.json"))
 utils = topcoffea.modules.utils
 make_html = require_script("make_html").make_html
 
-
-# This script takes an input pkl file that should have both data and background MC included.
-# The input is expected to be the 5-tuple histogram pickle produced by the current topcoffea
-# runners (including TaskVine) and saved with utils.dump_to_pkl/normalise_runner_output.
-# Use the -y option to specify a year; if no year is specified, all years will be included.
-# There are various other options available from the command line.
-# For example, to make unit normalized plots for 2018, with the timestamp appended to the directory name, you would run:
-#     python make_cr_plots.py -f histos/your.pkl.gz -o ~/www/somewhere/in/your/web/dir -n some_dir_name -y 2018 -t -u
 
 # Some options for plotting the data and MC
 DATA_ERR_OPS = {'linestyle':'none', 'marker': '.', 'markersize': 10., 'color':'k', 'elinewidth': 1,}

--- a/analysis/topeft_run2/make_jsons.py
+++ b/analysis/topeft_run2/make_jsons.py
@@ -1,6 +1,21 @@
-# This file is essentially a wrapper for createJSON.py:
-#   - It runs createJSON.py for each sample that you include in a dictionary, and moves the resulting json file to the directory you specify
-#   - If the private NAOD has to be remade, the version numbers should be updated in the dictionaries here, then just rerun the script to remake the jsons
+"""Generate batches of sample JSON files for private/central campaigns.
+
+Purpose:
+- Wrap ``topcoffea.modules.createJSON`` calls for predefined sample dictionaries
+  and optionally combine per-batch outputs into campaign-level JSON lists.
+
+Inputs/outputs:
+- Reads hard-coded sample dictionaries in this module plus xsec metadata.
+- Writes JSON files into configured output directories.
+
+Side effects:
+- Executes subprocess calls to JSON-generation utilities and writes many JSONs.
+
+How to run:
+- Edit the enabled ``make_jsons_for_dict_of_samples(...)`` calls in ``main()``
+  to select the campaign slices you want to (re)build.
+- Run ``python analysis/topeft_run2/make_jsons.py`` from the repository root.
+"""
 
 import os
 import re

--- a/analysis/topeft_run2/make_skim_jsons.py
+++ b/analysis/topeft_run2/make_skim_jsons.py
@@ -1,3 +1,21 @@
+"""Create skimmed-sample JSON manifests from existing template JSONs.
+
+Purpose:
+- Match skim directories to existing sample JSON files and emit updated JSON
+  manifests that point to skimmed outputs.
+
+Inputs/outputs:
+- Reads source skim directories and template JSON files.
+- Writes skim JSON files (in-place or to a dedicated output directory).
+
+Side effects:
+- Creates/updates JSON files on disk.
+
+How to run:
+- ``python analysis/topeft_run2/make_skim_jsons.py --help``
+- ``python analysis/topeft_run2/make_skim_jsons.py /path/to/skim_parent --json-dir input_samples/sample_jsons`` 
+"""
+
 import os
 import argparse
 
@@ -134,5 +152,4 @@ def main():
 
 if __name__ == "__main__":
     main()
-
 

--- a/analysis/topeft_run2/missing_parton.py
+++ b/analysis/topeft_run2/missing_parton.py
@@ -1,12 +1,24 @@
-'''
-This script computes the missing parton rate.
+"""Compute missing-parton corrections from central/private template pairs.
 
-It requires the central (tZq) and private (tllq) samples exist in
-`histos/central_sm/` and `histos/private_sm/` respectively. When comparing the
-two, process names are remapped to align the private tllq sample with the
-central tZq histograms (and similarly ttZ→ttll, ttW→ttlnu). To create the
-inputs, run the datacard maker (tllq `with` systematics, tZq without).
-'''
+Purpose:
+Compare private and central histogram templates for selected processes and
+derive missing-parton correction views used in validation plots/artifacts.
+
+Inputs/outputs:
+- Input: ROOT datacard templates under the expected central/private histogram
+  directories plus optional year/channel selections.
+- Output: plot files under ``--output-path`` and updated ROOT artifacts for
+  missing-parton summaries.
+
+Side effects:
+- Reads ROOT/template text files from histogram directories.
+- Writes plot files and updates a ROOT output file.
+- Creates output directories when needed.
+
+How to run:
+- ``python analysis/topeft_run2/missing_parton.py --years 2017 --var njets``
+- ``python analysis/topeft_run2/missing_parton.py --years 2017 2018 --var ptz --output-path results``
+"""
 import numpy as np
 import matplotlib.pyplot as plt
 import uproot
@@ -118,12 +130,14 @@ if __name__ == '__main__':
     import datetime
     import os
 
-    parser = argparse.ArgumentParser(description='You can select which file to run over')
-    parser.add_argument('--years',          default=[], action='extend', nargs='+', help = 'Specify a list of years')
-    parser.add_argument('--time', '-t',     action='store_true', help = 'Append time to dir')
-    parser.add_argument("-o", "--output-path", default=".", help = "The path the output files should be saved to")
-    parser.add_argument('--var',            default='njets', help = 'Specify variable to run over')
-    parser.add_argument('--channels', '-c', default=None, nargs='+', help='Limit the run to a subset of channels')
+    parser = argparse.ArgumentParser(
+        description="Compute missing-parton comparisons from central/private templates."
+    )
+    parser.add_argument('--years', default=[], action='extend', nargs='+', help='Year list (e.g. 2016APV 2016 2017 2018)')
+    parser.add_argument('--time', '-t', action='store_true', help='Append a timestamp to the output directory name')
+    parser.add_argument("-o", "--output-path", default=".", help="Base directory where output files are saved")
+    parser.add_argument('--var', default='njets', help='Histogram variable to process (e.g. njets or ptz)')
+    parser.add_argument('--channels', '-c', default=None, nargs='+', help='Restrict processing to specific channels')
 
     args = parser.parse_args()
     years    = args.years

--- a/analysis/topeft_run2/parse_datacard_templates.py
+++ b/analysis/topeft_run2/parse_datacard_templates.py
@@ -1,8 +1,20 @@
-# About this script (Apr 21, 2022)
-#   - This script takes as input the path to a dir that has all of the template root files produced by the datacard maker
-#       - All of the files in the dir should correspond to a single variable
-#       - So far the script has only been tested with njets, but in principle could be extended to other variables too
-#   - The script then grabs all of the nom, up, and down histos from the templates, and plots them and saves to png
+"""Inspect and plot nominal/up/down template histograms from datacard ROOT files.
+
+Purpose:
+- Parse template ROOT files created by datacard workflows and visualize nominal
+  vs systematic-shifted shapes.
+
+Inputs/outputs:
+- Reads a directory containing template ROOT files for a single variable.
+- Writes overlay plots (PNG/PDF) and optional ``index.html`` pages.
+
+Side effects:
+- Creates output image files and can create directories for plot staging.
+
+How to run:
+- ``python analysis/topeft_run2/parse_datacard_templates.py --help``
+- ``python analysis/topeft_run2/parse_datacard_templates.py -i templates_dir -o parsed_templates`` 
+"""
 
 import os
 import argparse

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -1,12 +1,21 @@
 #!/usr/bin/env python
 
-"""Command-line interface for the Run 2 analysis workflow.
+"""Command-line entrypoint for Run-2 histogram production.
 
-The YAML-first configuration pipeline, helper responsibilities, and common
-extension points are documented in ``docs/run_analysis_configuration.md``.  For
-a step-by-step walkthrough of environment prerequisites, metadata bundles, and
-example invocations that mirror ``fullR2_run.sh``, consult the
-``docs/quickstart_top22_006.md`` guide.
+Purpose:
+- Parse CLI/YAML options and launch the Run-2 workflow planner/executor stack.
+
+Inputs/outputs:
+- Reads sample manifests (JSON/CFG) plus optional YAML option profiles.
+- Writes tuple-keyed histogram pickles and run summaries to the configured
+  output directory.
+
+Side effects:
+- Creates output files/directories and may dispatch tasks to futures/TaskVine.
+
+How to run:
+- ``python analysis/topeft_run2/run_analysis.py --help``
+- ``python analysis/topeft_run2/run_analysis.py --options analysis/topeft_run2/configs/fullR2_run.yml:cr``
 """
 
 from __future__ import annotations

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -67,7 +67,7 @@ def _verify_numpy_pandas_abi() -> None:
             "refreshed environment for both futures and TaskVine runs."
         ) from exc
 
-from run_analysis_helpers import (
+from analysis.topeft_run2.run_analysis_helpers import (
     RunConfig,
     RunConfigBuilder,
     _normalize_executor_name,

--- a/analysis/topeft_run2/run_sow.py
+++ b/analysis/topeft_run2/run_sow.py
@@ -1,3 +1,21 @@
+"""Run the Sum-of-Weights preprocessing workflow for input samples.
+
+Purpose:
+- Execute ``sow_processor`` over JSON/CFG sample manifests to produce
+  SumOfWeights histograms used to normalize downstream analysis jobs.
+
+Inputs/outputs:
+- Reads sample manifests and ROOT files listed in those manifests.
+- Writes a gzip+pickle histogram artifact (default: ``histos/sowTopEFT.pkl.gz``).
+
+Side effects:
+- Creates output directories/files and may run distributed execution backends.
+
+How to run:
+- ``python analysis/topeft_run2/run_sow.py --help``
+- ``python analysis/topeft_run2/run_sow.py input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json -x futures``
+"""
+
 import argparse
 import cloudpickle
 import gzip

--- a/analysis/topeft_run2/run_sow.py
+++ b/analysis/topeft_run2/run_sow.py
@@ -55,16 +55,18 @@ load_sample_json_file = tc_utils.load_sample_json_file
 read_cfg_file = tc_utils.read_cfg_file
 update_cfg = tc_utils.update_cfg
 
-parser = argparse.ArgumentParser(description='You can customize your run')
-parser.add_argument('inputFiles'       , nargs='?', default='', help = 'Json or cfg file(s) containing files and metadata')
+parser = argparse.ArgumentParser(
+    description="Run the SumOfWeights preprocessor and write a histogram pickle."
+)
+parser.add_argument('inputFiles'       , nargs='?', default='', help = 'JSON or CFG file(s) containing sample metadata')
 parser.add_argument('--chunksize','-s' , default=100000, type=int, help = 'Number of events per chunk')
-parser.add_argument('--max-files','-N' , default=0, type=int, help = 'If specified, limit the number of root files per sample. Useful for testing')
-parser.add_argument('--nchunks','-c'   , default=0, type=int, help = 'You can choose to run only a number of chunks')
-parser.add_argument('--outname','-o'   , default='sowTopEFT', help = 'Name of the output file with histograms')
-parser.add_argument('--outpath','-p'   , default='histos', help = 'Name of the output directory')
-parser.add_argument('--treename'       , default='Events', help = 'Name of the tree inside the files')
-parser.add_argument('--xrd'            , default='', help = 'The XRootD redirector to use when reading directly from json files')
-parser.add_argument('--wc-list'        , action='extend', nargs='+', help = 'Specify a list of Wilson coefficients to use in filling histograms.')
+parser.add_argument('--max-files','-N' , default=0, type=int, help = 'Limit the number of ROOT files per sample (useful for tests)')
+parser.add_argument('--nchunks','-c'   , default=0, type=int, help = 'Limit the number of chunks processed')
+parser.add_argument('--outname','-o'   , default='sowTopEFT', help = 'Base name for the output histogram file')
+parser.add_argument('--outpath','-p'   , default='histos', help = 'Directory where output files are written')
+parser.add_argument('--treename'       , default='Events', help = 'Tree name inside each input ROOT file')
+parser.add_argument('--xrd'            , default='', help = 'Redirector prefix applied when reading files from JSON inputs')
+parser.add_argument('--wc-list'        , action='extend', nargs='+', help = 'Wilson-coefficient names to include while filling histograms')
 EXECUTOR_CLI = ExecutorCLIHelper(
     remote_environment=remote_environment,
     futures_spec=FuturesArgumentSpec(

--- a/analysis/topeft_run2/run_sow.py
+++ b/analysis/topeft_run2/run_sow.py
@@ -36,20 +36,21 @@ if hasattr(NanoEventsFactory, "warn_missing_crossrefs"):
 elif hasattr(NanoAODSchema, "warn_missing_crossrefs"):
     NanoAODSchema.warn_missing_crossrefs = False
 
-import sow_processor
+from analysis.topeft_run2 import sow_processor
 
 from topeft.modules.executor_cli import (
     ExecutorCLIHelper,
     FuturesArgumentSpec,
     TaskVineArgumentSpec,
 )
+from topeft.modules.executor import (
+    build_futures_executor,
+    futures_runner_overrides,
+    taskvine_log_configurator,
+)
 
 
 remote_environment = topcoffea.modules.remote_environment
-tc_executor = topcoffea.modules.executor
-build_futures_executor = tc_executor.build_futures_executor
-futures_runner_overrides = tc_executor.futures_runner_overrides
-taskvine_log_configurator = tc_executor.taskvine_log_configurator
 tc_utils = topcoffea.modules.utils
 load_sample_json_file = tc_utils.load_sample_json_file
 read_cfg_file = tc_utils.read_cfg_file

--- a/analysis/topeft_run2/tauFitter.py
+++ b/analysis/topeft_run2/tauFitter.py
@@ -1,11 +1,20 @@
-##############################################################
-# Script for creating the fake tau scale factors
-# To use, run command python tauFitter.py -f /path/to/pkl/file
-# pkl file should have CRs listed below and have all other
-# corrections aside from fake tau SFs
-# output is in the form of linear fit y = mx+b
-# where m and b are in numerical form, y is the SF, and x is the tau pt
-# pt bins are from [20, 30], [30, 40], [40, 50], [50, 60], [60, 80], [80, 100], [100, 200]
+"""Fit fake-tau scale factors from control-region histogram outputs.
+
+Purpose:
+- Derive linear fake-tau scale-factor fits and uncertainty summaries from
+  control-region histograms.
+
+Inputs/outputs:
+- Reads one histogram pickle containing tau control-region yields.
+- Writes scale-factor fit plots/tables and optional JSON outputs.
+
+Side effects:
+- Creates output files and can generate web-index pages for saved plots.
+
+How to run:
+- ``python analysis/topeft_run2/tauFitter.py --help``
+- ``python analysis/topeft_run2/tauFitter.py -f histos/plotsTopEFT.pkl.gz`` 
+"""
 
 import numpy as np
 import copy

--- a/analysis/topeft_run2/update_json_sow.py
+++ b/analysis/topeft_run2/update_json_sow.py
@@ -1,3 +1,21 @@
+"""Update sample JSON normalization fields from SumOfWeights histograms.
+
+Purpose:
+- Compare SumOfWeights histograms against sample JSON metadata and update
+  ``nSumOfWeights*`` keys when matching datasets are found.
+
+Inputs/outputs:
+- Reads one SOW histogram pickle and JSON files under a target directory.
+- Rewrites matching JSON files in place (unless ``--dry-run`` is requested).
+
+Side effects:
+- Modifies JSON metadata files on disk.
+
+How to run:
+- ``python analysis/topeft_run2/update_json_sow.py --help``
+- ``python analysis/topeft_run2/update_json_sow.py -f histos/sowTopEFT.pkl.gz``
+"""
+
 import os
 import argparse
 
@@ -14,25 +32,10 @@ get_files = topcoffea.modules.utils.get_files
 get_hist_from_pkl = topcoffea.modules.utils.get_hist_from_pkl
 update_json = topcoffea.modules.update_json.update_json
 
-# Description:
-#   This script runs on a histogram file produced by the sow_processor. It extracts the individual
-#   SumOfWeights histograms and then tries to find a matching json file from somewhere in the
-#   'topcoffea/json' directory. If it finds a matching file it replaces the value for the
-#   'nSumOfWeights' key in the file with the one computed from the histogram.
-#
-#   This is typically a pre-processing step to running the topeft processor so that both the central
-#   and private MC samples can be normalized and treated in the same way. The issue is that when the
-#   JSON files for the EFT samples are initially made, the 'nSumOfWeights' that is computed is not
-#   correct. This means we had to recompute this value to get the correct normaliztion, but only for
-#   the EFT samples! After running this script the EFT sample JSON files will have the correct value
-#   and can be treated the same as the central MC samples.
-#
-# Usage:
-#
 # Note:
-#   A current limitation of this script is that if it encounters two JSON files with the exact
-#   same name, but in different sub-directories, then it skips updating that file and instead prints
-#   an error displaying the confounding JSONs.
+#   A current limitation of this script is that if it encounters two JSON files
+#   with the exact same name in different sub-directories, it skips updating
+#   that sample and prints the conflicting file paths.
 
 MAX_PDIFF = 1e-7
 

--- a/analysis/training/intro_hist.py
+++ b/analysis/training/intro_hist.py
@@ -3,8 +3,21 @@
 
 """Intro to modern histogram usage with ``hist`` and ``mplhep``.
 
-This training script replaces the legacy Coffea histogram tutorial and focuses
-on the APIs used by the current topeft/topcoffea stack.
+Purpose:
+- Demonstrate basic 1D/2D histogram filling and plotting with the ``hist`` API.
+- Provide a lightweight training entrypoint for users learning current
+  topeft/topcoffea histogram tooling.
+
+Inputs/outputs:
+- Inputs: no required arguments; optional local pickle path for the loader demo.
+- Outputs: in-memory matplotlib figures and console summary output.
+
+Side effects:
+- Opens windows/files through matplotlib backends when plots are rendered.
+- Optionally reads a gzip+pickle histogram payload when present.
+
+How to run:
+- ``python analysis/training/intro_hist.py``
 """
 
 from __future__ import annotations

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,49 +1,36 @@
-# pytest
-## Installing
-Run `conda install pytest` to install
-Optionally `conda install pytest-cov` to generate a local coverage report
+# Running tests in `topeft`
 
-## Running
-Run `pytest` from the root directory of topcoffea. It will find the `tests` folder, and run all python scripts starting with `test_`.
+Run tests from the `topeft` repository root.
 
-## Local reports
-Running `pytest --cov` will print a report at the end.
-Running `pytest --cov --cov-report html` will generate an html directory that can be copied to `~/www/` to view in the browser.
-By default, pytest only prints failure messages. The flags `-rP` will print all messages (`-r` is for better formatting, and `-P` is for printing messages from tests which passed).
+## Basic usage
 
-## Contents of the `tests` folder
-### `tests/test_make_1d_quad_plots.py`
-Test the quadratic fit plotting script
-### `tests/test_futures.py`
-The `test_futures` runs the analysis processor over a given file, `test_nonprompt()` runs the output from `test_topcoffea()` through `topcoffea/modules/dataDrivenEstimation.py`, `test_datacardmaker()` creates a test datacard. 
-### `tests/test_taskvine_executor.py`
-Launches `analysis/topeft_run2/run_analysis.py` with the TaskVine executor using
-a minimal local manager.  The test provisions a single worker via
-`ndcctools.taskvine.Factory` and checks that the histogram archive is written to
-the requested output directory.  Run it with:
-
-```
-pytest tests/test_taskvine_executor.py -k taskvine
+```bash
+python -m pytest -q
 ```
 
-To execute the test locally you need:
+Run a single test file:
 
-- `ndcctools` with the Python TaskVine bindings (`pip install ndcctools` or the
-  package provided by `environment.yml`).
-- A Coffea build that provides `coffea.processor.TaskVineExecutor` (for example
-  `coffea==2025.7.*`).
-- The `vine_worker` and `vine_factory` binaries on your `PATH` (installed
-  alongside the TaskVine bindings).
-
-When the bindings or executor are missing, the test is skipped automatically.
-### `test_yields()`
-Checks the yields from the output pkl file from the processor against ref yields. 
-
-
-Any of these test can be run individually by running e.g.
-```python
-python -i tests/test_topcoffea.py 
-test_topcoffea()
+```bash
+python -m pytest -q tests/test_processor_logging.py
 ```
- If a test requires ROOT, install with `conda install root_base -c conda-forge`
 
+Run a keyword-selected subset:
+
+```bash
+python -m pytest -q -k "futures"
+```
+
+## Coverage (optional)
+
+```bash
+python -m pytest --cov=. --cov-report=term
+python -m pytest --cov=. --cov-report=html
+```
+
+## Notes
+
+- Some tests exercise optional integrations (for example TaskVine) and may skip
+  automatically when required runtime dependencies are unavailable.
+- This repository currently has no global pytest `addopts`/marker policy in
+  `pyproject.toml` or `pytest.ini`; use explicit `pytest` flags/selections in
+  your command line when you need targeted runs.

--- a/topeft/modules/dataDrivenEstimation.py
+++ b/topeft/modules/dataDrivenEstimation.py
@@ -1,3 +1,21 @@
+"""Construct data-driven fake/nonprompt estimates from histogram pickles.
+
+Purpose:
+Apply process/channel regrouping and subtraction rules to histogram outputs in
+order to build data-driven background estimates for downstream plotting/cards.
+
+Inputs/outputs:
+- Input: histogram dictionaries or ``.pkl.gz`` artifacts.
+- Output: transformed histogram dictionary, optionally serialized to pickle.
+
+Side effects:
+- Reads and writes gzip+pickle files on disk.
+- Mutates histogram dictionaries during grouping/removal operations.
+
+How to run:
+- ``python topeft/modules/dataDrivenEstimation.py --pkl-file-path histos/plotsTopEFT.pkl.gz``
+"""
+
 import argparse
 import cloudpickle
 from collections import defaultdict
@@ -358,8 +376,10 @@ if __name__ == "__main__":
     from topeft.modules.logging_config import configure_topeft_logging
 
     configure_topeft_logging("INFO")
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-f", "--pkl-file-path", default="histos/plotsTopEFT.pkl.gz", help = "The path to the pkl file")
+    parser = argparse.ArgumentParser(
+        description="Build data-driven estimation histograms from an input pickle."
+    )
+    parser.add_argument("-f", "--pkl-file-path", default="histos/plotsTopEFT.pkl.gz", help = "Path to the input histogram pickle (.pkl.gz)")
     args = parser.parse_args()
 
     DataDrivenProducer(args.pkl_file_path, '')

--- a/topeft/modules/get_renormfact_envelope.py
+++ b/topeft/modules/get_renormfact_envelope.py
@@ -1,3 +1,22 @@
+"""Build renorm/fact envelope systematics from histogram dictionaries.
+
+Purpose:
+Collapse the six renormalization/factorization systematic variations into the
+most extreme up/down envelope for each process/channel/bin.
+
+Inputs/outputs:
+- Input: a histogram dictionary loaded from a ``.pkl.gz`` artifact.
+- Output: a transformed histogram dictionary written to a pickle file.
+
+Side effects:
+- Reads and writes pickle artifacts on disk.
+- Prints progress and category summaries to stdout.
+
+How to run:
+- ``python topeft/modules/get_renormfact_envelope.py histos/plotsTopEFT.pkl.gz``
+- ``python topeft/modules/get_renormfact_envelope.py histos/plotsTopEFT.pkl.gz --output-name histos/plotsTopEFT_rfenv.pkl.gz``
+"""
+
 import numpy as np
 import argparse
 
@@ -141,9 +160,11 @@ def main():
 
 
     # Set up the command line parser
-    parser = argparse.ArgumentParser()
-    parser.add_argument("pkl_file_path", help = "The path to the pkl file")
-    parser.add_argument("-n", "--output-name", default="histos_dict", help = "A name for the output file")
+    parser = argparse.ArgumentParser(
+        description="Compute renorm/fact envelope variations from a histogram pickle."
+    )
+    parser.add_argument("pkl_file_path", help = "Path to the input histogram pickle (.pkl.gz)")
+    parser.add_argument("-n", "--output-name", default="histos_dict", help = "Output pickle name/path for the envelope result")
     args = parser.parse_args()
 
     # Get the envelope and write to an out pkl
@@ -153,4 +174,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/topeft/quickstart.py
+++ b/topeft/quickstart.py
@@ -1,4 +1,21 @@
-"""Command line entry point for the Run 2 quickstart helpers."""
+"""Run the lightweight Run-2 quickstart workflow from the command line.
+
+Purpose:
+Provide a convenient entrypoint that validates sample inputs and launches a
+small Coffea run suitable for first-pass checks and onboarding.
+
+Inputs/outputs:
+- Input: sample JSON/CFG/directory plus quickstart execution options.
+- Output: quickstart histogram pickle artifacts under the selected output dir.
+
+Side effects:
+- Reads sample metadata and ROOT files.
+- Executes the analysis runner (futures by default) and writes output files.
+
+How to run:
+- ``python -m topeft.quickstart input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json``
+- ``python -m topeft.quickstart input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json --pretend``
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
### Summary
- Clarify local testing instructions in `README.md` and consolidate pytest guidance in `tests/README.md`.
- Add consistent top-level docstrings and improve CLI `argparse` help text across key analysis/util scripts.
- Fix import hygiene for `--help` on Run-2 entrypoints by switching to package-qualified imports under sanitized environments.
- Keep analysis/runtime semantics unchanged (changes are documentation and CLI/bootstrap-only).

### Motivation
Several scripts and docs were written assuming an “implicit” environment (e.g., running from specific working directories or relying on local import resolution). Under wrapper-sanitized execution (e.g., `PYTHONSAFEPATH=1`), some entrypoints fail at import time even for `--help`, and testing instructions were slightly misleading/fragmented. This PR makes CLI behavior more robust and brings documentation in line with current usage patterns.

### Implementation details
A) Testing documentation cleanup
- `README.md`
  - Replace bare `pytest` invocation with `python -m pytest -q`.
  - Clarify that commands are run from the `topeft` repo root (not “topcoffea directory”).
  - Add a pointer to `tests/README.md` for more workflow details.
- `tests/README.md`
  - Rewrite as `topeft`-specific guidance.
  - Provide examples for full suite, single-file, and keyword selection.
  - Add optional coverage commands and note that some integration tests may skip when dependencies are missing.

B) Import hygiene for CLI `--help` / sanitized execution
- `analysis/btagMCeff/run.py`
  - Replace bare `import btagMCeff` with `from analysis.btagMCeff import btagMCeff` so `python ... --help` works under sanitized import paths.
- `analysis/topeft_run2/run_analysis.py`
  - Replace bare `from run_analysis_helpers import ...` with `from analysis.topeft_run2.run_analysis_helpers import ...` to avoid reliance on implicit CWD/module search.
- `analysis/topeft_run2/run_sow.py`
  - Replace bare `import sow_processor` with `from analysis.topeft_run2 import sow_processor`.
  - Switch executor helper imports from a missing `topcoffea.modules.executor` path to `topeft.modules.executor` (already used by maintained entrypoints).

C) Docstring + CLI help/doc polish (no behavior changes intended)
- Add/expand top-level docstrings describing purpose/inputs/outputs/how-to-run for:
  - `analysis/extreme_events_study/run_extreme_events.py`
  - `analysis/flip_measurement/*` plotters and `run_flip.py`
  - `analysis/mc_validation/*plotter.py`
  - `analysis/topeft_run2/{comp.py, comp_yields.py, datacards_post_processing.py, get_datacard_yields.py, get_yield_json.py, make_1d_quad_plots.py, make_1d_quad_plots_from_template_histos.py, make_cards.py, make_cr_and_sr_plots.py, make_jsons.py, make_skim_jsons.py, missing_parton.py, parse_datacard_templates.py, tauFitter.py, update_json_sow.py}`
  - `analysis/training/intro_hist.py`
  - `topeft/modules/{dataDrivenEstimation.py, get_renormfact_envelope.py}`
  - `topeft/quickstart.py`
- Improve `argparse` descriptions and option help strings in several scripts (e.g., “redirector prefix”, “limit chunks”, “base output name”).
- Explicitly: no defaults/executor settings were intentionally changed; edits focus on help text and doc clarity.

### Testing
- `python -m pytest -q` (documented usage; full suite in CI)
- Targeted CLI smoke checks (help output) under wrapper-sanitized execution:
  - `python analysis/btagMCeff/run.py --help`
  - `python analysis/topeft_run2/run_sow.py --help`
  - `python analysis/topeft_run2/run_analysis.py --help`
- `python -m compileall ...` over touched modules/directories (as part of the hygiene round)
- Targeted unit test example used during the change:
  - `python -m pytest -q tests/test_logging_policy.py`

### Review notes
- Please sanity-check that the switch to `topeft.modules.executor` in `run_sow.py` matches the intended canonical executor helpers (it replaces a missing `topcoffea.modules.executor` import path).
- The bulk of the diff is docstrings and help text; any semantic change would be accidental. Reviewers can focus on:
  - import changes in `analysis/btagMCeff/run.py`, `analysis/topeft_run2/run_analysis.py`, `analysis/topeft_run2/run_sow.py`
  - `tests/README.md` and `README.md` wording updates