### PR TITLE
docs+tests: align cross-repo guidance and harden hist import guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ The `topeft/topeft` directory is installable as a Python package:
 The analysis relies on the shared `coffea2025` Conda environment and a sibling
 [`topcoffea`](https://github.com/TopEFT/topcoffea) checkout. The start-here hub
 summarises the setup steps and links to the TaskVine environment packaging guide.
-All CLI entry points validate that the `topcoffea` branch matches
-`ch_update_calcoffea` (or the release tag you specify via `TOPCOFFEA_BRANCH`).
+All CLI entry points validate that the installed `topcoffea` ref matches the
+coordinated ref expected for your run; for policy details, see
+`docs/topeft_integration.md` in the `topcoffea` repository.
 
 ### HistEFT support
 
@@ -38,7 +39,8 @@ exposes `HistEFT` via `topcoffea.modules.histEFT`, so existing
 imports keep working once the dependency is installed. CI includes a smoke test
 that asserts `import topcoffea` resolves outside the `topeft` checkout—remove any
 stray `topcoffea/` directories under this repository and reinstall the sibling
-package (for example via `pip install -e ../topcoffea`) if that guard triggers.
+package (for example via `pip install -e /path/to/topcoffea`) if that guard
+triggers.
 
 ## Related docs
 

--- a/README.md
+++ b/README.md
@@ -172,24 +172,15 @@ sh remake_ci_ref_datacard.sh
 ```
 The first script remakes the reference `json` file for the yields, and the second remakes the reference `txt` file for the datacar maker. If you are sure these change are expected, commit and push them to the PR.
 
-## Installing and running pytest locally
-To install `pytest` for local testing, run:
-```bash
-conda install -c conda-forge pytest pytest-cov
-```
-where `pytest-cov` is only used if you want to locally check the code coverage.
+## Testing
 
-The `pytest` commands are run automatically in the CI. If you would like to run them locally, you can simply run:
-```bash
-python -m pytest -q
-```
-from the `topeft` repository root. To run a focused subset, use e.g.:
-```bash
-python -m pytest -q tests/test_logging_policy.py
-```
-where the targeted file can be replaced with any test under `tests/`. If you would also like to see how the coverage changes, you can add `--cov=./ --cov-report=html` to the `python -m pytest` commands. This will create an `html` directory that you can then copy to any folder which you have web access to (e.g. `~/www/` on Earth). For a better printout of what passed and failed, add `-rP` to the command.
+Testing instructions are centralized in
+[docs/developer/testing.md](docs/developer/testing.md), which is the canonical
+source of truth for wrapper usage, pytest invocation, TaskVine-related test
+notes, and optional coverage flags.
 
-More test workflow details are documented in [`tests/README.md`](tests/README.md).
+The file [tests/README.md](tests/README.md) is a stub that points to the same
+canonical page.
 
 
 

--- a/analysis/training/README.md
+++ b/analysis/training/README.md
@@ -22,7 +22,7 @@ Canonical project documentation lives in [docs/index.md](../../docs/index.md).
     ```
     - Run the run script over a json that points to the root file you downloaded: 
     ```
-    python simple_run.py ../../topcoffea/json/test_samples/UL17_private_ttH_for_CI.json
+    python simple_run.py ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json
     ```
 
 * `intro_hist.py` and `intro_hist.ipynb`: A basic introduction to the supported histogram stack (`hist` + `mplhep`), including modern filling, slicing, and 2D plotting.

--- a/docs/extreme_events_study.md
+++ b/docs/extreme_events_study.md
@@ -48,7 +48,7 @@ df_pt_j = output["pt_j"].value
 Example command pattern from historical notes:
 
 ```bash
-python run_extreme_events.py ../../topcoffea/cfg/mc_signal_samples_NDSkim.cfg --skip-cr --do-np --executor taskvine
+python run_extreme_events.py ../../input_samples/cfgs/mc_signal_samples_NDSkim.cfg --skip-cr --do-np --executor taskvine
 ```
 
 ### 2. Dataframe-driven yields

--- a/docs/quickstart_run2.md
+++ b/docs/quickstart_run2.md
@@ -11,8 +11,10 @@ set up the shared `coffea2025` environment plus the sibling
 1. Follow the “Start here” hub to create/activate the shared environment, install
    both repositories in editable mode, and build the TaskVine environment
    tarball (when needed).
-2. Keep `topcoffea` on the `ch_update_calcoffea` branch (or matching tag) so
-   cache-free jet/MET corrections match the workflow expectations.
+2. Keep `topcoffea` on a coordinated ref (matching release tags or aligned
+   feature refs) so cache-free jet/MET corrections match the workflow
+   expectations. For compatibility policy, see
+   `topcoffea/docs/topeft_integration.md`.
 3. Pick a sample manifest such as
    `input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json`. The
    helper accepts directories and `.cfg` bundles as well; see
@@ -25,13 +27,12 @@ minutes using the quickstart module below.
 ### Cache-free jet/MET corrections
 
 Run 2 processing now assumes the cache-free jet and MET correction interfaces
-shipped with the `ch_update_calcoffea` branch of `topcoffea`.  The helper and
-full workflow no longer rely on NanoEvents caches when building corrected jets
-or propagating jet variations into MET; the updated APIs materialise the
-corrections directly.  Make sure your environment uses the matching
-`topcoffea` checkout (or a release containing the same cache-free helpers) so
-the processor can run end-to-end without attaching a `lazy_cache` to the
-NanoEvents object.
+provided by coordinated `topcoffea` refs. The helper and full workflow no
+longer rely on NanoEvents caches when building corrected jets or propagating jet
+variations into MET; the updated APIs materialise the corrections directly. Make
+sure your environment uses a matching `topcoffea` checkout (or a release
+containing the same cache-free helpers) so the processor can run end-to-end
+without attaching a `lazy_cache` to the NanoEvents object.
 
 Run 2 histogramming expects Awkward's native implementations of helpers such as
 `ak.stack` and relies on in-memory arithmetic instead of array-of-arrays

--- a/docs/run_analysis_configuration.md
+++ b/docs/run_analysis_configuration.md
@@ -288,9 +288,10 @@ switching executors once the run is ready to scale beyond the local machine.
   root or supply absolute paths.
 * If histogram handling fails with an ``ImportError`` noting that
   ``topcoffea.modules.histEFT`` is missing, confirm
-  that your sibling ``topcoffea`` checkout is on the ``ch_update_calcoffea``
-  branch (or matching tag) and reinstall it with ``pip install -e ../topcoffea``
-  before retrying the run.
+  that your installed ``topcoffea`` ref follows the coordinated compatibility
+  guidance in ``topcoffea/docs/topeft_integration.md``, then reinstall from your
+  local checkout (for example ``pip install -e /path/to/topcoffea``) before
+  retrying the run.
 
 With these pieces in place you can mix and match quickstart presets and YAML
 profiles while keeping the run history compact and shareable.  When you need to

--- a/docs/taskvine_workflow.md
+++ b/docs/taskvine_workflow.md
@@ -24,10 +24,13 @@ next to `topeft` and install it in editable mode:
 cd ..
 git clone https://github.com/TopEFT/topcoffea.git
 cd topcoffea
-git switch ch_update_calcoffea
+git switch <coordinated-ref>
 pip install -e .
 cd ../topeft
 ```
+
+Choose a release tag or feature ref coordinated with your `topeft` checkout.
+Compatibility policy is documented in `topcoffea/docs/topeft_integration.md`.
 
 Upgrading an existing checkout?  Run `conda env update -f environment.yml --prune`
 instead of recreating the environment.  Conda may request a solver update when
@@ -41,10 +44,10 @@ The workflow relies on the refreshed
 `topcoffea.modules.remote_environment.get_environment()` helper to assemble a
 TaskVine-ready archive under `topeft-envs/`.  Run the packaging step after
 installing the editable modules or updating dependencies.  Always invoke the
-helper from the same branch (or tag) you just installed so the tarball mirrors
-the source checkout—every CLI entry point now validates the active branch via
-`.git/HEAD` (or the `TOPCOFFEA_BRANCH` override for detached tags) and aborts
-early when the sibling repository drifts from `ch_update_calcoffea`:
+helper from the same ref (or tag) you just installed so the tarball mirrors the
+source checkout—every CLI entry point now validates `.git/HEAD` (or the
+`TOPCOFFEA_BRANCH` override for detached tags) against the coordinated ref and
+aborts early when the sibling repository drifts:
 
 ```bash
 python -m topcoffea.modules.remote_environment

--- a/docs/workflow_and_yaml_hub.md
+++ b/docs/workflow_and_yaml_hub.md
@@ -14,8 +14,10 @@ This hub pulls together the essentials for launching Run 2 analyses, choosing be
    `topeft` and the sibling [`topcoffea`](https://github.com/TopEFT/topcoffea)
    checkout in editable mode. The commands are summarised in the repository
    `README.md` and expanded in the [environment packaging guide](environment_packaging.md).
-2. Keep `topcoffea` on the `ch_update_calcoffea` branch (or matching release tag)
-   so the cache-free jet/MET corrections match what the Run‑2 workflow expects.
+2. Keep `topcoffea` on a coordinated ref (matching release tags or aligned
+   feature refs) so the cache-free jet/MET corrections match what the Run‑2
+   workflow expects. Compatibility policy is documented in
+   `topcoffea/docs/topeft_integration.md`.
 3. If you plan to run distributed jobs, build the TaskVine environment tarball
    via `python -m topcoffea.modules.remote_environment` before launching any runs.
 4. When you are ready for an end-to-end smoke test, follow the links at the end

--- a/notes/format_update_anpicci_calcoffea.md
+++ b/notes/format_update_anpicci_calcoffea.md
@@ -1,5 +1,5 @@
 # Branch notes for `format_update_anpicci_calcoffea`
 
-- Verified the sibling `topcoffea` checkout is still on the `ch_update_calcoffea` branch for dependency alignment.
+- Verified the sibling `topcoffea` checkout remained on a coordinated ref for dependency alignment.
 - The workflow runner continues to invoke `coffea.processor.Runner` with the `AnalysisProcessor` instance (see `analysis/topeft_run2/workflow.py`).
 - Updated `analysis/topeft_run2/analysis_processor.py` so `AnalysisProcessor` directly subclasses `coffea.processor.ProcessorABC`, matching the executor's validation expectations and avoiding ProcessorABC mismatch errors.

--- a/tests/test_no_coffea_hist_imports.py
+++ b/tests/test_no_coffea_hist_imports.py
@@ -11,6 +11,7 @@ _FORBIDDEN_TOKENS = (
     "from coffea import hist",
     "import coffea.hist",
 )
+_SELF_TEST_RELATIVE = Path("tests/test_no_coffea_hist_imports.py")
 
 
 def _tracked_text_files() -> list[Path]:
@@ -33,6 +34,8 @@ def test_no_legacy_coffea_hist_imports() -> None:
     matches: list[str] = []
     for path in _tracked_text_files():
         relpath = path.relative_to(_ROOT)
+        if relpath == _SELF_TEST_RELATIVE:
+            continue
         for lineno, line in enumerate(path.read_text(encoding="utf-8", errors="ignore").splitlines(), start=1):
             if any(token in line for token in _FORBIDDEN_TOKENS):
                 matches.append(f"{relpath}:{lineno}:{line.strip()}")


### PR DESCRIPTION
### Summary
- Replace branch-specific `topcoffea` pairing language in `README.md`/Run 2 workflow docs with coordinated-ref guidance and a pointer to `topcoffea/docs/topeft_integration.md`.
- Remove outside-repo path examples (`../topcoffea`, `../../topcoffea/...`) from docs by switching to repo-agnostic placeholders or in-repo sample paths.
- Centralize local testing instructions by making `README.md` + `tests/README.md` point to `docs/developer/testing.md`.
- Fix a deterministic false-positive in `tests/test_no_coffea_hist_imports.py` by excluding the sentinel test file from its own forbidden-token scan.

### Motivation
- The docs had drifted into referencing a specific historical `topcoffea` branch (`ch_update_calcoffea`) and sibling checkout paths, which conflicts with the newer “coordinated refs/tags” policy and breaks for users who do not keep repos in a particular directory layout.
- Local testing guidance was duplicated between `README.md`, `tests/README.md`, and the developer docs, increasing maintenance burden and the chance of stale instructions.
- The “no legacy `coffea.hist` imports” guard test was failing deterministically because it scanned its own forbidden-token definitions; this is noise that can block CI without indicating a real regression.

### Implementation details
A) Cross-repo compatibility language (docs-only)
- `README.md`
  - Replace “branch matches `ch_update_calcoffea`” messaging with “installed `topcoffea` ref matches the coordinated ref expected for your run”.
  - Point readers to `docs/topeft_integration.md` in the `topcoffea` repository as the policy source of truth.
  - Make the reinstall example repo-agnostic (`pip install -e /path/to/topcoffea`) instead of assuming a sibling `../topcoffea` layout.

- `docs/quickstart_run2.md`, `docs/taskvine_workflow.md`, `docs/workflow_and_yaml_hub.md`, `docs/run_analysis_configuration.md`
  - Replace hard-coded `ch_update_calcoffea` branch pairing with coordinated-ref guidance (release tags or aligned feature refs).
  - Use a placeholder ref in command snippets (`git switch <coordinated-ref>`) and keep the policy pointer to `topcoffea/docs/topeft_integration.md`.

B) Remove outside-repo example paths in tracked docs
- `analysis/training/README.md`
  - Update the `simple_run.py` example to use an in-repo sample manifest under `input_samples/...` instead of `../../topcoffea/...`.

- `docs/extreme_events_study.md`
  - Update the historical command example to reference an in-repo cfg path under `input_samples/cfgs/...` instead of `../../topcoffea/cfg/...`.

C) Testing docs centralization
- `README.md`
  - Replace the detailed pytest installation/invocation block with a single canonical pointer to `docs/developer/testing.md`.

- `tests/README.md` (referenced by README; remains a stub)
  - Keep as a pointer to `docs/developer/testing.md` so there is exactly one maintained source for test workflow details.

D) Stabilize the legacy-hist import guard test
- `tests/test_no_coffea_hist_imports.py`
  - Add an explicit self-path constant and skip logic so the scanner does not flag its own forbidden-token literals.
  - Semantics are unchanged for all other tracked files: the test still fails if any other file contains a legacy `coffea.hist` import pattern.

### Testing
- `python -m compileall topeft/modules analysis tests`
- `python -m pytest -q`

Notes:
- These changes are documentation + test-only; no analysis/physics logic or runtime code paths were modified.

### Review notes
- Please sanity-check the coordinated-ref wording and the pointer to `topcoffea/docs/topeft_integration.md` to ensure it matches the intended cross-repo policy.
- Confirm the updated example paths under `input_samples/...` match the repository layout expected for training/extreme-events docs.
- For `tests/test_no_coffea_hist_imports.py`, the only behavior change should be excluding the test file itself from scanning; all other files remain covered.
````md