### PR TITLE
Runtime guard messaging: coordinated-ref guidance + eliminate invalid-escape warnings

### DIFF
--- a/analysis/topeft_run2/missing_parton.py
+++ b/analysis/topeft_run2/missing_parton.py
@@ -203,7 +203,7 @@ if __name__ == '__main__':
                 fout[fname_with_var.replace('njets', '2b')] = {proc : np.nan_to_num(parton/total_private, 0)}
             else:
                 lep_bin = re.sub('_'+var, '', fname_with_var)
-                lep_bin = re.sub('_\wj', '', lep_bin)
+                lep_bin = re.sub(r'_\wj', '', lep_bin)
                 if 'offZ' in lep_bin:
                     lep_bin = re.sub('_offZ', '', lep_bin)
                     lep_bin = lep_bin.split('_')
@@ -211,7 +211,7 @@ if __name__ == '__main__':
                 if 'onZ' in lep_bin:
                     lep_bin = re.sub('onZ', 'sfz', lep_bin)
                 offset = -4 if '3l' not in fname else -2
-                jet_bin = int(re.findall('\dj', fname_with_var)[0][:-1])
+                jet_bin = int(re.findall(r'\dj', fname_with_var)[0][:-1])
                 parton = np.array(fout[lep_bin]['tllq'].array())[jet_bin + offset] * total_private
             sign = np.ones_like(parton)
             err_low  = total_private - np.sqrt(np.square(err[0]) + np.square(parton))

--- a/analysis/topeft_run2/workflow.py
+++ b/analysis/topeft_run2/workflow.py
@@ -81,7 +81,8 @@ def _import_topcoffea_submodule(submodule: str):
             (
                 "Unable to import required topcoffea helper module '%s'. "
                 "Ensure the sibling topcoffea checkout is available and on the "
-                "'ch_update_calcoffea' branch."
+                "coordinated ref for this topeft checkout. See "
+                "topcoffea/docs/topeft_integration.md for compatibility policy."
             )
             % module_name
         ) from exc

--- a/tests/test_dependency_checks.py
+++ b/tests/test_dependency_checks.py
@@ -45,7 +45,9 @@ def test_branch_guard_rejects_mismatched_branch(monkeypatch, tmp_path):
     with pytest.raises(RuntimeError) as excinfo:
         ensure_topcoffea_branch()
 
-    assert "ch_update_calcoffea" in str(excinfo.value)
+    message = str(excinfo.value)
+    assert "coordinated ref" in message
+    assert "topcoffea/docs/topeft_integration.md" in message
 
 
 def test_branch_guard_accepts_env_override(monkeypatch, tmp_path):

--- a/tests/test_workflow_topcoffea_imports.py
+++ b/tests/test_workflow_topcoffea_imports.py
@@ -50,7 +50,7 @@ def test_workflow_imports_missing_paths(monkeypatch: pytest.MonkeyPatch) -> None
 
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=RuntimeWarning)
-        with pytest.raises(ImportError, match="ch_update_calcoffea"):
+        with pytest.raises(ImportError, match="coordinated ref"):
             runpy.run_module(
                 "analysis.topeft_run2.workflow", run_name="analysis.topeft_run2.workflow"
             )

--- a/topeft/_dependency_checks.py
+++ b/topeft/_dependency_checks.py
@@ -69,7 +69,9 @@ def ensure_topcoffea_branch(expected_refs: Optional[Sequence[str]] = None) -> No
     except Exception as exc:  # pragma: no cover - environment issue
         raise RuntimeError(
             "topcoffea is not installed. Clone https://github.com/TopEFT/topcoffea, "
-            "switch to the ch_update_calcoffea branch, and install it with 'pip install -e .'"
+            "install it with 'pip install -e .', and ensure the installed ref matches "
+            "the coordinated ref for this topeft checkout. See "
+            "topcoffea/docs/topeft_integration.md for compatibility policy."
         ) from exc
 
     repo_root = _topcoffea_repo_root(topcoffea)
@@ -90,8 +92,9 @@ def ensure_topcoffea_branch(expected_refs: Optional[Sequence[str]] = None) -> No
 
     message = (
         "topcoffea checkout at {repo} is on '{branch}' but the workflow expects one of "
-        "{expected}. Run 'git -C {repo} switch ch_update_calcoffea' (or checkout the "
-        "matching tag) before running topeft, or export TOPCOFFEA_BRANCH to override.".format(
+        "{expected}. Ensure the installed topcoffea ref matches the coordinated ref for "
+        "this topeft checkout; see topcoffea/docs/topeft_integration.md for compatibility "
+        "policy. You can export TOPCOFFEA_BRANCH to override.".format(
             repo=repo_root,
             branch=branch,
             expected=", ".join(expected),

--- a/topeft/modules/runner_output.py
+++ b/topeft/modules/runner_output.py
@@ -41,9 +41,10 @@ def _load_hist_eft():  # pragma: no cover - import shim exercised in dedicated t
     except Exception as exc:
         raise ImportError(
             "topcoffea is installed but does not provide a HistEFT class in "
-            "topcoffea.modules.histEFT. Update the dependency (for example by "
-            "checking out the ch_update_calcoffea branch) and reinstall to "
-            "restore tuple-keyed histogram support."
+            "topcoffea.modules.histEFT. Update the dependency so the installed "
+            "topcoffea ref matches the coordinated ref for this topeft checkout, "
+            "then reinstall to restore tuple-keyed histogram support. See "
+            "topcoffea/docs/topeft_integration.md for compatibility policy."
         ) from exc
 
     candidate = getattr(module, "HistEFT", None)
@@ -52,9 +53,10 @@ def _load_hist_eft():  # pragma: no cover - import shim exercised in dedicated t
 
     raise ImportError(
         "topcoffea is installed but does not provide a HistEFT class in "
-        "topcoffea.modules.histEFT. Update the dependency (for example by "
-        "checking out the ch_update_calcoffea branch) and reinstall to "
-        "restore tuple-keyed histogram support."
+        "topcoffea.modules.histEFT. Update the dependency so the installed "
+        "topcoffea ref matches the coordinated ref for this topeft checkout, "
+        "then reinstall to restore tuple-keyed histogram support. See "
+        "topcoffea/docs/topeft_integration.md for compatibility policy."
     )
 
 


### PR DESCRIPTION
### Summary
- Replace hard-coded `ch_update_calcoffea` guidance in runtime dependency/import errors with coordinated-ref wording and a pointer to `topcoffea/docs/topeft_integration.md`.
- Update tests to assert the new coordinated-ref messaging.
- Remove Python 3.13 `SyntaxWarning: invalid escape sequence` warnings in `analysis/topeft_run2/missing_parton.py` by using raw-string regex literals.

### Motivation
- `topeft` documentation has moved to a coordinated-ref policy, but runtime guard/error messages still instructed users to switch to a specific `topcoffea` branch. This mismatch creates confusion when diagnosing environment/setup issues.
- `compileall` emitted invalid-escape warnings under Python 3.13 from regex string literals in a runtime-adjacent analysis module; eliminating these warnings keeps verification output clean and easier to interpret.

### Implementation details
A) Runtime guard messaging aligned to coordinated refs
- `analysis/topeft_run2/workflow.py`
  - Update `_import_topcoffea_submodule(...)` ImportError text to remove `'ch_update_calcoffea'` and direct users to the coordinated ref policy (`topcoffea/docs/topeft_integration.md`).
- `topeft/_dependency_checks.py`
  - Update the “topcoffea not installed” RuntimeError to remove branch instructions and instead:
    - keep the editable install guidance (`pip install -e .`)
    - instruct that the installed `topcoffea` ref should match the coordinated ref for the current `topeft` checkout
    - link to `topcoffea/docs/topeft_integration.md`
  - Update the branch-mismatch message to remove `git switch ch_update_calcoffea` instructions and instead refer to coordinated ref policy; preserve the `TOPCOFFEA_BRANCH` override mention.
- `topeft/modules/runner_output.py`
  - Update HistEFT-related ImportError text to remove branch-specific suggestions and instead require a coordinated ref + reinstall, with the same docs pointer.

B) Tests updated for new wording
- `tests/test_dependency_checks.py`
  - Replace the branch-literal assertion with checks for:
    - `"coordinated ref"`
    - `"topcoffea/docs/topeft_integration.md"`
- `tests/test_workflow_topcoffea_imports.py`
  - Update the ImportError match from `"ch_update_calcoffea"` to `"coordinated ref"`.

C) Eliminate invalid-escape warnings without changing regex meaning
- `analysis/topeft_run2/missing_parton.py`
  - Switch regex patterns to raw strings:
    - `re.sub(r'_\wj', ...)` (was `re.sub('_\wj', ...)`)
    - `re.findall(r'\dj', ...)` (was `re.findall('\dj', ...)`)
  - This preserves regex semantics while avoiding Python invalid-escape warnings.

### Testing
- `python -m compileall topeft/modules analysis tests`
- `python -m pytest -q`

(Verification intent: ensure the coordinated-ref messaging changes are covered by tests and that `compileall` no longer emits invalid-escape warnings from `missing_parton.py`.)

### Review notes
- No changes to workflow logic, dependency-check semantics, or physics/analysis behavior are intended—this is limited to **user-facing error strings**, corresponding test expectations, and **raw-string regex literals** to silence warnings.
- Please confirm the revised error messages are actionable and consistent with the coordinated-ref policy documented in `topcoffea/docs/topeft_integration.md`.