### PR TITLE
docs: centralize README testing instructions to canonical testing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,24 +172,15 @@ sh remake_ci_ref_datacard.sh
 ```
 The first script remakes the reference `json` file for the yields, and the second remakes the reference `txt` file for the datacar maker. If you are sure these change are expected, commit and push them to the PR.
 
-## Installing and running pytest locally
-To install `pytest` for local testing, run:
-```bash
-conda install -c conda-forge pytest pytest-cov
-```
-where `pytest-cov` is only used if you want to locally check the code coverage.
+## Testing
 
-The `pytest` commands are run automatically in the CI. If you would like to run them locally, you can simply run:
-```bash
-python -m pytest -q
-```
-from the `topeft` repository root. To run a focused subset, use e.g.:
-```bash
-python -m pytest -q tests/test_logging_policy.py
-```
-where the targeted file can be replaced with any test under `tests/`. If you would also like to see how the coverage changes, you can add `--cov=./ --cov-report=html` to the `python -m pytest` commands. This will create an `html` directory that you can then copy to any folder which you have web access to (e.g. `~/www/` on Earth). For a better printout of what passed and failed, add `-rP` to the command.
+Testing instructions are centralized in
+[docs/developer/testing.md](docs/developer/testing.md), which is the canonical
+source of truth for wrapper usage, pytest invocation, TaskVine-related test
+notes, and optional coverage flags.
 
-More test workflow details are documented in [`tests/README.md`](tests/README.md).
+The file [tests/README.md](tests/README.md) is a stub that points to the same
+canonical page.
 
 
 


### PR DESCRIPTION
### Summary
- Replace the README’s local pytest installation/invocation section with a pointer to the canonical testing documentation.
- Clarify that `docs/developer/testing.md` is the single source of truth for wrapper usage, pytest commands, TaskVine-related notes, and optional coverage flags.
- Keep `tests/README.md` positioned as a stub that points to the canonical page (no new testing workflow introduced here).

### Motivation
Testing guidance was duplicated across multiple places (README, tests docs, and developer docs). Keeping multiple “how to run pytest” snippets in sync is error-prone and can lead to outdated instructions (especially around wrapper usage and environment details). This PR reduces drift by making the README defer to the canonical testing page.

### Implementation details
A) README testing section
- `README.md`
  - Renamed the section to **Testing**.
  - Removed the inline conda install instructions for pytest and the extended local invocation guidance.
  - Added a pointer to `docs/developer/testing.md` as the canonical reference for:
    - wrapper usage
    - pytest invocation patterns
    - TaskVine-related test notes
    - optional coverage flags
  - Kept a short note explaining that `tests/README.md` is a stub pointing to the same canonical page.

### Testing
- Documentation-only change; no runtime or test behavior changes.
- No tests executed as part of this PR.

### Review notes
- Confirm the new README wording matches the project expectation that `docs/developer/testing.md` is the authoritative testing entrypoint.
- Ensure the links render correctly in the GitHub view:
  - `docs/developer/testing.md`
  - `tests/README.md`