### PR TITLE
Fix year-scoped filtering for Flips/Nonprompt (DD) labels in CR/SR plotter

### DIFF
--- a/analysis/topeft_run2/make_cr_and_sr_plots.py
+++ b/analysis/topeft_run2/make_cr_and_sr_plots.py
@@ -285,6 +285,11 @@ DD_ALIAS_MAP = {
     "2017": ("UL17",),
     "2018": ("UL18",),
 }
+_DD_YEAR_TOKENS_BY_LENGTH = tuple(sorted(DD_YEAR_TOKENS, key=len, reverse=True))
+_DD_YEAR_TOKEN_PATTERNS = {
+    token: re.compile(rf"{re.escape(token)}(?=$|[_-])", re.IGNORECASE)
+    for token in _DD_YEAR_TOKENS_BY_LENGTH
+}
 
 _YEAR_SUFFIX_TOKENS = tuple(sorted(YEAR_TOKEN_RULES, key=len, reverse=True))
 _LEPFLAV_TOKENS = (
@@ -856,6 +861,37 @@ def _extract_dd_year_tokens_from_cli_years(year_tokens):
                     collected.append(mapped)
 
     return tuple(collected) if collected else None
+
+
+def _is_data_driven_process_label(label):
+    """Return ``True`` when *label* belongs to a data-driven process family."""
+
+    if not isinstance(label, str):
+        return False
+    return any(matcher.search(label) for matcher in DATA_DRIVEN_MATCHERS)
+
+
+def _detect_dd_year_token(label: str) -> "str | None":
+    """Return the canonical DD year token detected in *label*, if any."""
+
+    if not isinstance(label, str):
+        return None
+
+    for token in _DD_YEAR_TOKENS_BY_LENGTH:
+        if _DD_YEAR_TOKEN_PATTERNS[token].search(label):
+            return token
+    return None
+
+
+def _dd_label_matches_selected_years(label, dd_year_tokens):
+    """Return ``True`` when DD *label* matches the requested DD year tokens."""
+
+    if dd_year_tokens is None:
+        return True
+    detected_token = _detect_dd_year_token(label)
+    if detected_token is None:
+        return False
+    return detected_token in dd_year_tokens
 
 
 def _hist_has_content(histogram):
@@ -4490,6 +4526,9 @@ def build_region_context(
         must_have_tokens = list(dict.fromkeys(must_have_tokens))
         optional_tokens = list(dict.fromkeys(optional_tokens))
         optional_token_set = set(optional_tokens)
+        dd_year_token_set = (
+            frozenset(dd_year_tokens) if dd_year_tokens is not None else None
+        )
 
         year_token_cache = {}
 
@@ -4537,6 +4576,12 @@ def build_region_context(
             if require_optional_tokens and optional_tokens:
                 if not present_tokens.intersection(optional_token_set):
                     return False
+            if (
+                dd_year_token_set is not None
+                and _is_data_driven_process_label(label)
+                and not _dd_label_matches_selected_years(label, dd_year_token_set)
+            ):
+                return False
             return True
 
         filtered = [
@@ -4550,15 +4595,13 @@ def build_region_context(
             for label in all_labels:
                 if label in filtered_set:
                     continue
-                if not any(matcher.search(label) for matcher in DATA_DRIVEN_MATCHERS):
+                if not _is_data_driven_process_label(label):
                     continue
                 if any(token in label for token in blacklist):
                     continue
                 if must_have_tokens and any(token not in label for token in must_have_tokens):
                     continue
-                if dd_year_tokens is not None and not any(
-                    token in label for token in dd_year_tokens
-                ):
+                if not _dd_label_matches_selected_years(label, dd_year_token_set):
                     continue
                 filtered.append(label)
                 filtered_set.add(label)

--- a/tests/test_make_cr_and_sr_plots_dd_year_filter.py
+++ b/tests/test_make_cr_and_sr_plots_dd_year_filter.py
@@ -1,0 +1,62 @@
+from analysis.topeft_run2 import make_cr_and_sr_plots
+
+
+DD_PROCESS_LABELS = (
+    "charge_flips_sm_2022",
+    "charge_flips_sm_2022EE",
+    "charge_flips_sm_2023",
+    "charge_flips_sm_2023BPix",
+    "nonprompt_2022",
+    "nonprompt_2022EE",
+    "nonprompt_2023",
+    "nonprompt_2023BPix",
+    "nonprompt",
+)
+
+
+def _filter_dd_labels(dd_year_tokens):
+    return [
+        label
+        for label in DD_PROCESS_LABELS
+        if make_cr_and_sr_plots._dd_label_matches_selected_years(
+            label, dd_year_tokens
+        )
+    ]
+
+
+def test_detect_dd_year_token_prefers_longest_match_and_supports_case_and_separators():
+    assert make_cr_and_sr_plots._detect_dd_year_token("charge_flips_sm_2022") == "2022"
+    assert make_cr_and_sr_plots._detect_dd_year_token("charge_flips_sm-2022EE") == "2022EE"
+    assert (
+        make_cr_and_sr_plots._detect_dd_year_token("nonprompt2023bpix")
+        == "2023BPix"
+    )
+    assert make_cr_and_sr_plots._detect_dd_year_token("nonprompt_2023") == "2023"
+    assert make_cr_and_sr_plots._detect_dd_year_token("nonprompt") is None
+
+
+def test_dd_year_filter_keeps_only_2022_labels():
+    kept = _filter_dd_labels(("2022",))
+    assert kept == ["charge_flips_sm_2022", "nonprompt_2022"]
+
+
+def test_dd_year_filter_keeps_requested_pair():
+    kept = _filter_dd_labels(("2022", "2022EE"))
+    assert kept == [
+        "charge_flips_sm_2022",
+        "charge_flips_sm_2022EE",
+        "nonprompt_2022",
+        "nonprompt_2022EE",
+    ]
+
+
+def test_dd_year_filter_prevents_2023_collision_with_2023bpix():
+    kept = _filter_dd_labels(("2023BPix",))
+    assert "charge_flips_sm_2023BPix" in kept
+    assert "nonprompt_2023BPix" in kept
+    assert "charge_flips_sm_2023" not in kept
+    assert "nonprompt_2023" not in kept
+
+
+def test_dd_year_filter_none_keeps_baseline_behavior():
+    assert _filter_dd_labels(None) == list(DD_PROCESS_LABELS)


### PR DESCRIPTION
### Summary

- Enforce **year-scoped filtering** for data-driven (DD) process labels (Flips/Nonprompt) so `-y <year>` no longer leaks DD instances from other year tags.
- Replace substring-based DD token checks with a **canonical, longest-match-first token detector** to avoid collisions (e.g. `2023` vs `2023BPix`, `UL16` vs `UL16APV`).
- Add focused unit tests validating DD token detection and filtering semantics for single-year and multi-year selections.

### Motivation

When running the CR/SR plotter with a single year token (e.g. `-y 2022`), the plotter was including **all** Flips/Nonprompt variants present in the PKL instead of restricting to the requested year tag(s). This produced undesired plots mixing DD instances across years, and made year-by-year plotting unreliable.

### Implementation details

**A) Canonical DD year-token detection and matching**

- Updated: `analysis/topeft_run2/make_cr_and_sr_plots.py`
- Added helpers:
  - `_detect_dd_year_token(label)`:
    - case-insensitive,
    - longest-token-first,
    - delimiter-aware via `(?=$|[_-])` to reduce accidental substring matches.
  - `_dd_label_matches_selected_years(label, dd_year_tokens)`:
    - strict: if `dd_year_tokens` is provided, labels without a detectable DD token do not match.
  - `_is_data_driven_process_label(label)`:
    - uses existing `DATA_DRIVEN_MATCHERS` to identify DD families.

**B) Apply the DD year filter in both required paths**

- Updated: `build_region_context()` → nested `_filter_samples()` inside `analysis/topeft_run2/make_cr_and_sr_plots.py`
- Enforced DD year-token filtering:
  1) In the main filtering predicate (`_label_passes`) so DD labels are rejected when their detected token is not among the selected DD tokens.
  2) In the DD reinsertion path (`allow_data_driven_reinsertion=True`) so the “re-add DD samples” logic also respects the same canonical token rule (removes prior substring membership behavior that allowed leakage).

**Semantics note**
- This PR intends to change *only* DD sample selection for Flips/Nonprompt under year filtering. Non-DD sample selection logic is unchanged.
- Token detection requires the DD year token to end at end-of-string or be followed by `_` or `-`. DD labels that append alphanumerics directly after the token without a separator will not match when DD year filtering is enabled.

### Testing

Targeted unit tests added and run:

- `tests/test_make_cr_and_sr_plots_dd_year_filter.py`
  - Covers:
    - `_detect_dd_year_token` behavior (longest match wins, case/sep handling)
    - filtering with `("2022",)`
    - filtering with `("2022","2022EE")`
    - collision guard for `("2023BPix",)` not matching `2023`
    - baseline behavior for `dd_year_tokens=None` (keeps all DD labels)

Commands executed (per report):

```bash
WRAP=/users/apiccine/work/correction-lib/codex-run.sh
PYTHON_ENV="/users/apiccine/work/miniconda3/envs/clib-env/bin/python"

$WRAP /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && '"$PYTHON_ENV"' -m py_compile analysis/topeft_run2/make_cr_and_sr_plots.py tests/test_make_cr_and_sr_plots_dd_year_filter.py'
$WRAP /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && '"$PYTHON_ENV"' -m pytest -q tests/test_make_cr_and_sr_plots_dd_year_filter.py'
```

Notes:
- Full `compileall analysis tests` failed due an unrelated local file (`analysis/topeft_run2/fullR2_run_diboson.py`) containing shell syntax; this PR’s changed files compile cleanly and the new targeted tests pass.

### Review notes

- Please sanity-check the token boundary rule (`(?=$|[_-])`) against the actual naming conventions used for DD process labels in Run2/Run3 PKLs. If DD labels can legitimately be of the form `nonpromptUL17vX` (no separator), we may need to broaden the boundary logic.
- The key correctness property to verify: with `-y <year>`, DD labels from other year tags must not appear in `region_ctx.mc_samples` / the resulting plots.