### PR TITLE
Scope split-channel warning diagnostics to active region (CR vs SR)

### DIFF
--- a/analysis/topeft_run2/make_cr_and_sr_plots.py
+++ b/analysis/topeft_run2/make_cr_and_sr_plots.py
@@ -489,11 +489,57 @@ def _preview_channel_axis_labels(histogram_mapping):
     return ()
 
 
-def _warn_missing_split_channels(histogram_mapping, reference_channel_map=None):
+_SPLIT_WARNING_EXPECTED_PREVIEW_LIMIT = 30
+
+
+def _resolve_split_warning_reference_map(region_name):
+    """Return the region-specific channel map used for split-warning diagnostics."""
+
+    region_key = str(region_name or "").upper()
+    if region_key == "CR":
+        return CR_CHAN_DICT
+    if region_key == "SR":
+        return SR_CHAN_DICT
+    return CHANNEL_REFERENCE_MAP
+
+
+def _summarize_expected_split_bins(
+    expected_split_channels,
+    *,
+    preview_limit=_SPLIT_WARNING_EXPECTED_PREVIEW_LIMIT,
+):
+    """Return a compact summary string for expected split-channel labels."""
+
+    count = len(expected_split_channels or ())
+    if count == 0:
+        return "0 total (<unspecified>)"
+
+    if preview_limit is None:
+        preview_limit = _SPLIT_WARNING_EXPECTED_PREVIEW_LIMIT
+
+    limit = max(int(preview_limit), 0)
+    if limit == 0:
+        return f"{count} total"
+
+    preview = list(expected_split_channels[:limit])
+    summary = f"{count} total; showing first {len(preview)}: {', '.join(preview)}"
+    if count > limit:
+        summary = f"{summary}, ..."
+    return summary
+
+
+def _warn_missing_split_channels(
+    histogram_mapping,
+    reference_channel_map=None,
+    *,
+    region_name=None,
+    expected_preview_limit=_SPLIT_WARNING_EXPECTED_PREVIEW_LIMIT,
+):
     """Emit a diagnostic when lepton-flavour split channels are unavailable."""
 
     reference_channel_map = reference_channel_map or {}
     available_channels = _preview_channel_axis_labels(histogram_mapping)
+    region_label = str(region_name or "<unknown>").upper()
 
     expected_split = sorted(
         {
@@ -507,11 +553,14 @@ def _warn_missing_split_channels(histogram_mapping, reference_channel_map=None):
     available_summary = (
         ", ".join(sorted(map(str, available_channels))) if available_channels else "<none>"
     )
-    expected_summary = ", ".join(expected_split) if expected_split else "<unspecified>"
+    expected_summary = _summarize_expected_split_bins(
+        expected_split, preview_limit=expected_preview_limit
+    )
 
     _logger.warning(
-        "Split channel output was requested but lep-flavour labels were not found on the channel axis. "
+        "Split channel output was requested for region=%s but lep-flavour labels were not found on the channel axis. "
         "Available channel bins: %s. Expected flavour-split bins (from configuration): %s.",
+        region_label,
         available_summary,
         expected_summary,
     )
@@ -6339,6 +6388,7 @@ def run_plots_for_region(
 
     requested_channel_modes = channel_output_cfg["modes"]
     preserve_njets_bins = channel_output_cfg.get("preserve_njets", False)
+    warning_reference_channel_map = _resolve_split_warning_reference_map(region_name)
 
     multi_mode = len(requested_channel_modes) > 1
     split_channels_available = yt.is_split_by_lepflav(
@@ -6358,7 +6408,9 @@ def run_plots_for_region(
 
         if not split_channels_available:
             _warn_missing_split_channels(
-                dict_of_hists, reference_channel_map=CHANNEL_REFERENCE_MAP
+                dict_of_hists,
+                reference_channel_map=warning_reference_channel_map,
+                region_name=region_name,
             )
 
     for channel_mode in requested_channel_modes:

--- a/tests/test_make_cr_and_sr_plots.py
+++ b/tests/test_make_cr_and_sr_plots.py
@@ -1,6 +1,7 @@
 import copy
 import re
 import warnings
+from types import SimpleNamespace
 
 import hist
 import numpy as np
@@ -754,6 +755,89 @@ def test_both_includes_split_channels_when_available(tmp_path):
     ]
     for split_dir in split_dirs:
         assert split_dir.exists()
+
+
+def test_split_warning_uses_cr_reference_bins_for_cr_region(monkeypatch, tmp_path):
+    class _AxisOnlyHist:
+        def __init__(self, channel_labels):
+            self.axes = {"channel": channel_labels}
+
+    warning_messages = []
+
+    def _capture_warning(msg, *args, **kwargs):
+        if args:
+            msg = msg % args
+        warning_messages.append(msg)
+
+    hist_inputs = {"met": _AxisOnlyHist(["2lss_mm_CR_1j"])}
+
+    with monkeypatch.context() as m:
+        m.setattr(make_cr_and_sr_plots._logger, "warning", _capture_warning)
+        m.setattr(
+            make_cr_and_sr_plots,
+            "CR_CHAN_DICT",
+            {"cr_ref": ["cr_only_mm_2j"]},
+        )
+        m.setattr(
+            make_cr_and_sr_plots,
+            "SR_CHAN_DICT",
+            {"sr_ref": ["sr_only_ee_2j"]},
+        )
+        m.setattr(
+            make_cr_and_sr_plots.yt,
+            "is_split_by_lepflav",
+            lambda *args, **kwargs: False,
+        )
+        m.setattr(
+            make_cr_and_sr_plots.yt,
+            "restore_split_channel_labels",
+            lambda *args, **kwargs: False,
+        )
+        m.setattr(
+            make_cr_and_sr_plots,
+            "build_region_context",
+            lambda *args, **kwargs: SimpleNamespace(
+                name="CR", channel_mode="per-channel"
+            ),
+        )
+        m.setattr(
+            make_cr_and_sr_plots,
+            "_summarize_zero_yield_processes",
+            lambda *args, **kwargs: {
+                "region": "CR",
+                "channels_scanned": 0,
+                "channel_entries": [],
+                "zero_process_total": 0,
+                "data_driven_zero_total": 0,
+                "missing_data_driven_prefixes": set(),
+                "errors": [],
+            },
+        )
+        m.setattr(
+            make_cr_and_sr_plots,
+            "_emit_zero_yield_summary",
+            lambda *args, **kwargs: None,
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            make_cr_and_sr_plots.run_plots_for_region(
+                "CR",
+                hist_inputs,
+                years=["2022"],
+                save_dir_path=str(tmp_path),
+                channel_output="split-njets",
+                skip_syst_errs=True,
+                workers=1,
+                verbose=False,
+            )
+
+    assert warning_messages
+    warning_text = warning_messages[-1]
+    assert "region=CR" in warning_text
+    assert "Expected flavour-split bins (from configuration): 1 total; showing first 1:" in warning_text
+    assert "cr_only_mm_2j" in warning_text
+    assert "sr_only_ee_2j" not in warning_text
 
 
 @pytest.mark.parametrize("channel_output", ["both", "both-njets"])


### PR DESCRIPTION
### Summary
- Scope the “missing lepton-flavour split channels” warning to the active plotting region (CR uses `CR_CHAN_DICT`, SR uses `SR_CHAN_DICT`).
- Make the warning more readable by including `region=<...>` and summarizing expected split bins as `count + preview` instead of dumping the full list.
- Keep split detection / restore attempts / skip-or-fallback plotting behavior unchanged.
- Add a focused unit test ensuring CR warnings do not include SR-only expected bins.

### Motivation
When running `make_cr_and_sr_plots.py` with `--channel-output split-njets`, the code can warn that flavour-split labels are missing. Previously, the warning’s “expected bins” list was derived from a CR+SR union map, producing a long list with SR-only entries even when plotting CR. This made the message look contradictory (especially when users see flavour-split categories elsewhere in configs) and obscured the real issue (input histograms not being flavour-split).

### Implementation details
A) Region-scoped expected-bin map for split warnings  
- `analysis/topeft_run2/make_cr_and_sr_plots.py`
  - Add `_resolve_split_warning_reference_map(region_name)` to pick the reference map used **only** for warning diagnostics:
    - CR → `CR_CHAN_DICT`
    - SR → `SR_CHAN_DICT`
    - fallback → `CHANNEL_REFERENCE_MAP` for unknown regions
  - Update the split-warning call site in `run_plots_for_region(...)` to pass the resolved, region-specific map and `region_name`.
  - **No change** to split detection (`yt.is_split_by_lepflav`), restoration (`yt.restore_split_channel_labels`), or the logic that decides whether to skip split output.

B) Reduce warning verbosity while keeping it informative  
- `analysis/topeft_run2/make_cr_and_sr_plots.py`
  - Add `_summarize_expected_split_bins(...)` plus `_SPLIT_WARNING_EXPECTED_PREVIEW_LIMIT = 30`.
  - Update `_warn_missing_split_channels(...)` to:
    - include `region=<...>` in the warning
    - print expected bins as: `"<N> total; showing first <M>: <...>, ..."` (ellipsis when truncated)

C) Tests  
- `tests/test_make_cr_and_sr_plots.py`
  - Add `test_split_warning_uses_cr_reference_bins_for_cr_region(...)`:
    - monkeypatches `CR_CHAN_DICT`/`SR_CHAN_DICT` with sentinel labels
    - forces “unsplit” behavior (`yt.is_split_by_lepflav` → False)
    - asserts the warning includes the CR sentinel and excludes the SR sentinel, and includes the summarized expected-bin text.

### Testing
Run via wrapper + non-login shell (as in the Codex report):
- Focused new unit test:
  - `pytest -q tests/test_make_cr_and_sr_plots.py -k "split_warning_uses_cr_reference_bins_for_cr_region"` ✅

Notes:
- Repository baseline failures exist (full `pytest -q` and larger subsets were already failing in this workspace). This PR adds a focused test covering the new diagnostic behavior without attempting to resolve unrelated baseline issues.

### Review notes
- This PR is intentionally **diagnostics-only**:
  - It changes **which reference map** is used to *format the warning*, and how that warning is summarized.
  - It does **not** change plotting semantics, split detection, or restoration behavior.
- Please sanity-check that:
  - CR warnings no longer reference SR-only expected bins
  - the summarized expected-bin preview is sufficiently informative (limit = 30) without being noisy.