### PR TITLE
Make_cards/make_cr_and_sr_plots: support multi-pkl inputs with validated merge + diagnostics

### DIFF
--- a/analysis/topeft_run2/make_cards.py
+++ b/analysis/topeft_run2/make_cards.py
@@ -91,7 +91,16 @@ def build_arg_parser():
     parser.add_argument("--use-AAC","-A",action="store_true",help="Include all EFT templates in datacards for AAC model")
     parser.add_argument("--wc-vals", default="",action="store", nargs="+", help="Specify the corresponding wc values to set for the wc list")
     parser.add_argument("--wc-scalings", default=[],action="extend",nargs="+",help="Specify a list of wc ordering for scalings.json")
-    parser.add_argument("--on-process-collision",choices=["error","warn","allow"],default="error",help="Policy for process label overlaps when merging multiple input pkl files")
+    parser.add_argument(
+        "--on-process-collision",
+        choices=["error","warn","allow"],
+        default="error",
+        help=(
+            "Policy for process-label overlaps when merging multiple input pkl files. "
+            "Default is strict `error`. Expert-only escape hatches: `warn`/`allow`, "
+            "to be used only when overlaps are intentional (e.g. chunked outputs)."
+        ),
+    )
     parser.add_argument("--merge-report",default="-",help="Path for merge diagnostic report JSON, or '-' for stdout")
     parser.add_argument("--merge-only",action="store_true",help="Only load+merge+validate input histograms and exit")
     parser.add_argument("--cache-merged-pkl",default="",help="Optional output path for merged histogram dictionary (.pkl.gz)")

--- a/analysis/topeft_run2/make_cards.py
+++ b/analysis/topeft_run2/make_cards.py
@@ -3,6 +3,8 @@ import time
 import json
 import shutil
 import argparse
+import gzip
+import pickle
 import numpy as np
 
 from topcoffea.modules.utils import regex_match,clean_dir,dict_comp
@@ -20,7 +22,7 @@ from topeft.modules.datacard_tools import *
 sub_fragment = """\
 universe   = vanilla
 executable = condor.sh
-arguments  = "{usr_dir} {inf} {out_dir} {var_lst} '{ch_lst}' '{other}'"
+arguments  = "{usr_dir} {pkl_list} {out_dir} {var_lst} '{ch_lst}' '{other}'"
 output = {condor_dir}/job_{idx}.out
 error  = {condor_dir}/job_{idx}.err
 log    = {condor_dir}/job_{idx}.log
@@ -29,7 +31,7 @@ request_cpus = 1
 request_memory = 20000
 request_disk = 4096
 
-transfer_input_files = make_cards.py,selectedWCs.txt
+transfer_input_files = {transfer_inputs}
 should_transfer_files = yes
 transfer_executable = true
 
@@ -39,14 +41,14 @@ queue 1
 
 sh_fragment = r"""#!/bin/sh
 USR_DIR=${1}
-INF=${2}
+PKL_LIST_FILE=${2}
 OUT_DIR=${3}
 VAR_LST=${4}
 CH_LST=${5}
 OTHER=${6}
 
 echo "USR_DIR: ${USR_DIR}"
-echo "INF: ${INF}"
+echo "PKL_LIST_FILE: ${PKL_LIST_FILE}"
 echo "OUT_DIR: ${OUT_DIR}"
 echo "VAR_LST: ${VAR_LST}"
 echo "CH_LST: ${CH_LST}"
@@ -59,100 +61,13 @@ unset PYTHONPATH
 conda activate ${CONDA_DEFAULT_ENV}
 
 ulimit -s unlimited
-python make_cards.py ${INF} -d ${OUT_DIR} --var-lst ${VAR_LST} --ch-lst ${CH_LST} --use-selected "selectedWCs.txt" ${OTHER}
+python make_cards.py --pkl-list-file "${PKL_LIST_FILE}" -d ${OUT_DIR} --var-lst ${VAR_LST} --ch-lst ${CH_LST} --use-selected "selectedWCs.txt" ${OTHER}
 """
 
-def run_local(dc,km_dists,channels,selected_wcs, crop_negative_bins, wcs_dict):
-    for km_dist in km_dists:
-        all_chs = dc.channels(km_dist)
-        matched_chs = regex_match(all_chs,channels)
-        if channels:
-            print(f"Channels to process: {matched_chs}")
-        for ch in matched_chs:
-            r = dc.analyze(km_dist,ch,selected_wcs, crop_negative_bins, wcs_dict)
-
-# VERY IMPORTANT:
-#   This setup assumes the output directory is mounted on the remote condor machines
-# Note:
-#   The condor jobs currently have to read the various .json files from the default locations, which
-#   means that they will probably be getting read from the user's AFS area (or wherever their TopEFT
-#   repo is located).
-# TODO: Currently there's no way to transparently passthrough parent arguments to the condor ones.
-#   There's also no clear way to pass customized options to different sub-sets of condor jobs
-def run_condor(dc,pkl_fpath,out_dir,var_lst,ch_lst,chunk_size):
-    import subprocess
-    import stat
-
-    home = os.getcwd()
-
-    condor_dir = os.path.join(out_dir,"job_logs")
-
-    if not os.path.exists(condor_dir):
-        print(f"Making condor output directory {condor_dir}")
-        os.mkdir(condor_dir)
-
-    clean_dir(condor_dir,targets=["job_.*log","job_.*err","job_.*out","^condor.*sub$"])
-
-    condor_exe_fname = "condor.sh"
-    if not os.path.samefile(home,out_dir):
-        condor_exe_fname = os.path.join(out_dir,"condor.sh")
-
-    print("Generating condor executable script")
-    with open(condor_exe_fname,"w") as f:
-        f.write(sh_fragment)
-
-    usr_perms = stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR
-    grp_perms = stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP
-    all_perms = stat.S_IROTH | stat.S_IWOTH | stat.S_IXOTH
-
-    os.chmod(condor_exe_fname,usr_perms | grp_perms | all_perms)    # equiv. to 777
-
-    other_opts = []
-    if dc.do_mc_stat:
-        other_opts.append("--do-mc-stat")
-    if dc.verbose:
-        other_opts.append("--verbose")
-    if dc.use_real_data:
-        other_opts.append("--unblind")
-    if dc.do_nuisance:
-        other_opts.append("--do-nuisance")
-    if dc.year_lst:
-        other_opts.extend(["--year"," ".join(dc.year_lst)])
-    if dc.drop_syst:
-        other_opts.extend(["--drop-syst"," ".join(dc.drop_syst)])
-    other_opts = " ".join(other_opts)
-
-    idx = 0
-    for km_dist in var_lst:
-        all_chs = dc.channels(km_dist)
-        matched_chs = regex_match(all_chs,ch_lst)
-        n = max(chunk_size,1)
-        chunks = np.split(matched_chs,[i for i in range(n,len(matched_chs),n)])
-        for chnk in chunks:
-            print(f"[{idx+1:0>3}] Variable: {km_dist} -- Channels: {chnk}")
-            s = sub_fragment.format(
-                idx=idx,
-                usr_dir=os.path.expanduser("~"),
-                inf=pkl_fpath,
-                out_dir=os.path.realpath(out_dir),
-                var_lst=km_dist,
-                ch_lst=" ".join(chnk),
-                condor_dir=condor_dir,
-                other=f"{other_opts}",
-            )
-            condor_submit_fname = os.path.join(condor_dir,f"condor.{idx}.sub")
-            with open(condor_submit_fname,"w") as f:
-                f.write(s)
-            cmd = ["condor_submit",condor_submit_fname]
-            print(f"{'':>5} Condor command: {' '.join(cmd)}")
-            os.chdir(out_dir)
-            p = subprocess.run(cmd)
-            os.chdir(home)
-            idx += 1
-
-def main():
+def build_arg_parser():
     parser = argparse.ArgumentParser(description="You can select which file to run over")
-    parser.add_argument("pkl_file",nargs="?",help="Pickle file with histograms to run over")
+    parser.add_argument("pkl_file",nargs="*",help="One or more pickle files with histograms to run over")
+    parser.add_argument("--pkl-list-file",default="",help="Optional text file with one pkl path per line")
     parser.add_argument("--rate-syst-json","-s",default="params/rate_systs.json",help="Rate related systematics json file, path relative to topeft_path()")
     parser.add_argument("--miss-parton-file","-m",default="data/missing_parton/missing_parton.root",help="File for missing parton systematic, path relative to topeft_path()")
     parser.add_argument("--selected-wcs-ref",default="test/selectedWCs.json",help="Reference file for selected wcs")
@@ -176,9 +91,172 @@ def main():
     parser.add_argument("--use-AAC","-A",action="store_true",help="Include all EFT templates in datacards for AAC model")
     parser.add_argument("--wc-vals", default="",action="store", nargs="+", help="Specify the corresponding wc values to set for the wc list")
     parser.add_argument("--wc-scalings", default=[],action="extend",nargs="+",help="Specify a list of wc ordering for scalings.json")
+    parser.add_argument("--on-process-collision",choices=["error","warn","allow"],default="error",help="Policy for process label overlaps when merging multiple input pkl files")
+    parser.add_argument("--merge-report",default="-",help="Path for merge diagnostic report JSON, or '-' for stdout")
+    parser.add_argument("--merge-only",action="store_true",help="Only load+merge+validate input histograms and exit")
+    parser.add_argument("--cache-merged-pkl",default="",help="Optional output path for merged histogram dictionary (.pkl.gz)")
+    return parser
 
+
+def _resolve_pkl_paths(args, parser):
+    pkl_files = list(args.pkl_file)
+    if args.pkl_list_file:
+        if pkl_files:
+            parser.error("Specify either positional pkl files or --pkl-list-file, not both.")
+        with open(args.pkl_list_file) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                pkl_files.append(line)
+    if not pkl_files:
+        parser.error("No input pkl files were provided.")
+    return pkl_files
+
+
+def _emit_merge_report(report_obj, report_path, out_dir):
+    if report_path == "-":
+        print("Merge report:")
+        print(json.dumps(report_obj, indent=2, sort_keys=True))
+        return
+
+    report_fpath = report_path
+    if not os.path.isabs(report_fpath):
+        report_fpath = os.path.join(out_dir, report_fpath)
+    report_parent = os.path.dirname(report_fpath)
+    if report_parent:
+        os.makedirs(report_parent, exist_ok=True)
+    with open(report_fpath, "w") as f:
+        json.dump(report_obj, f, indent=2, sort_keys=True)
+    print(f"Wrote merge report: {report_fpath}")
+
+
+def _cache_merged_histograms(merged_hists, cache_path, out_dir):
+    out_fpath = cache_path
+    if not os.path.isabs(out_fpath):
+        out_fpath = os.path.join(out_dir, out_fpath)
+    if not out_fpath.endswith(".pkl.gz"):
+        out_fpath += ".pkl.gz"
+    out_parent = os.path.dirname(out_fpath)
+    if out_parent:
+        os.makedirs(out_parent, exist_ok=True)
+    print(f"Caching merged histograms to {out_fpath}")
+    with gzip.open(out_fpath, "wb") as fout:
+        pickle.dump(merged_hists, fout, protocol=pickle.HIGHEST_PROTOCOL)
+    return out_fpath
+
+def run_local(dc,km_dists,channels,selected_wcs, crop_negative_bins, wcs_dict):
+    for km_dist in km_dists:
+        all_chs = dc.channels(km_dist)
+        matched_chs = regex_match(all_chs,channels)
+        if channels:
+            print(f"Channels to process: {matched_chs}")
+        for ch in matched_chs:
+            r = dc.analyze(km_dist,ch,selected_wcs, crop_negative_bins, wcs_dict)
+
+# VERY IMPORTANT:
+#   This setup assumes the output directory is mounted on the remote condor machines
+# Note:
+#   The condor jobs currently have to read the various .json files from the default locations, which
+#   means that they will probably be getting read from the user's AFS area (or wherever their TopEFT
+#   repo is located).
+# TODO: Currently there's no way to transparently passthrough parent arguments to the condor ones.
+#   There's also no clear way to pass customized options to different sub-sets of condor jobs
+def run_condor(dc,pkl_paths,out_dir,var_lst,ch_lst,chunk_size,on_process_collision="error",merge_report="-"):
+    import subprocess
+    import stat
+
+    home = os.getcwd()
+
+    condor_dir = os.path.join(out_dir,"job_logs")
+
+    if not os.path.exists(condor_dir):
+        print(f"Making condor output directory {condor_dir}")
+        os.mkdir(condor_dir)
+
+    clean_dir(condor_dir,targets=["job_.*log","job_.*err","job_.*out","^condor.*sub$"])
+
+    condor_exe_fname = "condor.sh"
+    if not os.path.samefile(home,out_dir):
+        condor_exe_fname = os.path.join(out_dir,"condor.sh")
+
+    print("Generating condor executable script")
+    with open(condor_exe_fname,"w") as f:
+        f.write(sh_fragment)
+
+    pkl_list_basename = "pkl_inputs.txt"
+    pkl_list_fpath = os.path.join(out_dir,pkl_list_basename)
+    print(f"Writing pkl list file for condor: {pkl_list_fpath}")
+    with open(pkl_list_fpath,"w") as f:
+        for p in pkl_paths:
+            f.write(f"{p}\n")
+
+    usr_perms = stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR
+    grp_perms = stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP
+    all_perms = stat.S_IROTH | stat.S_IWOTH | stat.S_IXOTH
+
+    os.chmod(condor_exe_fname,usr_perms | grp_perms | all_perms)    # equiv. to 777
+
+    base_other_opts = []
+    if dc.do_mc_stat:
+        base_other_opts.append("--do-mc-stat")
+    if dc.verbose:
+        base_other_opts.append("--verbose")
+    if dc.use_real_data:
+        base_other_opts.append("--unblind")
+    if dc.do_nuisance:
+        base_other_opts.append("--do-nuisance")
+    if dc.year_lst:
+        base_other_opts.extend(["--year"," ".join(dc.year_lst)])
+    if dc.drop_syst:
+        base_other_opts.extend(["--drop-syst"," ".join(dc.drop_syst)])
+    base_other_opts.extend(["--on-process-collision",on_process_collision])
+
+    idx = 0
+    for km_dist in var_lst:
+        all_chs = dc.channels(km_dist)
+        matched_chs = regex_match(all_chs,ch_lst)
+        n = max(chunk_size,1)
+        chunks = np.split(matched_chs,[i for i in range(n,len(matched_chs),n)])
+        for chnk in chunks:
+            print(f"[{idx+1:0>3}] Variable: {km_dist} -- Channels: {chnk}")
+            other_opts = list(base_other_opts)
+            if merge_report == "-":
+                other_opts.extend(["--merge-report","-"])
+            else:
+                report_path = merge_report
+                if report_path.endswith(".json"):
+                    report_path = report_path.replace(".json",f".job_{idx}.json")
+                else:
+                    report_path = f"{report_path}.job_{idx}.json"
+                other_opts.extend(["--merge-report",report_path])
+            other_opts = " ".join(other_opts)
+
+            s = sub_fragment.format(
+                idx=idx,
+                usr_dir=os.path.expanduser("~"),
+                pkl_list=pkl_list_basename,
+                out_dir=os.path.realpath(out_dir),
+                var_lst=km_dist,
+                ch_lst=" ".join(chnk),
+                condor_dir=condor_dir,
+                other=f"{other_opts}",
+                transfer_inputs=f"make_cards.py,selectedWCs.txt,{pkl_list_basename}",
+            )
+            condor_submit_fname = os.path.join(condor_dir,f"condor.{idx}.sub")
+            with open(condor_submit_fname,"w") as f:
+                f.write(s)
+            cmd = ["condor_submit",condor_submit_fname]
+            print(f"{'':>5} Condor command: {' '.join(cmd)}")
+            os.chdir(out_dir)
+            p = subprocess.run(cmd)
+            os.chdir(home)
+            idx += 1
+
+def main():
+    parser = build_arg_parser()
     args = parser.parse_args()
-    pkl_file   = args.pkl_file
+    pkl_files  = _resolve_pkl_paths(args, parser)
     rs_json    = args.rate_syst_json
     mp_file    = args.miss_parton_file
     out_dir    = args.out_dir
@@ -230,8 +308,23 @@ def main():
     if use_condor and not os.path.samefile(os.getcwd(),out_dir):
         shutil.copy("make_cards.py",out_dir)
 
+    if args.condor and args.merge_only:
+        parser.error("--merge-only and --condor cannot be used together.")
+
+    merged_hists, merge_report = load_and_merge_histogram_pkls(
+        pkl_files,
+        on_process_collision=args.on_process_collision,
+        require_sumw2=True,
+    )
+    _emit_merge_report(merge_report, args.merge_report, out_dir)
+    if args.cache_merged_pkl:
+        _cache_merged_histograms(merged_hists, args.cache_merged_pkl, out_dir)
+    if args.merge_only:
+        print("Merge-only mode enabled, stopping after successful merge validation.")
+        return
+
     tic = time.time()
-    dc = DatacardMaker(pkl_file,**kwargs)
+    dc = DatacardMaker(hists=merged_hists,**kwargs)
 
     # convert wc_vals string to a dictionary
     wc_vals = ''.join(wc_vals)
@@ -291,7 +384,16 @@ def main():
         return
 
     if use_condor:
-        run_condor(dc,pkl_file,out_dir,dists,ch_lst,chunks)
+        run_condor(
+            dc,
+            pkl_files,
+            out_dir,
+            dists,
+            ch_lst,
+            chunks,
+            on_process_collision=args.on_process_collision,
+            merge_report=args.merge_report,
+        )
     else:
         run_local(dc,dists,ch_lst,selected_wcs, not args.keep_negative_bins, wcs_dict)
 
@@ -304,4 +406,5 @@ def main():
     print(f"Total Time: {dt:.2f} s")
     print("Finished!")
 
-main()
+if __name__ == "__main__":
+    main()

--- a/analysis/topeft_run2/make_cr_and_sr_plots.py
+++ b/analysis/topeft_run2/make_cr_and_sr_plots.py
@@ -3,6 +3,9 @@ import os
 import copy
 import datetime
 import argparse
+import json
+import gzip
+import pickle
 import re
 from collections import OrderedDict
 from collections.abc import Mapping
@@ -40,6 +43,7 @@ from topeft.modules.get_rate_systs import (
     get_syst as te_get_syst,
     get_syst_lst as te_get_syst_lst,
 )
+from topeft.modules.datacard_tools import load_and_merge_histogram_pkls
 
 
 _logger = logging.getLogger(__name__)
@@ -6564,11 +6568,52 @@ def run_plots_for_region(
 
     return zero_yield_summary
 
-def main():
+def _running_in_condor():
+    condor_env_vars = (
+        "_CONDOR_SCRATCH_DIR",
+        "_CONDOR_SLOT",
+        "CONDOR_JOB_AD",
+        "CONDOR_JOBID",
+    )
+    return any(os.environ.get(var) for var in condor_env_vars)
 
-    # Set up the command line parser
+
+def _detect_region_from_path(path):
+    if not path:
+        return None, False
+    filename = os.path.basename(path)
+    uppercase = filename.upper()
+    matched_regions = []
+    for region in ("CR", "SR"):
+        # Accept filenames where the region token is directly followed by
+        # qualifiers such as a year (e.g. "SR2018") or run tag (e.g. "CRRun2").
+        # We only guard against being embedded within a longer alphanumeric
+        # token by ensuring the preceding character is not an uppercase
+        # letter or digit.
+        pattern = re.compile(rf"(?<![A-Z0-9]){region}")
+        if pattern.search(uppercase):
+            matched_regions.append(region)
+    if len(matched_regions) == 1:
+        return matched_regions[0], False
+    if len(matched_regions) > 1:
+        return None, True
+    return None, False
+
+
+def build_arg_parser():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-f", "--pkl-file-path", default="histos/plotsTopEFT.pkl.gz", help = "The path to the pkl file")
+    parser.add_argument(
+        "-f",
+        "--pkl-file-path",
+        action="append",
+        default=[],
+        help="Path to an input pkl file. Repeat for multiple inputs.",
+    )
+    parser.add_argument(
+        "--pkl-list-file",
+        default="",
+        help="Optional text file with one pkl path per line (blank lines and # comments ignored).",
+    )
     parser.add_argument("-o", "--output-path", default=".", help = "The path the output files should be saved to")
     parser.add_argument("-n", "--output-name", default="plots", help = "A name for the output directory")
     parser.add_argument("-t", "--include-timestamp-tag", action="store_true", help = "Append the timestamp to the out dir name")
@@ -6665,6 +6710,31 @@ def main():
             " after plotting."
         ),
     )
+    parser.add_argument(
+        "--on-process-collision",
+        choices=["error", "warn", "allow"],
+        default="error",
+        help=(
+            "Policy for process-label overlaps when merging multiple input pkl files. "
+            "Default is strict `error`. Expert-only escape hatches: `warn`/`allow`, "
+            "to be used only when overlaps are intentional (e.g. chunked outputs)."
+        ),
+    )
+    parser.add_argument(
+        "--merge-report",
+        default="-",
+        help="Path for merge diagnostic report JSON, or '-' for stdout.",
+    )
+    parser.add_argument(
+        "--merge-only",
+        action="store_true",
+        help="Only load+merge+validate input histograms and exit.",
+    )
+    parser.add_argument(
+        "--cache-merged-pkl",
+        default="",
+        help="Optional output path for merged histogram dictionary (.pkl.gz).",
+    )
     verbosity_group = parser.add_mutually_exclusive_group()
     verbosity_group.add_argument(
         "--verbose",
@@ -6679,7 +6749,60 @@ def main():
         help="Limit output to high-level progress messages (default).",
     )
     parser.set_defaults(unblind=None, verbose=False)
-    args = parser.parse_args()
+    return parser
+
+
+def _resolve_pkl_paths(args, parser):
+    pkl_paths = list(args.pkl_file_path or [])
+    if args.pkl_list_file:
+        if pkl_paths:
+            parser.error("Specify either repeated -f/--pkl-file-path or --pkl-list-file, not both.")
+        with open(args.pkl_list_file) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                pkl_paths.append(line)
+    if not pkl_paths:
+        parser.error("No input pkl files were provided. Use -f/--pkl-file-path or --pkl-list-file.")
+    return pkl_paths
+
+
+def _emit_merge_report(report_obj, report_path, out_dir):
+    if report_path == "-":
+        print("Merge report:")
+        print(json.dumps(report_obj, indent=2, sort_keys=True))
+        return
+
+    report_fpath = report_path
+    if not os.path.isabs(report_fpath):
+        report_fpath = os.path.join(out_dir, report_fpath)
+    report_parent = os.path.dirname(report_fpath)
+    if report_parent:
+        os.makedirs(report_parent, exist_ok=True)
+    with open(report_fpath, "w") as f:
+        json.dump(report_obj, f, indent=2, sort_keys=True)
+    print(f"Wrote merge report: {report_fpath}")
+
+
+def _cache_merged_histograms(merged_hists, cache_path, out_dir):
+    out_fpath = cache_path
+    if not os.path.isabs(out_fpath):
+        out_fpath = os.path.join(out_dir, out_fpath)
+    if not out_fpath.endswith(".pkl.gz"):
+        out_fpath += ".pkl.gz"
+    out_parent = os.path.dirname(out_fpath)
+    if out_parent:
+        os.makedirs(out_parent, exist_ok=True)
+    print(f"Caching merged histograms to {out_fpath}")
+    with gzip.open(out_fpath, "wb") as fout:
+        pickle.dump(merged_hists, fout, protocol=pickle.HIGHEST_PROTOCOL)
+    return out_fpath
+
+
+def run_with_args(args, parser):
+    pkl_paths = _resolve_pkl_paths(args, parser)
+
     normalized_years = _normalize_year_tokens(args.year)
     if args.year and not normalized_years:
         parser.error(
@@ -6689,37 +6812,7 @@ def main():
         )
     selected_years = normalized_years
 
-    def _running_in_condor():
-        condor_env_vars = (
-            "_CONDOR_SCRATCH_DIR",
-            "_CONDOR_SLOT",
-            "CONDOR_JOB_AD",
-            "CONDOR_JOBID",
-        )
-        return any(os.environ.get(var) for var in condor_env_vars)
-
-    def _detect_region_from_path(path):
-        if not path:
-            return None, False
-        filename = os.path.basename(path)
-        uppercase = filename.upper()
-        matched_regions = []
-        for region in ("CR", "SR"):
-            # Accept filenames where the region token is directly followed by
-            # qualifiers such as a year (e.g. "SR2018") or run tag (e.g. "CRRun2").
-            # We only guard against being embedded within a longer alphanumeric
-            # token by ensuring the preceding character is not an uppercase
-            # letter or digit.
-            pattern = re.compile(rf"(?<![A-Z0-9]){region}")
-            if pattern.search(uppercase):
-                matched_regions.append(region)
-        if len(matched_regions) == 1:
-            return matched_regions[0], False
-        if len(matched_regions) > 1:
-            return None, True
-        return None, False
-
-    detected_region, ambiguous_region = _detect_region_from_path(args.pkl_file_path)
+    detected_region, ambiguous_region = _detect_region_from_path(pkl_paths[0])
     resolved_region = args.region_override or detected_region or "CR"
     if ambiguous_region and not args.region_override:
         print(
@@ -6782,24 +6875,35 @@ def main():
     else:
         print(f"Created output directory: {save_dir_path}")
 
-    # Get the histograms
+    # Get and merge histograms from one or more input pkl files
     load_start_time = datetime.datetime.now()
     if args.verbose:
+        path_preview = pkl_paths[:3]
+        preview_msg = ", ".join(f"'{path}'" for path in path_preview)
+        if len(pkl_paths) > 3:
+            preview_msg += ", ..."
         print(
-            f"[{load_start_time:%H:%M:%S}] Loading histograms from '{args.pkl_file_path}'..."
+            f"[{load_start_time:%H:%M:%S}] Loading histograms from {len(pkl_paths)} input file(s): {preview_msg}"
         )
-    hin_dict = tc_utils.get_hist_from_pkl(args.pkl_file_path, allow_empty=False)
+    hin_dict, merge_report = load_and_merge_histogram_pkls(
+        pkl_paths,
+        on_process_collision=args.on_process_collision,
+        require_sumw2=True,
+    )
+    _emit_merge_report(merge_report, args.merge_report, save_dir_path)
+    if args.cache_merged_pkl:
+        _cache_merged_histograms(hin_dict, args.cache_merged_pkl, save_dir_path)
     if args.verbose:
         load_finish_time = datetime.datetime.now()
         print(
-            "[{}] Histogram load completed in {:.2f}s".format(
+            "[{}] Histogram load+merge completed in {:.2f}s".format(
                 load_finish_time.strftime("%H:%M:%S"),
                 (load_finish_time - load_start_time).total_seconds(),
             )
         )
-    # Print info about histos
-    #yt.print_hist_info(args.pkl_file_path,"nbtagsl")
-    #exit()
+    if args.merge_only:
+        print("Merge-only mode enabled, stopping after successful merge validation.")
+        return 0
 
     print("\nMaking plots for years:", selected_years if selected_years else "All")
     print("Output dir:",save_dir_path)
@@ -6823,5 +6927,14 @@ def main():
         enable_category_skips=args.enable_category_skips,
         report_zero_yields=args.report_zero_yields,
     )
+    return 0
+
+
+def main():
+    parser = build_arg_parser()
+    args = parser.parse_args()
+    return run_with_args(args, parser)
+
+
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tests/test_make_cards_multi_pkl.py
+++ b/tests/test_make_cards_multi_pkl.py
@@ -8,23 +8,26 @@ from topcoffea.modules.sparseHist import SparseHist
 from topeft.modules import datacard_tools
 
 
-def _make_hist(processes, dense_name, nbins=1):
+def _make_hist(processes, dense_name, nbins=1, dense_hi=None):
+    if dense_hi is None:
+        dense_hi = float(nbins)
+    fill_value = float(dense_hi) / (2.0 * float(nbins))
     h = SparseHist(
         hist.axis.StrCategory([], name="process", growth=True),
         hist.axis.StrCategory([], name="channel", growth=True),
-        hist.axis.Regular(nbins, 0.0, float(nbins), name=dense_name),
+        hist.axis.Regular(nbins, 0.0, float(dense_hi), name=dense_name),
         storage="Double",
     )
     for proc in processes:
-        h.fill(process=proc, channel="ch1", **{dense_name: 0.5}, weight=1.0)
+        h.fill(process=proc, channel="ch1", **{dense_name: fill_value}, weight=1.0)
     return h
 
 
-def _make_payload(key, processes, *, with_sumw2=True, nbins=1):
-    payload = {key: _make_hist(processes, key, nbins=nbins)}
+def _make_payload(key, processes, *, with_sumw2=True, nbins=1, dense_hi=None):
+    payload = {key: _make_hist(processes, key, nbins=nbins, dense_hi=dense_hi)}
     if with_sumw2:
         sumw2_key = f"{key}_sumw2"
-        payload[sumw2_key] = _make_hist(processes, sumw2_key, nbins=nbins)
+        payload[sumw2_key] = _make_hist(processes, sumw2_key, nbins=nbins, dense_hi=dense_hi)
     return payload
 
 
@@ -60,6 +63,21 @@ def test_merge_histogram_pkls_fails_when_sumw2_missing(monkeypatch):
         datacard_tools.load_and_merge_histogram_pkls(["broken.pkl.gz"])
 
 
+def test_merge_histogram_pkls_fails_on_dense_axis_edges_mismatch(monkeypatch):
+    payloads = {
+        "a.pkl.gz": _make_payload("met", ["proc_a"], dense_hi=1.0),
+        "b.pkl.gz": _make_payload("met", ["proc_b"], dense_hi=2.0),
+    }
+
+    monkeypatch.setattr(datacard_tools, "get_hist_from_pkl", lambda path, allow_empty=False: payloads[path])
+
+    with pytest.raises(ValueError, match="Dense-axis edges mismatch"):
+        datacard_tools.load_and_merge_histogram_pkls(
+            ["a.pkl.gz", "b.pkl.gz"],
+            on_process_collision="allow",
+        )
+
+
 def test_merge_histogram_pkls_process_overlap_policy(monkeypatch):
     payloads = {
         "a.pkl.gz": _make_payload("met", ["shared_proc"]),
@@ -68,11 +86,15 @@ def test_merge_histogram_pkls_process_overlap_policy(monkeypatch):
 
     monkeypatch.setattr(datacard_tools, "get_hist_from_pkl", lambda path, allow_empty=False: payloads[path])
 
-    with pytest.raises(RuntimeError, match="Process-label overlap detected"):
+    with pytest.raises(RuntimeError) as exc_info:
         datacard_tools.load_and_merge_histogram_pkls(
             ["a.pkl.gz", "b.pkl.gz"],
             on_process_collision="error",
         )
+    msg = str(exc_info.value)
+    assert "Process-label overlap detected" in msg
+    assert "--on-process-collision allow" in msg
+    assert "--merge-only --on-process-collision warn" in msg
 
     merged, report = datacard_tools.load_and_merge_histogram_pkls(
         ["a.pkl.gz", "b.pkl.gz"],
@@ -118,4 +140,3 @@ def test_resolve_pkl_paths_from_file(tmp_path):
     resolved = make_cards._resolve_pkl_paths(args, parser)
 
     assert resolved == ["/tmp/a.pkl.gz", "/tmp/b.pkl.gz"]
-

--- a/tests/test_make_cards_multi_pkl.py
+++ b/tests/test_make_cards_multi_pkl.py
@@ -121,6 +121,13 @@ def test_make_cards_parser_accepts_multiple_pkls():
     assert args.merge_only is True
 
 
+def test_make_cards_parser_default_process_collision_policy_is_error():
+    parser = make_cards.build_arg_parser()
+    args = parser.parse_args(["a.pkl.gz"])
+
+    assert args.on_process_collision == "error"
+
+
 def test_resolve_pkl_paths_from_file(tmp_path):
     pkl_list = tmp_path / "pkls.txt"
     pkl_list.write_text(

--- a/tests/test_make_cards_multi_pkl.py
+++ b/tests/test_make_cards_multi_pkl.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import hist
+import pytest
+
+from analysis.topeft_run2 import make_cards
+from topcoffea.modules.sparseHist import SparseHist
+from topeft.modules import datacard_tools
+
+
+def _make_hist(processes, dense_name, nbins=1):
+    h = SparseHist(
+        hist.axis.StrCategory([], name="process", growth=True),
+        hist.axis.StrCategory([], name="channel", growth=True),
+        hist.axis.Regular(nbins, 0.0, float(nbins), name=dense_name),
+        storage="Double",
+    )
+    for proc in processes:
+        h.fill(process=proc, channel="ch1", **{dense_name: 0.5}, weight=1.0)
+    return h
+
+
+def _make_payload(key, processes, *, with_sumw2=True, nbins=1):
+    payload = {key: _make_hist(processes, key, nbins=nbins)}
+    if with_sumw2:
+        sumw2_key = f"{key}_sumw2"
+        payload[sumw2_key] = _make_hist(processes, sumw2_key, nbins=nbins)
+    return payload
+
+
+def test_merge_histogram_pkls_succeeds_for_disjoint_processes(monkeypatch):
+    payloads = {
+        "a.pkl.gz": _make_payload("met", ["proc_a"]),
+        "b.pkl.gz": _make_payload("met", ["proc_b"]),
+    }
+
+    def fake_loader(path, allow_empty=False):
+        assert allow_empty is False
+        return payloads[path]
+
+    monkeypatch.setattr(datacard_tools, "get_hist_from_pkl", fake_loader)
+
+    merged, report = datacard_tools.load_and_merge_histogram_pkls(
+        ["a.pkl.gz", "b.pkl.gz"],
+        on_process_collision="error",
+    )
+
+    assert set(merged["met"].axes["process"]) == {"proc_a", "proc_b"}
+    assert report["num_process_collisions"] == 0
+
+
+def test_merge_histogram_pkls_fails_when_sumw2_missing(monkeypatch):
+    payloads = {
+        "broken.pkl.gz": _make_payload("met", ["proc_a"], with_sumw2=False),
+    }
+
+    monkeypatch.setattr(datacard_tools, "get_hist_from_pkl", lambda path, allow_empty=False: payloads[path])
+
+    with pytest.raises(RuntimeError, match="missing required \\*_sumw2 companions"):
+        datacard_tools.load_and_merge_histogram_pkls(["broken.pkl.gz"])
+
+
+def test_merge_histogram_pkls_process_overlap_policy(monkeypatch):
+    payloads = {
+        "a.pkl.gz": _make_payload("met", ["shared_proc"]),
+        "b.pkl.gz": _make_payload("met", ["shared_proc"]),
+    }
+
+    monkeypatch.setattr(datacard_tools, "get_hist_from_pkl", lambda path, allow_empty=False: payloads[path])
+
+    with pytest.raises(RuntimeError, match="Process-label overlap detected"):
+        datacard_tools.load_and_merge_histogram_pkls(
+            ["a.pkl.gz", "b.pkl.gz"],
+            on_process_collision="error",
+        )
+
+    merged, report = datacard_tools.load_and_merge_histogram_pkls(
+        ["a.pkl.gz", "b.pkl.gz"],
+        on_process_collision="allow",
+    )
+    assert "met" in merged
+    assert report["num_process_collisions"] >= 1
+
+
+def test_make_cards_parser_accepts_multiple_pkls():
+    parser = make_cards.build_arg_parser()
+    args = parser.parse_args(
+        [
+            "a.pkl.gz",
+            "b.pkl.gz",
+            "--on-process-collision",
+            "warn",
+            "--merge-only",
+        ]
+    )
+
+    assert args.pkl_file == ["a.pkl.gz", "b.pkl.gz"]
+    assert args.on_process_collision == "warn"
+    assert args.merge_only is True
+
+
+def test_resolve_pkl_paths_from_file(tmp_path):
+    pkl_list = tmp_path / "pkls.txt"
+    pkl_list.write_text(
+        "\n".join(
+            [
+                "# comment line",
+                "",
+                "/tmp/a.pkl.gz",
+                "/tmp/b.pkl.gz",
+            ]
+        )
+        + "\n"
+    )
+
+    parser = make_cards.build_arg_parser()
+    args = parser.parse_args(["--pkl-list-file", str(pkl_list)])
+    resolved = make_cards._resolve_pkl_paths(args, parser)
+
+    assert resolved == ["/tmp/a.pkl.gz", "/tmp/b.pkl.gz"]
+

--- a/tests/test_make_cr_and_sr_plots_multi_pkl.py
+++ b/tests/test_make_cr_and_sr_plots_multi_pkl.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from analysis.topeft_run2 import make_cr_and_sr_plots
+
+
+def test_parser_accepts_repeated_f_and_defaults_collision_policy_error():
+    parser = make_cr_and_sr_plots.build_arg_parser()
+    args = parser.parse_args(["-f", "a.pkl.gz", "-f", "b.pkl.gz"])
+
+    assert args.pkl_file_path == ["a.pkl.gz", "b.pkl.gz"]
+    assert args.on_process_collision == "error"
+
+
+def test_resolve_pkl_paths_from_repeated_f_only():
+    parser = make_cr_and_sr_plots.build_arg_parser()
+    args = parser.parse_args(["-f", "a.pkl.gz", "-f", "b.pkl.gz"])
+
+    resolved = make_cr_and_sr_plots._resolve_pkl_paths(args, parser)
+
+    assert resolved == ["a.pkl.gz", "b.pkl.gz"]
+
+
+def test_resolve_pkl_paths_from_list_file_only(tmp_path):
+    pkl_list = tmp_path / "pkls.txt"
+    pkl_list.write_text("# comment\n\n/tmp/a.pkl.gz\n/tmp/b.pkl.gz\n")
+
+    parser = make_cr_and_sr_plots.build_arg_parser()
+    args = parser.parse_args(["--pkl-list-file", str(pkl_list)])
+
+    resolved = make_cr_and_sr_plots._resolve_pkl_paths(args, parser)
+
+    assert resolved == ["/tmp/a.pkl.gz", "/tmp/b.pkl.gz"]
+
+
+def test_resolve_pkl_paths_errors_when_mixing_repeated_f_and_list_file(tmp_path):
+    pkl_list = tmp_path / "pkls.txt"
+    pkl_list.write_text("/tmp/a.pkl.gz\n")
+
+    parser = make_cr_and_sr_plots.build_arg_parser()
+    args = parser.parse_args(["-f", "one.pkl.gz", "--pkl-list-file", str(pkl_list)])
+
+    with pytest.raises(SystemExit):
+        make_cr_and_sr_plots._resolve_pkl_paths(args, parser)
+
+
+def test_merge_only_short_circuits_before_plotting(monkeypatch, tmp_path):
+    parser = make_cr_and_sr_plots.build_arg_parser()
+    args = parser.parse_args(
+        [
+            "-f",
+            "input.pkl.gz",
+            "-o",
+            str(tmp_path),
+            "-n",
+            "out",
+            "--merge-only",
+            "--merge-report",
+            "merge_report.json",
+        ]
+    )
+
+    fake_report = {
+        "num_inputs": 1,
+        "num_merged_keys": 1,
+        "num_process_collisions": 0,
+        "process_collisions": [],
+    }
+
+    monkeypatch.setattr(
+        make_cr_and_sr_plots,
+        "load_and_merge_histogram_pkls",
+        lambda *_, **__: ({"met": object()}, fake_report),
+    )
+
+    def _fail_if_called(*_args, **_kwargs):
+        raise AssertionError("run_plots_for_region should not be called in --merge-only mode")
+
+    monkeypatch.setattr(make_cr_and_sr_plots, "run_plots_for_region", _fail_if_called)
+
+    exit_code = make_cr_and_sr_plots.run_with_args(args, parser)
+
+    assert exit_code == 0
+    report_path = tmp_path / "out" / "merge_report.json"
+    assert report_path.exists()
+    report_data = json.loads(report_path.read_text())
+    assert report_data["num_inputs"] == 1
+    assert report_data["num_process_collisions"] == 0

--- a/topeft/modules/datacard_tools.py
+++ b/topeft/modules/datacard_tools.py
@@ -39,10 +39,29 @@ def _short_examples(values, max_items=8):
 def _categorical_axis_names(h):
     cat_axes = getattr(h, "categorical_axes", None)
     if cat_axes is not None:
-        return tuple(cat_axes.name)
+        try:
+            return tuple(ax.name for ax in cat_axes)
+        except Exception:
+            cat_names = getattr(cat_axes, "name", None)
+            if cat_names is None:
+                raise
+            if isinstance(cat_names, str):
+                return (cat_names,)
+            return tuple(cat_names)
+
+    str_category_type = getattr(hist.axis, "StrCategory", None)
+    int_category_type = getattr(hist.axis, "IntCategory", None)
+    categorical_types = tuple(
+        ax_type
+        for ax_type in (str_category_type, int_category_type)
+        if ax_type is not None
+    )
+
     names = []
     for ax in h.axes:
-        if "Category" in type(ax).__name__:
+        if categorical_types and isinstance(ax, categorical_types):
+            names.append(ax.name)
+        elif type(ax).__name__ in {"StrCategory", "IntCategory"}:
             names.append(ax.name)
     return tuple(names)
 
@@ -53,12 +72,23 @@ def _dense_axes(h):
 
 
 def _axis_edges(ax):
-    if hasattr(ax, "edges"):
-        try:
-            return np.asarray(ax.edges(), dtype=float)
-        except Exception:
-            return None
-    return None
+    if not hasattr(ax, "edges"):
+        return None
+
+    edges_obj = getattr(ax, "edges")
+    try:
+        edges = edges_obj() if callable(edges_obj) else edges_obj
+    except Exception:
+        return None
+
+    try:
+        arr = np.asarray(edges, dtype=float)
+    except Exception:
+        return None
+
+    if arr.ndim != 1:
+        return None
+    return arr
 
 
 def _validate_hist_compatibility(key, existing_hist, incoming_hist, incoming_path):
@@ -242,7 +272,11 @@ def load_and_merge_histogram_pkls(
 
                     msg = (
                         f"Process-label overlap detected while merging key '{key}' from '{path}': "
-                        f"{len(overlap)} overlapping labels (examples: {collision['overlap_examples']})."
+                        f"{len(overlap)} overlapping labels (examples: {collision['overlap_examples']}). "
+                        "If this overlap is intentional (e.g. chunked outputs), rerun with "
+                        "`--on-process-collision allow`. "
+                        "If you just want diagnostics, use "
+                        "`--merge-only --on-process-collision warn`."
                     )
                     if on_process_collision == "error":
                         raise RuntimeError(msg)

--- a/topeft/modules/datacard_tools.py
+++ b/topeft/modules/datacard_tools.py
@@ -11,13 +11,261 @@ import time
 
 from collections import defaultdict
 
-from topcoffea.modules.utils import regex_match
+from topcoffea.modules.utils import regex_match, get_hist_from_pkl
 from topeft.modules.paths import topeft_path
 from topeft.modules.axes import info as axes_info
 from topeft.modules.compatibility import add_sumw2_stub
 
 
 PRECISION = 6   # Decimal point precision in the text datacard output
+SUMW2_SUFFIX = "_sumw2"
+
+
+def _is_sumw2_key(key):
+    return isinstance(key, str) and key.endswith(SUMW2_SUFFIX)
+
+
+def _base_key(key):
+    return key[: -len(SUMW2_SUFFIX)]
+
+
+def _short_examples(values, max_items=8):
+    items = list(values)
+    if len(items) <= max_items:
+        return items
+    return items[:max_items] + ["..."]
+
+
+def _categorical_axis_names(h):
+    cat_axes = getattr(h, "categorical_axes", None)
+    if cat_axes is not None:
+        return tuple(cat_axes.name)
+    names = []
+    for ax in h.axes:
+        if "Category" in type(ax).__name__:
+            names.append(ax.name)
+    return tuple(names)
+
+
+def _dense_axes(h):
+    cat_names = set(_categorical_axis_names(h))
+    return [ax for ax in h.axes if ax.name not in cat_names]
+
+
+def _axis_edges(ax):
+    if hasattr(ax, "edges"):
+        try:
+            return np.asarray(ax.edges(), dtype=float)
+        except Exception:
+            return None
+    return None
+
+
+def _validate_hist_compatibility(key, existing_hist, incoming_hist, incoming_path):
+    if type(existing_hist) is not type(incoming_hist):
+        raise TypeError(
+            f"Histogram type mismatch for key '{key}' while merging '{incoming_path}': "
+            f"{type(existing_hist)} != {type(incoming_hist)}"
+        )
+
+    if not hasattr(existing_hist, "axes") or not hasattr(incoming_hist, "axes"):
+        raise TypeError(
+            f"Object for key '{key}' from '{incoming_path}' does not look like a histogram "
+            f"(missing 'axes')."
+        )
+
+    existing_all_axis_names = tuple(ax.name for ax in existing_hist.axes)
+    incoming_all_axis_names = tuple(ax.name for ax in incoming_hist.axes)
+    if existing_all_axis_names != incoming_all_axis_names:
+        raise ValueError(
+            f"Axis-name/order mismatch for key '{key}' while merging '{incoming_path}': "
+            f"{existing_all_axis_names} != {incoming_all_axis_names}"
+        )
+
+    existing_cat_axes_obj = getattr(existing_hist, "categorical_axes", [])
+    incoming_cat_axes_obj = getattr(incoming_hist, "categorical_axes", [])
+    existing_cat_axes = tuple((ax.name, type(ax).__name__) for ax in existing_cat_axes_obj)
+    incoming_cat_axes = tuple((ax.name, type(ax).__name__) for ax in incoming_cat_axes_obj)
+    if existing_cat_axes != incoming_cat_axes:
+        raise ValueError(
+            f"Categorical axis mismatch for key '{key}' while merging '{incoming_path}': "
+            f"{existing_cat_axes} != {incoming_cat_axes}"
+        )
+
+    existing_dense_axes = _dense_axes(existing_hist)
+    incoming_dense_axes = _dense_axes(incoming_hist)
+    if len(existing_dense_axes) != len(incoming_dense_axes):
+        raise ValueError(
+            f"Dense-axis-count mismatch for key '{key}' while merging '{incoming_path}': "
+            f"{len(existing_dense_axes)} != {len(incoming_dense_axes)}"
+        )
+
+    for existing_axis, incoming_axis in zip(existing_dense_axes, incoming_dense_axes):
+        if type(existing_axis) is not type(incoming_axis):
+            raise ValueError(
+                f"Dense-axis type mismatch for key '{key}' axis '{existing_axis.name}' while merging "
+                f"'{incoming_path}': {type(existing_axis)} != {type(incoming_axis)}"
+            )
+        if existing_axis.name != incoming_axis.name:
+            raise ValueError(
+                f"Dense-axis name mismatch for key '{key}' while merging '{incoming_path}': "
+                f"{existing_axis.name} != {incoming_axis.name}"
+            )
+        if len(existing_axis) != len(incoming_axis):
+            raise ValueError(
+                f"Dense-axis bin-count mismatch for key '{key}' axis '{existing_axis.name}' while "
+                f"merging '{incoming_path}': {len(existing_axis)} != {len(incoming_axis)}"
+            )
+        existing_edges = _axis_edges(existing_axis)
+        incoming_edges = _axis_edges(incoming_axis)
+        if existing_edges is not None and incoming_edges is not None:
+            if existing_edges.shape != incoming_edges.shape or not np.array_equal(existing_edges, incoming_edges):
+                raise ValueError(
+                    f"Dense-axis edges mismatch for key '{key}' axis '{existing_axis.name}' while "
+                    f"merging '{incoming_path}'."
+                )
+
+    existing_wcs = getattr(existing_hist, "wc_names", None)
+    incoming_wcs = getattr(incoming_hist, "wc_names", None)
+    if existing_wcs is not None or incoming_wcs is not None:
+        if list(existing_wcs) != list(incoming_wcs):
+            raise ValueError(
+                f"WC-name mismatch for key '{key}' while merging '{incoming_path}': "
+                f"{existing_wcs} != {incoming_wcs}"
+            )
+
+
+def _process_labels(hist_obj):
+    try:
+        return set(hist_obj.axes["process"])
+    except Exception:
+        return None
+
+
+def load_and_merge_histogram_pkls(
+    pkl_paths,
+    *,
+    on_process_collision="error",
+    require_sumw2=True,
+):
+    """
+        Load one or more histogram pkls and merge them in memory with strict validation.
+        Returns: (merged_hist_dict, merge_report_dict)
+    """
+    if on_process_collision not in {"error", "warn", "allow"}:
+        raise ValueError(
+            f"Unknown process collision policy '{on_process_collision}'. "
+            "Valid options are: error, warn, allow."
+        )
+    if not pkl_paths:
+        raise ValueError("No input pickle files were provided for merging.")
+
+    report = {
+        "num_inputs": len(pkl_paths),
+        "inputs": list(pkl_paths),
+        "on_process_collision": on_process_collision,
+        "require_sumw2": bool(require_sumw2),
+        "files": [],
+        "process_collisions": [],
+    }
+
+    merged_hists = {}
+    for path in pkl_paths:
+        print(f"Opening: {path}")
+        tic = time.time()
+        hist_dict = get_hist_from_pkl(path, allow_empty=False)
+        dt = time.time() - tic
+        print(f"Pkl Open Time: {dt:.2f} s")
+
+        if not isinstance(hist_dict, dict):
+            raise TypeError(
+                f"Histogram input '{path}' is not a dictionary. Got: {type(hist_dict)}"
+            )
+        non_string_keys = [k for k in hist_dict if not isinstance(k, str)]
+        if non_string_keys:
+            raise TypeError(
+                f"Histogram input '{path}' contains non-string keys: "
+                f"{_short_examples(non_string_keys)}"
+            )
+
+        keys = set(hist_dict.keys())
+        base_keys = sorted(k for k in keys if not _is_sumw2_key(k))
+        sumw2_keys = sorted(k for k in keys if _is_sumw2_key(k))
+
+        orphan_sumw2 = sorted(k for k in sumw2_keys if _base_key(k) not in keys)
+        if orphan_sumw2:
+            raise RuntimeError(
+                f"Input '{path}' contains *_sumw2 keys without base histograms: "
+                f"{_short_examples(orphan_sumw2)}"
+            )
+
+        missing_sumw2 = []
+        if require_sumw2:
+            missing_sumw2 = sorted(k for k in base_keys if f"{k}{SUMW2_SUFFIX}" not in keys)
+            if missing_sumw2:
+                raise RuntimeError(
+                    f"Input '{path}' is missing required *_sumw2 companions for: "
+                    f"{_short_examples(missing_sumw2)}"
+                )
+
+        report["files"].append(
+            {
+                "path": path,
+                "num_keys": len(keys),
+                "num_base_keys": len(base_keys),
+                "num_sumw2_keys": len(sumw2_keys),
+            }
+        )
+
+        for key, incoming_hist in hist_dict.items():
+            if key not in merged_hists:
+                merged_hists[key] = incoming_hist
+                continue
+
+            existing_hist = merged_hists[key]
+            _validate_hist_compatibility(key, existing_hist, incoming_hist, path)
+
+            existing_procs = _process_labels(existing_hist)
+            incoming_procs = _process_labels(incoming_hist)
+            if existing_procs is not None and incoming_procs is not None:
+                overlap = sorted(existing_procs & incoming_procs)
+                if overlap:
+                    collision = {
+                        "key": key,
+                        "path": path,
+                        "overlap_count": len(overlap),
+                        "overlap_examples": _short_examples(overlap, max_items=15),
+                        "existing_process_count": len(existing_procs),
+                        "incoming_process_count": len(incoming_procs),
+                    }
+                    report["process_collisions"].append(collision)
+
+                    msg = (
+                        f"Process-label overlap detected while merging key '{key}' from '{path}': "
+                        f"{len(overlap)} overlapping labels (examples: {collision['overlap_examples']})."
+                    )
+                    if on_process_collision == "error":
+                        raise RuntimeError(msg)
+                    if on_process_collision == "warn":
+                        print(f"WARNING: {msg}")
+
+            try:
+                merged_hists[key] += incoming_hist
+            except Exception as inplace_err:
+                try:
+                    merged_hists[key] = merged_hists[key] + incoming_hist
+                except Exception as add_err:
+                    raise RuntimeError(
+                        f"Failed to merge key '{key}' from '{path}'. "
+                        f"In-place add error: {inplace_err!r}. Add error: {add_err!r}."
+                    ) from add_err
+
+        del hist_dict
+
+    report["num_merged_keys"] = len(merged_hists)
+    report["num_process_collisions"] = len(report["process_collisions"])
+
+    return merged_hists, report
 
 def to_hist(arr,name,zero_wgts=False):
     """
@@ -316,7 +564,7 @@ class DatacardMaker():
             r[p].append(cls.get_process(x))
         return r
 
-    def __init__(self,pkl_path,**kwargs):
+    def __init__(self,pkl_path=None,hists=None,**kwargs):
         self.year_lst        = kwargs.pop("year_lst",[])
         self.do_sm           = kwargs.pop("do_sm",False)
         self.do_nuisance     = kwargs.pop("do_nuisance",False)
@@ -451,24 +699,41 @@ class DatacardMaker():
         self.tolerance = 1e-4
         self.hists = None
 
+        if hists is not None and pkl_path is not None:
+            raise ValueError("Specify either 'pkl_path' or 'hists', not both.")
+        if hists is None and pkl_path is None:
+            raise ValueError("Must specify either 'pkl_path' or 'hists'.")
+
         tic = time.time()
-        self.read(pkl_path)
+        self.read(fpath=pkl_path, hists=hists)
         dt = time.time() - tic
         print(f"Total Read+Prune Time: {dt:.2f} s")
 
         print (f"Saving output to {os.path.realpath(self.out_dir)}")
 
-    def read(self,fpath):
+    def read(self,fpath=None,hists=None):
         """
-            Input should be a file path to a pkl file containing histograms produced by the topeft.py
-            processor. The histograms are extracted and then pre-processed to remove / group / scale
-            various sparse axes categories.
+            Input can be either:
+              - a file path to a pkl file containing histograms produced by the topeft.py processor
+              - a pre-loaded dictionary of histograms
+            The histograms are then pre-processed to remove / group / scale various sparse axes
+            categories.
         """
-        print(f"Opening: {fpath}")
-        tic = time.time()
-        self.hists = pickle.load(gzip.open(fpath))
-        dt = time.time() - tic
-        print(f"Pkl Open Time: {dt:.2f} s")
+        if hists is not None:
+            if not isinstance(hists, dict):
+                raise TypeError(
+                    f"Expected 'hists' to be a dict, got {type(hists)}"
+                )
+            self.hists = hists
+            print(f"Using preloaded histogram dictionary ({len(self.hists)} keys)")
+        elif fpath is not None:
+            print(f"Opening: {fpath}")
+            tic = time.time()
+            self.hists = get_hist_from_pkl(fpath, allow_empty=True)
+            dt = time.time() - tic
+            print(f"Pkl Open Time: {dt:.2f} s")
+        else:
+            raise ValueError("Need either fpath or hists for read().")
 
         for km_dist, h in self.hists.items():
             if h.empty():


### PR DESCRIPTION
### Summary
- Add a shared “load + validate + merge” path for running over **multiple** `.pkl(.gz)` histogram inputs before plotting or card-making.
- Extend `make_cards.py` to accept multiple pkls (positional or `--pkl-list-file`), emit a merge report, optionally cache the merged pkl, and support a `--merge-only` validation mode.
- Extend `make_cr_and_sr_plots.py` to accept repeated `-f/--pkl-file-path` (or `--pkl-list-file`), emit a merge report, optionally cache the merged pkl, and add `--merge-only` to stop before plotting.
- Add unit tests covering merge validation (sumw2 requirement, axis compatibility, collision policy) and CLI parsing/short-circuit behavior.

### Motivation
We want to run the same plotting and datacard workflows over **multiple pkl outputs** (e.g. per-year pkls) without having to pre-merge them externally or rebuild monolithic pkls. The current flow assumes a single input pkl and offers no standardized validation for:
- missing `*_sumw2` companions,
- incompatible axis/edges across inputs,
- accidental overlaps in process labels across pkls.

This PR introduces an explicit, auditable merge step with diagnostics and “fail-fast” behavior by default.

### Implementation details

#### A) `topeft/modules/datacard_tools.py`: new merge utility + DatacardMaker input flexibility
- Introduce `load_and_merge_histogram_pkls(pkl_paths, on_process_collision=..., require_sumw2=True)`:
  - Loads each pkl via `topcoffea.modules.utils.get_hist_from_pkl`.
  - Validates inputs are dicts with string keys.
  - Enforces (optionally) that each base key has a `*_sumw2` companion (`require_sumw2=True` default).
  - Validates histogram compatibility per key:
    - histogram type matches,
    - axis names/order match,
    - categorical axis definitions match,
    - dense axis binning/edges match,
    - EFT `wc_names` match (when present).
  - Detects overlaps on the `process` axis and applies a policy:
    - `error` (default): raise with actionable guidance,
    - `warn`: print warning and proceed,
    - `allow`: proceed silently.
  - Returns `(merged_hist_dict, merge_report_dict)` including per-file counts and collisions.
- Update `DatacardMaker` to accept either:
  - `pkl_path=...` (existing behavior), **or**
  - `hists=<preloaded dict>` (new), enabling callers to run on already-merged histograms.
  - Guardrails: reject “both” and reject “neither”.

Semantics note: This PR does not change any physics content of the histograms; it only changes how inputs are loaded and validated before being processed.

#### B) `analysis/topeft_run2/make_cards.py`: multi-input CLI + condor integration
- Replace single positional pkl with:
  - `pkl_file` positional accepting **0+** args (multi-file), and
  - `--pkl-list-file` (mutually exclusive with positional pkls).
- Add merge controls:
  - `--on-process-collision {error,warn,allow}` (default `error`)
  - `--merge-report <path|->` (default `-` for stdout)
  - `--merge-only` (validate merge and exit)
  - `--cache-merged-pkl <path>` (write merged dict as `.pkl.gz`)
- Always load+merge once up front:
  - `merged_hists, report = load_and_merge_histogram_pkls(...)`
  - create `DatacardMaker(hists=merged_hists, ...)`
- Condor changes:
  - Condor jobs now receive a **pkl list file** via `transfer_input_files` (rather than a single pkl path argument).
  - `condor.sh` now calls:
    - `python make_cards.py --pkl-list-file "${PKL_LIST_FILE}" ...`
  - Per-job merge reports: if `--merge-report` is a path, jobs write `...job_<idx>.json`.

#### C) `analysis/topeft_run2/make_cr_and_sr_plots.py`: multi-input CLI + “merge-only”
- Change `-f/--pkl-file-path` to `action="append"` so it can be repeated.
- Add `--pkl-list-file` with the same “don’t mix” rule as make_cards.
- Add merge controls matching make_cards:
  - `--on-process-collision`, `--merge-report`, `--merge-only`, `--cache-merged-pkl`
- Refactor entrypoint:
  - `build_arg_parser()` for testability.
  - `run_with_args(args, parser)` to enable unit tests for merge-only short-circuit.
  - Exit via `raise SystemExit(main())` (preserves correct exit codes).
- Load+merge using `load_and_merge_histogram_pkls(..., require_sumw2=True)` before plotting.

#### D) Tests
- `tests/test_make_cards_multi_pkl.py`
  - Validates merge helper behavior:
    - succeeds for disjoint processes,
    - fails when `*_sumw2` missing,
    - fails on dense-axis edges mismatch,
    - collision policy `error` vs `allow`,
  - Validates CLI parsing: multi positional pkls + default collision policy,
  - Validates `--pkl-list-file` parsing.
- `tests/test_make_cr_and_sr_plots_multi_pkl.py`
  - Validates repeated `-f` parsing,
  - Validates list-file parsing and mixing error,
  - Validates `--merge-only` short-circuits before calling plotting.

### Testing
- Unit tests added for merge + CLI behavior:
  - `pytest -q tests/test_make_cards_multi_pkl.py`
  - `pytest -q tests/test_make_cr_and_sr_plots_multi_pkl.py`

(If you also ran broader pytest/compileall locally, list it here; otherwise keep scoped since the PR is focused on this new functionality.)

### Review notes
- Please pay attention to **merge validation strictness**:
  - edge comparisons use exact `np.array_equal` for dense axis edges; this is intentional to prevent subtle binning drift across inputs.
- Default behavior is **fail-fast** on process-label overlaps; reviewers should confirm that’s the desired default for multi-pkl usage.
- Condor behavior now relies on transferring the pkl list text file (not the pkls themselves). This assumes pkls are accessible from worker nodes via shared FS/paths; check that this matches your deployment model.
- `DatacardMaker` now supports `hists=...`; call sites must not accidentally provide both `pkl_path` and `hists`.