### PR TITLE
Add regression tests for *-njets channel-output with base-only channel dict keys

### DIFF
--- a/tests/test_make_cr_and_sr_plots.py
+++ b/tests/test_make_cr_and_sr_plots.py
@@ -29,6 +29,36 @@ def _find_zero_yield_entry(summary, *, label, variable):
     return None
 
 
+def _make_met_histogram_for_channels(channel_names):
+    process_axis = hist.axis.StrCategory([], name="process", growth=True)
+    channel_axis = hist.axis.StrCategory([], name="channel", growth=True)
+    syst_axis = hist.axis.StrCategory([], name="systematic", growth=True)
+    met_axis = hist.axis.Regular(1, 0.0, 1.0, name="met")
+
+    hist_obj = make_cr_and_sr_plots.tc_sparseHist.SparseHist(
+        process_axis, channel_axis, syst_axis, met_axis
+    )
+    setattr(hist_obj, "_sumw2", defaultdict(lambda: None))
+
+    for channel_name in channel_names:
+        hist_obj.fill(
+            process="ttH_central2022",
+            channel=channel_name,
+            systematic="nominal",
+            met=0.5,
+            weight=1.0,
+        )
+        hist_obj.fill(
+            process="data2022",
+            channel=channel_name,
+            systematic="nominal",
+            met=0.5,
+            weight=1.0,
+        )
+
+    return hist_obj
+
+
 def test_unit_normalization_skips_empty_histograms(monkeypatch):
     dummy_mc = _DummyHist()
     dummy_data = _DummyHist()
@@ -838,6 +868,124 @@ def test_split_warning_uses_cr_reference_bins_for_cr_region(monkeypatch, tmp_pat
     assert "Expected flavour-split bins (from configuration): 1 total; showing first 1:" in warning_text
     assert "cr_only_mm_2j" in warning_text
     assert "sr_only_ee_2j" not in warning_text
+
+
+@pytest.mark.parametrize(
+    "region_name,channel_dict_attr,base_key,channel_bins",
+    [
+        (
+            "CR",
+            "CR_CHAN_DICT",
+            "cr_dy_tautau_m",
+            (
+                "1l_m_dy_tautau_CR_2j",
+                "1l_m_dy_tautau_CR_3j",
+                "1l_m_dy_tautau_CR_4j",
+            ),
+        ),
+        (
+            "SR",
+            "SR_CHAN_DICT",
+            "2lss_m",
+            (
+                "2lss_m_4j",
+                "2lss_m_5j",
+                "2lss_m_6j",
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "channel_output,expected_modes",
+    [
+        ("merged-njets", ("aggregate",)),
+        ("split-njets", ("per-channel",)),
+        ("both-njets", ("aggregate", "per-channel")),
+    ],
+)
+def test_njets_channel_output_modes_accept_base_channel_keys(
+    tmp_path,
+    monkeypatch,
+    region_name,
+    channel_dict_attr,
+    base_key,
+    channel_bins,
+    channel_output,
+    expected_modes,
+):
+    hist_inputs = {"met": _make_met_histogram_for_channels(channel_bins)}
+    captured_channel_maps = {}
+    base_channel_map = {base_key: list(channel_bins)}
+
+    assert list(base_channel_map.keys()) == [base_key]
+
+    def _capture_payload(region_ctx, *args, **kwargs):
+        payload = make_cr_and_sr_plots._prepare_variable_payload(
+            "met", region_ctx, metadata_only=True
+        )
+        captured_channel_maps[region_ctx.channel_mode] = payload["channel_dict"]
+
+    minimal_summary = {
+        "region": region_name,
+        "channels_scanned": 0,
+        "channel_entries": [],
+        "zero_process_total": 0,
+        "data_driven_zero_total": 0,
+        "missing_data_driven_prefixes": set(),
+        "errors": [],
+    }
+
+    with monkeypatch.context() as m:
+        if channel_dict_attr == "CR_CHAN_DICT":
+            m.setattr(make_cr_and_sr_plots, "CR_CHAN_DICT", base_channel_map)
+            m.setattr(
+                make_cr_and_sr_plots,
+                "CHANNEL_REFERENCE_MAP",
+                {**base_channel_map, **make_cr_and_sr_plots.SR_CHAN_DICT},
+            )
+        else:
+            m.setattr(make_cr_and_sr_plots, "SR_CHAN_DICT", base_channel_map)
+            m.setattr(
+                make_cr_and_sr_plots,
+                "CHANNEL_REFERENCE_MAP",
+                {**make_cr_and_sr_plots.CR_CHAN_DICT, **base_channel_map},
+            )
+
+        m.setattr(make_cr_and_sr_plots, "produce_region_plots", _capture_payload)
+        m.setattr(
+            make_cr_and_sr_plots,
+            "_summarize_zero_yield_processes",
+            lambda *args, **kwargs: minimal_summary,
+        )
+        m.setattr(
+            make_cr_and_sr_plots, "_emit_zero_yield_summary", lambda *args, **kwargs: None
+        )
+
+        make_cr_and_sr_plots.run_plots_for_region(
+            region_name,
+            hist_inputs,
+            years=["2022"],
+            save_dir_path=str(tmp_path),
+            channel_output=channel_output,
+            skip_syst_errs=True,
+            workers=1,
+            verbose=False,
+        )
+
+    assert set(captured_channel_maps.keys()) == set(expected_modes)
+
+    expected_keys = {}
+    for bin_name in channel_bins:
+        suffix = make_cr_and_sr_plots._extract_njet_suffix(bin_name)
+        assert suffix is not None
+        expected_keys[f"{base_key}_{suffix}"] = [bin_name]
+
+    for mode_name in expected_modes:
+        transformed_map = captured_channel_maps[mode_name]
+        assert base_key not in transformed_map
+        for expected_key, expected_bins in expected_keys.items():
+            assert expected_key in transformed_map
+            assert transformed_map[expected_key] == expected_bins
 
 
 @pytest.mark.parametrize("channel_output", ["both", "both-njets"])


### PR DESCRIPTION
### Summary

- Add regression coverage ensuring `merged-njets`, `split-njets`, and `both-njets` work with **base-only** `CR_CHAN_DICT` / `SR_CHAN_DICT` keys (no per-njet keys required).
- Introduce a small helper to build a minimal in-memory histogram with channels already suffixed by `_<N>j`.
- Validate that `_prepare_variable_payload(..., metadata_only=True)` produces per-njet category keys derived from channel-bin suffixes.

### Motivation

When using `*-njets` channel-output modes, it’s easy to worry that configuration must include expanded per-njet keys (e.g. `cr_dy_tautau_m_2j`, `..._3j`, `..._4j`). This PR adds tests that lock in the expected behavior: **base keys are sufficient** as long as the member channel labels already carry the `_<N>j` suffix.

This is test-only coverage to prevent future refactors from accidentally introducing a requirement for per-njet channel dict duplication.

### Implementation details

A) Test helper to create minimal histogram inputs  
- File: `tests/test_make_cr_and_sr_plots.py`
- Added `_make_met_histogram_for_channels(channel_names)` which constructs a small `SparseHist` with:
  - `process`, `channel`, `systematic`, and `met` axes
  - one nominal fill for one MC-like process and one data-like process per channel

B) Regression test for base-only channel dict behavior across regions and modes  
- File: `tests/test_make_cr_and_sr_plots.py`
- Added `test_njets_channel_output_modes_accept_base_channel_keys`:
  - Parameterizes over:
    - region: `CR` vs `SR`
    - which dict is patched: `CR_CHAN_DICT` vs `SR_CHAN_DICT`
    - a base key + channel bins that already include `_<N>j`
    - channel output mode: `merged-njets`, `split-njets`, `both-njets`
  - Monkeypatches:
    - `CR_CHAN_DICT` or `SR_CHAN_DICT` to contain only `{base_key: [<bins with _<N>j>]}`.
    - `CHANNEL_REFERENCE_MAP` to remain consistent with the patched dict.
    - `produce_region_plots` to capture the output of `_prepare_variable_payload("met", ..., metadata_only=True)` without running full plotting.
    - zero-yield summarization emitters to no-op (avoid unrelated logging/side effects).
  - Assertions:
    - For expected plotting modes, `payload["channel_dict"]` does **not** contain `base_key` directly.
    - Instead it contains `base_key_<N>j` keys for each input bin (via `_extract_njet_suffix`), each mapping to the corresponding single bin.

No production code or analysis semantics are changed (tests only).

### Testing

Focused regression test:
```bash
pytest -q tests/test_make_cr_and_sr_plots.py -k "njets_channel_output_modes_accept_base_channel_keys"
```

Note: This PR adds tests only; it does not attempt to address any unrelated baseline failures outside this focused selector.

### Review notes

- This PR is test-only and should be safe to merge.
- Key expectation being locked in: `*-njets` modes derive per-njet group keys from **member bin suffixes**, not from explicit per-njet entries in `CR_CHAN_DICT` / `SR_CHAN_DICT`.
- If `channel` labels stop carrying the `_<N>j` suffix in upstream histogram production, this behavior would change by design; these tests would catch that regression early.