### PR TITLE
tests: silence upstream coffea warnings in cacheless NanoEvents paths

### DIFF
--- a/tests/test_analysis_processor_jetmet_cacheless.py
+++ b/tests/test_analysis_processor_jetmet_cacheless.py
@@ -4,6 +4,7 @@ import types
 
 import awkward as ak
 import numpy as np
+import pytest
 
 from coffea.nanoevents import BaseSchema, NanoEventsFactory
 
@@ -26,6 +27,18 @@ sys.modules["topcoffea.modules.histEFT"] = _hist_eft_stub
 sys.modules["topcoffea.modules.histEFT"] = _hist_eft_stub
 
 import analysis.topeft_run2.analysis_processor as ap
+
+pytestmark = [
+    pytest.mark.filterwarnings(
+        "ignore:Skipping Jet as it is not interpretable by NanoEvents:UserWarning:coffea\\.nanoevents\\.mapping\\.preloaded"
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:Skipping MET as it is not interpretable by NanoEvents:UserWarning:coffea\\.nanoevents\\.mapping\\.preloaded"
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:__array__ implementation doesn't accept a copy keyword.*:DeprecationWarning:coffea\\.nanoevents\\.mapping\\.base"
+    ),
+]
 
 
 class _DummyMapping(dict):

--- a/tests/test_nanoevents_without_caches.py
+++ b/tests/test_nanoevents_without_caches.py
@@ -4,6 +4,7 @@ import types
 import uuid
 
 import awkward as ak
+import pytest
 from coffea.nanoevents import BaseSchema, NanoEventsFactory
 from analysis.topeft_run2.nanoevents_helpers import ensure_factory_mode
 
@@ -27,6 +28,12 @@ sys.modules["topcoffea.modules.histEFT"] = _hist_eft_stub
 sys.modules["topcoffea.modules.histEFT"] = _hist_eft_stub
 
 import analysis.topeft_run2.analysis_processor as ap
+
+pytestmark = [
+    pytest.mark.filterwarnings(
+        "ignore:__array__ implementation doesn't accept a copy keyword.*:DeprecationWarning:coffea\\.nanoevents\\.mapping\\.base"
+    )
+]
 
 
 class _DummyMapping(dict):


### PR DESCRIPTION
### Summary
- Add narrowly scoped `pytest` warning filters to keep cacheless NanoEvents runtime-path tests warning-free.
- Preserve all runtime/physics semantics; changes are test-only.

### Motivation
These cacheless NanoEvents tests intentionally exercise “runtime-like” code paths, but they surface non-actionable warnings emitted by upstream `coffea`/NumPy (Jet/MET interpretability messages and a NumPy copy-keyword deprecation). Keeping the suite warning-free improves CI signal and makes new warnings easier to spot.

### Implementation details
A) Filter upstream `coffea` warnings in cacheless Jet/MET tests  
- `tests/test_analysis_processor_jetmet_cacheless.py`
  - Import `pytest`.
  - Add module-scoped `pytestmark` filters for:
    - `UserWarning` from `coffea.nanoevents.mapping.preloaded` about skipping `Jet`.
    - `UserWarning` from `coffea.nanoevents.mapping.preloaded` about skipping `MET`.
    - `DeprecationWarning` from `coffea.nanoevents.mapping.base` about NumPy’s `copy` keyword behavior.
  - Filters are scoped by message + category + originating module to avoid hiding unrelated warnings.

B) Filter upstream NumPy copy-keyword deprecation warning in generic cacheless NanoEvents tests  
- `tests/test_nanoevents_without_caches.py`
  - Import `pytest`.
  - Add module-scoped `pytestmark` filter for the same `DeprecationWarning` from `coffea.nanoevents.mapping.base`.

**Semantics:** No production modules changed; only warning handling in tests.

### Testing
- `python -m compileall -q -f topeft/modules analysis tests`
- `python -m pytest -q`
  - Expected: `209 passed, 6 skipped` and **no warnings summary**.

### Review notes
- The filters match on warning *message + category + module* to stay as narrow as possible.
- If upstream `coffea` changes warning text/module paths, these filters may need small updates, but failures should be obvious (warnings reappear).