### PR TITLE
docs: align topeft docs with coordinated topcoffea refs and canonical testing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ The `topeft/topeft` directory is installable as a Python package:
 The analysis relies on the shared `coffea2025` Conda environment and a sibling
 [`topcoffea`](https://github.com/TopEFT/topcoffea) checkout. The start-here hub
 summarises the setup steps and links to the TaskVine environment packaging guide.
-All CLI entry points validate that the `topcoffea` branch matches
-`ch_update_calcoffea` (or the release tag you specify via `TOPCOFFEA_BRANCH`).
+All CLI entry points validate that the installed `topcoffea` ref matches the
+coordinated ref expected for your run; for policy details, see
+`docs/topeft_integration.md` in the `topcoffea` repository.
 
 ### HistEFT support
 
@@ -38,7 +39,8 @@ exposes `HistEFT` via `topcoffea.modules.histEFT`, so existing
 imports keep working once the dependency is installed. CI includes a smoke test
 that asserts `import topcoffea` resolves outside the `topeft` checkout—remove any
 stray `topcoffea/` directories under this repository and reinstall the sibling
-package (for example via `pip install -e ../topcoffea`) if that guard triggers.
+package (for example via `pip install -e /path/to/topcoffea`) if that guard
+triggers.
 
 ## Related docs
 

--- a/README.md
+++ b/README.md
@@ -172,24 +172,15 @@ sh remake_ci_ref_datacard.sh
 ```
 The first script remakes the reference `json` file for the yields, and the second remakes the reference `txt` file for the datacar maker. If you are sure these change are expected, commit and push them to the PR.
 
-## Installing and running pytest locally
-To install `pytest` for local testing, run:
-```bash
-conda install -c conda-forge pytest pytest-cov
-```
-where `pytest-cov` is only used if you want to locally check the code coverage.
+## Testing
 
-The `pytest` commands are run automatically in the CI. If you would like to run them locally, you can simply run:
-```bash
-python -m pytest -q
-```
-from the `topeft` repository root. To run a focused subset, use e.g.:
-```bash
-python -m pytest -q tests/test_logging_policy.py
-```
-where the targeted file can be replaced with any test under `tests/`. If you would also like to see how the coverage changes, you can add `--cov=./ --cov-report=html` to the `python -m pytest` commands. This will create an `html` directory that you can then copy to any folder which you have web access to (e.g. `~/www/` on Earth). For a better printout of what passed and failed, add `-rP` to the command.
+Testing instructions are centralized in
+[docs/developer/testing.md](docs/developer/testing.md), which is the canonical
+source of truth for wrapper usage, pytest invocation, TaskVine-related test
+notes, and optional coverage flags.
 
-More test workflow details are documented in [`tests/README.md`](tests/README.md).
+The file [tests/README.md](tests/README.md) is a stub that points to the same
+canonical page.
 
 
 

--- a/analysis/training/README.md
+++ b/analysis/training/README.md
@@ -22,7 +22,7 @@ Canonical project documentation lives in [docs/index.md](../../docs/index.md).
     ```
     - Run the run script over a json that points to the root file you downloaded: 
     ```
-    python simple_run.py ../../topcoffea/json/test_samples/UL17_private_ttH_for_CI.json
+    python simple_run.py ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json
     ```
 
 * `intro_hist.py` and `intro_hist.ipynb`: A basic introduction to the supported histogram stack (`hist` + `mplhep`), including modern filling, slicing, and 2D plotting.

--- a/docs/extreme_events_study.md
+++ b/docs/extreme_events_study.md
@@ -48,7 +48,7 @@ df_pt_j = output["pt_j"].value
 Example command pattern from historical notes:
 
 ```bash
-python run_extreme_events.py ../../topcoffea/cfg/mc_signal_samples_NDSkim.cfg --skip-cr --do-np --executor taskvine
+python run_extreme_events.py ../../input_samples/cfgs/mc_signal_samples_NDSkim.cfg --skip-cr --do-np --executor taskvine
 ```
 
 ### 2. Dataframe-driven yields

--- a/docs/quickstart_run2.md
+++ b/docs/quickstart_run2.md
@@ -11,8 +11,10 @@ set up the shared `coffea2025` environment plus the sibling
 1. Follow the “Start here” hub to create/activate the shared environment, install
    both repositories in editable mode, and build the TaskVine environment
    tarball (when needed).
-2. Keep `topcoffea` on the `ch_update_calcoffea` branch (or matching tag) so
-   cache-free jet/MET corrections match the workflow expectations.
+2. Keep `topcoffea` on a coordinated ref (matching release tags or aligned
+   feature refs) so cache-free jet/MET corrections match the workflow
+   expectations. For compatibility policy, see
+   `topcoffea/docs/topeft_integration.md`.
 3. Pick a sample manifest such as
    `input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json`. The
    helper accepts directories and `.cfg` bundles as well; see
@@ -25,13 +27,12 @@ minutes using the quickstart module below.
 ### Cache-free jet/MET corrections
 
 Run 2 processing now assumes the cache-free jet and MET correction interfaces
-shipped with the `ch_update_calcoffea` branch of `topcoffea`.  The helper and
-full workflow no longer rely on NanoEvents caches when building corrected jets
-or propagating jet variations into MET; the updated APIs materialise the
-corrections directly.  Make sure your environment uses the matching
-`topcoffea` checkout (or a release containing the same cache-free helpers) so
-the processor can run end-to-end without attaching a `lazy_cache` to the
-NanoEvents object.
+provided by coordinated `topcoffea` refs. The helper and full workflow no
+longer rely on NanoEvents caches when building corrected jets or propagating jet
+variations into MET; the updated APIs materialise the corrections directly. Make
+sure your environment uses a matching `topcoffea` checkout (or a release
+containing the same cache-free helpers) so the processor can run end-to-end
+without attaching a `lazy_cache` to the NanoEvents object.
 
 Run 2 histogramming expects Awkward's native implementations of helpers such as
 `ak.stack` and relies on in-memory arithmetic instead of array-of-arrays

--- a/docs/run_analysis_configuration.md
+++ b/docs/run_analysis_configuration.md
@@ -288,9 +288,10 @@ switching executors once the run is ready to scale beyond the local machine.
   root or supply absolute paths.
 * If histogram handling fails with an ``ImportError`` noting that
   ``topcoffea.modules.histEFT`` is missing, confirm
-  that your sibling ``topcoffea`` checkout is on the ``ch_update_calcoffea``
-  branch (or matching tag) and reinstall it with ``pip install -e ../topcoffea``
-  before retrying the run.
+  that your installed ``topcoffea`` ref follows the coordinated compatibility
+  guidance in ``topcoffea/docs/topeft_integration.md``, then reinstall from your
+  local checkout (for example ``pip install -e /path/to/topcoffea``) before
+  retrying the run.
 
 With these pieces in place you can mix and match quickstart presets and YAML
 profiles while keeping the run history compact and shareable.  When you need to

--- a/docs/taskvine_workflow.md
+++ b/docs/taskvine_workflow.md
@@ -24,10 +24,13 @@ next to `topeft` and install it in editable mode:
 cd ..
 git clone https://github.com/TopEFT/topcoffea.git
 cd topcoffea
-git switch ch_update_calcoffea
+git switch <coordinated-ref>
 pip install -e .
 cd ../topeft
 ```
+
+Choose a release tag or feature ref coordinated with your `topeft` checkout.
+Compatibility policy is documented in `topcoffea/docs/topeft_integration.md`.
 
 Upgrading an existing checkout?  Run `conda env update -f environment.yml --prune`
 instead of recreating the environment.  Conda may request a solver update when
@@ -41,10 +44,10 @@ The workflow relies on the refreshed
 `topcoffea.modules.remote_environment.get_environment()` helper to assemble a
 TaskVine-ready archive under `topeft-envs/`.  Run the packaging step after
 installing the editable modules or updating dependencies.  Always invoke the
-helper from the same branch (or tag) you just installed so the tarball mirrors
-the source checkout—every CLI entry point now validates the active branch via
-`.git/HEAD` (or the `TOPCOFFEA_BRANCH` override for detached tags) and aborts
-early when the sibling repository drifts from `ch_update_calcoffea`:
+helper from the same ref (or tag) you just installed so the tarball mirrors the
+source checkout—every CLI entry point now validates `.git/HEAD` (or the
+`TOPCOFFEA_BRANCH` override for detached tags) against the coordinated ref and
+aborts early when the sibling repository drifts:
 
 ```bash
 python -m topcoffea.modules.remote_environment

--- a/docs/workflow_and_yaml_hub.md
+++ b/docs/workflow_and_yaml_hub.md
@@ -14,8 +14,10 @@ This hub pulls together the essentials for launching Run 2 analyses, choosing be
    `topeft` and the sibling [`topcoffea`](https://github.com/TopEFT/topcoffea)
    checkout in editable mode. The commands are summarised in the repository
    `README.md` and expanded in the [environment packaging guide](environment_packaging.md).
-2. Keep `topcoffea` on the `ch_update_calcoffea` branch (or matching release tag)
-   so the cache-free jet/MET corrections match what the Run‑2 workflow expects.
+2. Keep `topcoffea` on a coordinated ref (matching release tags or aligned
+   feature refs) so the cache-free jet/MET corrections match what the Run‑2
+   workflow expects. Compatibility policy is documented in
+   `topcoffea/docs/topeft_integration.md`.
 3. If you plan to run distributed jobs, build the TaskVine environment tarball
    via `python -m topcoffea.modules.remote_environment` before launching any runs.
 4. When you are ready for an end-to-end smoke test, follow the links at the end

--- a/notes/format_update_anpicci_calcoffea.md
+++ b/notes/format_update_anpicci_calcoffea.md
@@ -1,5 +1,5 @@
 # Branch notes for `format_update_anpicci_calcoffea`
 
-- Verified the sibling `topcoffea` checkout is still on the `ch_update_calcoffea` branch for dependency alignment.
+- Verified the sibling `topcoffea` checkout remained on a coordinated ref for dependency alignment.
 - The workflow runner continues to invoke `coffea.processor.Runner` with the `AnalysisProcessor` instance (see `analysis/topeft_run2/workflow.py`).
 - Updated `analysis/topeft_run2/analysis_processor.py` so `AnalysisProcessor` directly subclasses `coffea.processor.ProcessorABC`, matching the executor's validation expectations and avoiding ProcessorABC mismatch errors.


### PR DESCRIPTION
### Summary
- Replaced hard-coded `topcoffea` branch pairing language (`ch_update_calcoffea`) with coordinated-ref guidance and a pointer to `topcoffea/docs/topeft_integration.md`.
- Removed tracked docs examples that relied on sibling-repo relative paths (`../topcoffea`, `../../topcoffea`) in favor of repo-agnostic placeholders or in-repo sample paths.
- Centralized local testing instructions by pointing the README (and `tests/README.md` stub) to `docs/developer/testing.md`.

### Motivation
Several `topeft` docs had drifted into branch-specific and checkout-layout-specific guidance (explicit `ch_update_calcoffea` pairing and `../topcoffea` style examples). This is brittle:
- it becomes stale as soon as coordinated branches/tags change,
- it breaks for users who do not place repositories as siblings,
- it conflicts with the coordinated-ref policy documented in `topcoffea/docs/topeft_integration.md`,
- it duplicates (and risks diverging from) canonical testing documentation.

This PR makes the documentation consistent with the coordinated-ref policy and reduces assumptions about local directory layout.

### Implementation details

A) Coordinated-ref policy wording (no branch literals in guidance)
- `README.md`: replaced “validate that the `topcoffea` branch matches `ch_update_calcoffea`” with “validate the installed `topcoffea` ref matches the coordinated ref expected for your run,” and pointed to `topcoffea/docs/topeft_integration.md` for policy.
- `docs/quickstart_run2.md`, `docs/workflow_and_yaml_hub.md`, `docs/run_analysis_configuration.md`, `docs/taskvine_workflow.md`: removed branch-pairing instructions and replaced them with coordinated-ref language; where relevant, pointed to `topcoffea/docs/topeft_integration.md`.

Semantics note: documentation-only wording changes; no runtime behavior is changed by this PR.

B) Remove checkout-layout coupling in examples
- `README.md`: replaced `pip install -e ../topcoffea` example with a repo-agnostic placeholder (`pip install -e /path/to/topcoffea`).
- `analysis/training/README.md`: updated the training example to use an in-repo sample JSON under `input_samples/...` instead of `../../topcoffea/...`.
- `docs/extreme_events_study.md`: updated the historical command example to use an in-repo config path under `input_samples/cfgs/...`.

C) Canonical testing documentation
- `README.md`: collapsed verbose pytest install/invocation instructions into a pointer to `docs/developer/testing.md`, making it the source of truth for wrapper usage, pytest patterns, TaskVine notes, and coverage flags.
- `README.md`: clarified that `tests/README.md` is a stub pointing to the canonical page.

### Testing
Docs-only change; no code-path tests were added or modified.

What was verified during the audit workflow:
- Tracked markdown relative-link integrity check passed (all tracked `*.md`).
- Guard scan confirmed no remaining `../topcoffea` / `../../topcoffea` style references in tracked markdown docs after the update.

### Review notes
- Please sanity-check the updated example paths:
  - `analysis/training/README.md` now points to `../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json`.
  - `docs/extreme_events_study.md` now uses `../../input_samples/cfgs/mc_signal_samples_NDSkim.cfg`.
- The intent is strictly documentation consistency and reduced brittleness; any lingering branch literals in “historical notes” files are out of scope unless they still read as prescriptive guidance.