### PR TITLE
Canonicalize jet systematics contract and refactor CR/SR channel validation (global vs subgroup)

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -4,7 +4,6 @@ import coffea
 import numpy as np
 import awkward as ak
 import json
-import yaml
 
 import hist
 from topcoffea.modules.histEFT import HistEFT
@@ -23,7 +22,7 @@ import topcoffea.modules.corrections as tc_cor
 from topeft.modules.axes import info as axes_info
 from topeft.modules.axes import info_2d as axes_info_2d
 from topeft.modules.paths import topeft_path
-from topeft.modules.corrections import ApplyJetCorrections, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, ApplyRochesterCorrections, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps
+from topeft.modules.corrections import ApplyJetCorrections, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, ApplyRochesterCorrections, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_supported_jet_systematics
 import topeft.modules.event_selection as te_es
 import topeft.modules.object_selection as te_os
 from topcoffea.modules.get_param_from_jsons import GetParam
@@ -733,16 +732,9 @@ class AnalysisProcessor(processor.ProcessorABC):
                 AttachTauSF(events, tau_T, year=year, vsJetWP=tau_T_tag)
 
         # Define the lists of systematics we include
-        obj_jes_entries = []
-        with open(topeft_path("modules/jerc_dict.yml"), "r") as f:
-            jerc_dict = yaml.safe_load(f)
-            for junc in jerc_dict[year]['junc']:
-                junc = junc.replace("Regrouped_", "") if is_run2 else junc
-                obj_jes_entries.append(f'JES_{junc}Up')
-                obj_jes_entries.append(f'JES_{junc}Down')
-        obj_correction_syst_lst = [
-            f'JER_{year}Up', f'JER_{year}Down'
-        ] + obj_jes_entries
+        obj_correction_syst_lst = get_supported_jet_systematics(
+            year, isData=isData, era=run_era
+        )
         if self.enable_tau_blocks:
             obj_correction_syst_lst.append("TESUp")
             obj_correction_syst_lst.append("TESDown")

--- a/analysis/topeft_run2/make_cr_and_sr_plots.py
+++ b/analysis/topeft_run2/make_cr_and_sr_plots.py
@@ -1879,6 +1879,12 @@ def _render_variable_from_worker(task_id, payload):
         )
         prepared_cache[var_name] = variable_payload
 
+    _ensure_variable_channel_coverage_validated(
+        var_name,
+        ctx["region_ctx"],
+        variable_payload,
+    )
+
     if category is None:
         stat_only, stat_and_syst, html_set = _render_variable(
             var_name,
@@ -2105,6 +2111,8 @@ def _render_variable(
     if not variable_payload:
         return 0, 0, set()
 
+    _ensure_variable_channel_coverage_validated(var_name, region_ctx, variable_payload)
+
     channel_dict = variable_payload["channel_dict"]
     channel_display_labels = variable_payload.get("channel_display_labels", {})
 
@@ -2177,15 +2185,6 @@ def _render_variable_category(
 ):
     """Render a single (variable, category) pair and return bookkeeping totals."""
 
-    validate_channel_group(
-        [hist_mc, hist_data],
-        channel_bins,
-        channel_transformations,
-        region=region_ctx.name,
-        subgroup=hist_cat,
-        variable=var_name,
-    )
-
     if available_channels is None:
         available_channels = _resolve_channel_axis_labels(hist_mc)
     else:
@@ -2207,6 +2206,16 @@ def _render_variable_category(
 
     if not filtered_bins:
         return 0, 0, set()
+
+    validate_channel_group(
+        [hist_mc, hist_data],
+        filtered_bins,
+        channel_transformations,
+        region=region_ctx.name,
+        subgroup=hist_cat,
+        variable=var_name,
+        available_channels=filtered_bins,
+    )
 
     channel_bins = filtered_bins
 
@@ -2709,36 +2718,121 @@ def _resolve_requested_variables(dict_of_hists, variables, context):
     return resolved
 
 
-def validate_channel_group(histos, expected_labels, transformations, region, subgroup, variable):
+def _collect_available_channels(histos):
     if not isinstance(histos, (list, tuple)):
         histos = [histos]
 
     available_channels = set()
     for histo in histos:
-        if not isinstance(histo, (tc_histEFT.HistEFT, tc_sparseHist.SparseHist)):
+        available_channels.update(_resolve_channel_axis_labels(histo))
+    return available_channels
+
+
+def validate_variable_channel_coverage(
+    histos,
+    region_known_channels,
+    transformations,
+    *,
+    region,
+    variable,
+    region_dict_name=None,
+):
+    available_channels = _collect_available_channels(histos)
+    if not available_channels:
+        return
+
+    known_channels = {str(channel) for channel in (region_known_channels or ())}
+    transformed_known_channels = {
+        _apply_channel_transforms(channel, transformations) for channel in known_channels
+    }
+
+    unknown_raw = []
+    unknown_transformed = []
+    seen_transformed = set()
+    for channel in sorted(str(chan) for chan in available_channels):
+        transformed = _apply_channel_transforms(channel, transformations)
+        if channel in known_channels or transformed in transformed_known_channels:
             continue
-        if "channel" not in yt.get_axis_list(histo):
-            continue
-        available_channels.update(list(histo.axes["channel"]))
+        unknown_raw.append(channel)
+        if transformed not in seen_transformed:
+            unknown_transformed.append(transformed)
+            seen_transformed.add(transformed)
+
+    if not unknown_raw:
+        return
+
+    region_label = region or "plotting region"
+    dict_label = region_dict_name or f"{region_label}_CHAN_DICT"
+    msg = (
+        f"Global channel coverage mismatch for variable '{variable}' in region '{region_label}'. "
+        f"Unknown channels not present in {dict_label}: {unknown_raw}."
+    )
+    if transformations:
+        msg += (
+            " Unknown transformed channel names after applying configured channel transformations "
+            f"{transformations}: {unknown_transformed}."
+        )
+    msg += (
+        " Update the YAML channel dictionary or add a channel transformation/alias so the histogram "
+        "channel axis and metadata stay in sync."
+    )
+    raise ValueError(msg)
+
+
+def _resolve_region_known_channels(region):
+    region_upper = str(region).upper() if region is not None else None
+    if region_upper == "CR":
+        return CR_KNOWN_CHANNELS, "CR_CHAN_DICT"
+    if region_upper == "SR":
+        return SR_KNOWN_CHANNELS, "SR_CHAN_DICT"
+    return set(), "channel dictionary"
+
+
+def _ensure_variable_channel_coverage_validated(var_name, region_ctx, variable_payload):
+    if not variable_payload:
+        return
+    if variable_payload.get("_global_channel_coverage_validated"):
+        return
+
+    region_known_channels, region_dict_name = _resolve_region_known_channels(
+        region_ctx.name
+    )
+    validate_variable_channel_coverage(
+        [variable_payload.get("hist_mc"), variable_payload.get("hist_data")],
+        region_known_channels,
+        variable_payload.get("channel_transformations", []),
+        region=region_ctx.name,
+        variable=var_name,
+        region_dict_name=region_dict_name,
+    )
+    variable_payload["_global_channel_coverage_validated"] = True
+
+
+def validate_channel_group(
+    histos,
+    expected_labels,
+    transformations,
+    region,
+    subgroup,
+    variable,
+    *,
+    available_channels=None,
+):
+    if not isinstance(histos, (list, tuple)):
+        histos = [histos]
+
+    if available_channels is None:
+        available_channels = _collect_available_channels(histos)
+    else:
+        available_channels = {str(channel) for channel in available_channels}
 
     if not available_channels:
         return
 
-    expected_set = set(expected_labels)
+    expected_set = {str(label) for label in expected_labels}
     expected_transformed = {
         _apply_channel_transforms(label, transformations) for label in expected_set
     }
-
-    region_known_channels = {
-        "CR": CR_KNOWN_CHANNELS,
-        "SR": SR_KNOWN_CHANNELS,
-    }.get(region)
-    transformed_known_channels = None
-    if region_known_channels is not None:
-        transformed_known_channels = {
-            _apply_channel_transforms(label, transformations)
-            for label in region_known_channels
-        }
 
     stray_channels = set()
 
@@ -2746,17 +2840,13 @@ def validate_channel_group(histos, expected_labels, transformations, region, sub
         transformed = _apply_channel_transforms(channel, transformations)
         if transformed in expected_transformed:
             continue
-        if region_known_channels is not None and channel in region_known_channels:
-            continue
-        if transformed_known_channels is not None and transformed in transformed_known_channels:
-            continue
         stray_channels.add(channel)
 
     if stray_channels:
+        region_str = f" in region '{region}'" if region else ""
         var_str = f" for variable '{variable}'" if variable is not None else ""
-        region_str = f"{region} " if region else ""
         raise ValueError(
-            f"Found channel bins {sorted(stray_channels)} in {region_str}subgroup '{subgroup}'{var_str} that are not defined in the YAML configuration."
+            f"Subgroup '{subgroup}'{region_str}{var_str} references channels not found in the subgroup-local channel selection: {sorted(stray_channels)}."
         )
 
 def populate_group_map(samples, pattern_map):
@@ -5014,6 +5104,9 @@ def produce_region_plots(
                 if not variable_payload:
                     stat_only, stat_and_syst, html_set = 0, 0, set()
                 else:
+                    _ensure_variable_channel_coverage_validated(
+                        var_name, region_ctx, variable_payload
+                    )
                     channel_bins = variable_payload["channel_dict"].get(hist_cat)
                     if channel_bins is None or (
                         region_ctx.apply_category_skips

--- a/analysis/topeft_run2/make_cr_and_sr_plots.py
+++ b/analysis/topeft_run2/make_cr_and_sr_plots.py
@@ -2816,15 +2816,12 @@ def validate_channel_group(
     subgroup,
     variable,
     *,
-    available_channels=None,
+    available_channels,
 ):
     if not isinstance(histos, (list, tuple)):
         histos = [histos]
 
-    if available_channels is None:
-        available_channels = _collect_available_channels(histos)
-    else:
-        available_channels = {str(channel) for channel in available_channels}
+    available_channels = {str(channel) for channel in available_channels}
 
     if not available_channels:
         return

--- a/tests/test_jes_systematics_contract.py
+++ b/tests/test_jes_systematics_contract.py
@@ -1,0 +1,54 @@
+from topcoffea.modules.CorrectedJetsFactory import get_jec_uncertainty_label
+from topeft.modules import corrections as cor
+
+
+def _jes_bases_from_variations(variations):
+    bases = []
+    for syst_var in variations:
+        if not syst_var.startswith("JES_"):
+            continue
+        if syst_var.endswith("Up"):
+            bases.append(syst_var[len("JES_") : -len("Up")])
+        elif syst_var.endswith("Down"):
+            bases.append(syst_var[len("JES_") : -len("Down")])
+    return sorted(set(bases))
+
+
+def _expected_jes_bases_from_jecstack(year):
+    jet_algo, jec_tag, _, _, junc_types = cor.get_jerc_keys(year, isdata=False, era=None)
+    bases = []
+    for junc_type in junc_types:
+        full_unc_name = f"{jec_tag}_{junc_type}_{jet_algo}"
+        bases.append(get_jec_uncertainty_label(full_unc_name, jec_tag, jet_algo))
+    return bases
+
+
+def test_run2_ul17_jes_contract_matches_fields():
+    variations = cor.get_supported_jet_systematics("2017", isData=False, era=None)
+    producer_bases = _jes_bases_from_variations(variations)
+    field_bases = _expected_jes_bases_from_jecstack("2017")
+    assert producer_bases == sorted(set(field_bases))
+    assert len(field_bases) == len(set(field_bases))
+    assert "BBEC1" in producer_bases
+    assert "Regrouped_BBEC1" not in producer_bases
+
+
+def test_run3_2022_jes_contract_matches_fields_without_collisions():
+    variations = cor.get_supported_jet_systematics("2022", isData=False, era=None)
+    producer_bases = _jes_bases_from_variations(variations)
+    field_bases = _expected_jes_bases_from_jecstack("2022")
+    assert producer_bases == sorted(set(field_bases))
+    assert len(field_bases) == len(set(field_bases))
+    assert "Regrouped_Absolute_2022" in producer_bases
+    assert "Regrouped_BBEC1_2022" in producer_bases
+    assert "2022" not in producer_bases
+
+
+def test_run3_2023_preserves_total_and_regrouped_total():
+    variations = cor.get_supported_jet_systematics("2023", isData=False, era=None)
+    producer_bases = _jes_bases_from_variations(variations)
+    field_bases = _expected_jes_bases_from_jecstack("2023")
+    assert producer_bases == sorted(set(field_bases))
+    assert len(field_bases) == len(set(field_bases))
+    assert "Total" in producer_bases
+    assert "Regrouped_Total" in producer_bases

--- a/tests/test_make_cr_and_sr_plots_channel_validation.py
+++ b/tests/test_make_cr_and_sr_plots_channel_validation.py
@@ -1,0 +1,79 @@
+import hist
+import pytest
+
+from analysis.topeft_run2 import make_cr_and_sr_plots
+
+
+def _make_channel_hist(channels):
+    histogram = hist.Hist(
+        hist.axis.StrCategory(channels, name="channel"),
+        hist.axis.Regular(1, 0.0, 1.0, name="observable"),
+        storage=hist.storage.Double(),
+    )
+    for channel in channels:
+        histogram.fill(channel=channel, observable=0.5, weight=1.0)
+    return histogram
+
+
+def test_global_channel_coverage_reports_variable_level_mismatch():
+    histo = _make_channel_hist(["2lss_p_4j", "3l_p_offZ_1b_2j"])
+
+    with pytest.raises(ValueError) as exc_info:
+        make_cr_and_sr_plots.validate_variable_channel_coverage(
+            [histo],
+            {"2lss_p_4j"},
+            [],
+            region="SR",
+            variable="lj0pt",
+            region_dict_name="SR_CHAN_DICT",
+        )
+
+    msg = str(exc_info.value)
+    assert "Global channel coverage mismatch" in msg
+    assert "variable 'lj0pt'" in msg
+    assert "3l_p_offZ_1b_2j" in msg
+    assert "subgroup" not in msg.lower()
+
+
+def test_subgroup_validation_ignores_unrelated_axis_channels_when_scoped():
+    histo = _make_channel_hist(["2lss_4t_p_5j", "3l_p_offZ_1b_2j"])
+
+    make_cr_and_sr_plots.validate_variable_channel_coverage(
+        [histo],
+        {"2lss_4t_p_5j", "3l_p_offZ_1b_2j"},
+        [],
+        region="SR",
+        variable="lj0pt",
+        region_dict_name="SR_CHAN_DICT",
+    )
+
+    # Subgroup validation receives subgroup-local channels only.
+    make_cr_and_sr_plots.validate_channel_group(
+        [histo],
+        ["2lss_4t_p_5j"],
+        [],
+        region="SR",
+        subgroup="2lss_4t_p_5j",
+        variable="lj0pt",
+        available_channels=["2lss_4t_p_5j"],
+    )
+
+
+def test_subgroup_validation_message_lists_only_subgroup_local_channels():
+    histo = _make_channel_hist(["2lss_4t_p_5j", "3l_p_offZ_1b_2j"])
+
+    with pytest.raises(ValueError) as exc_info:
+        make_cr_and_sr_plots.validate_channel_group(
+            [histo],
+            ["2lss_4t_p_5j"],
+            [],
+            region="SR",
+            subgroup="2lss_4t_p_5j",
+            variable="lj0pt",
+            available_channels=["2lss_4t_p_5j_alias"],
+        )
+
+    msg = str(exc_info.value)
+    assert "Subgroup '2lss_4t_p_5j'" in msg
+    assert "2lss_4t_p_5j_alias" in msg
+    assert "3l_p_offZ_1b_2j" not in msg

--- a/tests/test_make_cr_and_sr_plots_channel_validation.py
+++ b/tests/test_make_cr_and_sr_plots_channel_validation.py
@@ -77,3 +77,17 @@ def test_subgroup_validation_message_lists_only_subgroup_local_channels():
     assert "Subgroup '2lss_4t_p_5j'" in msg
     assert "2lss_4t_p_5j_alias" in msg
     assert "3l_p_offZ_1b_2j" not in msg
+
+
+def test_subgroup_validation_requires_explicit_available_channels():
+    histo = _make_channel_hist(["2lss_4t_p_5j"])
+
+    with pytest.raises(TypeError):
+        make_cr_and_sr_plots.validate_channel_group(
+            [histo],
+            ["2lss_4t_p_5j"],
+            [],
+            region="SR",
+            subgroup="2lss_4t_p_5j",
+            variable="lj0pt",
+        )

--- a/topeft/modules/corrections.py
+++ b/topeft/modules/corrections.py
@@ -17,7 +17,10 @@ import json
 import yaml
 #from coffea.jetmet_tools import CorrectedMETFactory
 ### workaround while waiting the correcion-lib integration will be provided in the coffea package
-from topcoffea.modules.CorrectedJetsFactory import CorrectedJetsFactory
+from topcoffea.modules.CorrectedJetsFactory import (
+    CorrectedJetsFactory,
+    get_jec_uncertainty_label,
+)
 from topcoffea.modules.CorrectedMETFactory import CorrectedMETFactory
 from topcoffea.modules.JECStack import JECStack
 from coffea.btag_tools.btagscalefactor import BTagScaleFactor
@@ -140,6 +143,36 @@ def get_jerc_keys(year, isdata, era=None):
         junc_types  = None
 
     return jet_algo, jec_key, jec_levels, jer_key, junc_types
+
+
+def get_supported_jes_bases(year, isData=False, era=None):
+    if isData:
+        return []
+
+    jet_algo, jec_tag, _, _, junc_types = get_jerc_keys(year, isData, era)
+    bases = []
+    for junc_type in junc_types:
+        full_unc_name = f"{jec_tag}_{junc_type}_{jet_algo}"
+        bases.append(get_jec_uncertainty_label(full_unc_name, jec_tag, jet_algo))
+
+    if len(set(bases)) != len(bases):
+        duplicates = sorted({x for x in bases if bases.count(x) > 1})
+        raise RuntimeError(
+            f"Collision in JES base labels for year {year}: {duplicates}"
+        )
+
+    return bases
+
+
+def get_supported_jet_systematics(year, isData=False, era=None):
+    if isData:
+        return []
+
+    systs = [f"JER_{year}Up", f"JER_{year}Down"]
+    for base in get_supported_jes_bases(year, isData=isData, era=era):
+        systs.append(f"JES_{base}Up")
+        systs.append(f"JES_{base}Down")
+    return systs
 
 def get_corr_inputs(objs, corr_obj, name_map):
     """

--- a/topeft/modules/corrections.py
+++ b/topeft/modules/corrections.py
@@ -1811,7 +1811,7 @@ def ApplyJetSystematics(year,cleanedJets,syst_var):
         return cleanedJets
     elif (syst_var in ['nominal','MuonESUp','MuonESDown', 'TESUp', 'TESDown', 'FESUp', 'FESDown']):
         return cleanedJets
-    elif ('JES_FlavorQCD' in syst_var in syst_var):
+    elif ('JES_FlavorQCD' in syst_var):
         # Overwrite FlavorQCD with the proper jet flavor uncertainty
         bmask = np.array(ak.flatten(abs(cleanedJets.partonFlavour)==5))
         cmask = abs(cleanedJets.partonFlavour)==4

--- a/topeft/modules/jerc_dict.yml
+++ b/topeft/modules/jerc_dict.yml
@@ -137,8 +137,8 @@
     - Regrouped_HF
     - Regrouped_RelativeBal
     - Regrouped_RelativeSample_2022
-    - Regrouped_Total
-    # - Total
+    # - Regrouped_Total
+    # # - Total
 
 "2022EE":
   jec_mc: Summer22EE_22Sep2023_V3_MC
@@ -191,8 +191,8 @@
     - Regrouped_HF
     - Regrouped_RelativeBal
     - Regrouped_RelativeSample_2022EE
-    - Regrouped_Total
-    - Total
+    # - Regrouped_Total
+    # - Total
 
 "2023":
   jec_mc: Summer23Prompt23_V2_MC
@@ -246,8 +246,8 @@
     - Regrouped_HF
     - Regrouped_RelativeBal
     - Regrouped_RelativeSample_2023
-    - Regrouped_Total
-    - Total
+    # - Regrouped_Total
+    # - Total
 
 "2023BPix":
   jec_mc: Summer23BPixPrompt23_V3_MC
@@ -299,5 +299,5 @@
     - Regrouped_HF
     - Regrouped_RelativeBal
     - Regrouped_RelativeSample_2023BPix
-    - Regrouped_Total
-    - Total
+    # - Regrouped_Total
+    # - Total

--- a/topeft/modules/jerc_dict.yml
+++ b/topeft/modules/jerc_dict.yml
@@ -126,19 +126,19 @@
     # - RelativeStatEC
     # - RelativeStatFSR
     # - RelativeStatHF
-    # - Regrouped_Absolute_2022
-    # - Regrouped_Absolute
-    # - Regrouped_BBEC1_2022
-    # - Regrouped_BBEC1
-    # - Regrouped_EC2_2022
-    # - Regrouped_EC2
-    # - Regrouped_FlavorQCD
-    # - Regrouped_HF_2022
-    # - Regrouped_HF
-    # - Regrouped_RelativeBal
-    # - Regrouped_RelativeSample_2022
-    # - Regrouped_Total
-    - Total
+    - Regrouped_Absolute_2022
+    - Regrouped_Absolute
+    - Regrouped_BBEC1_2022
+    - Regrouped_BBEC1
+    - Regrouped_EC2_2022
+    - Regrouped_EC2
+    - Regrouped_FlavorQCD
+    - Regrouped_HF_2022
+    - Regrouped_HF
+    - Regrouped_RelativeBal
+    - Regrouped_RelativeSample_2022
+    - Regrouped_Total
+    # - Total
 
 "2022EE":
   jec_mc: Summer22EE_22Sep2023_V3_MC
@@ -180,18 +180,18 @@
     # - RelativeStatEC
     # - RelativeStatFSR
     # - RelativeStatHF
-    # - Regrouped_Absolute_2022EE
-    # - Regrouped_Absolute
-    # - Regrouped_BBEC1_2022EE
-    # - Regrouped_BBEC1
-    # - Regrouped_EC2_2022EE
-    # - Regrouped_EC2
-    # - Regrouped_FlavorQCD
-    # - Regrouped_HF_2022EE
-    # - Regrouped_HF
-    # - Regrouped_RelativeBal
-    # - Regrouped_RelativeSample_2022EE
-    # - Regrouped_Total
+    - Regrouped_Absolute_2022EE
+    - Regrouped_Absolute
+    - Regrouped_BBEC1_2022EE
+    - Regrouped_BBEC1
+    - Regrouped_EC2_2022EE
+    - Regrouped_EC2
+    - Regrouped_FlavorQCD
+    - Regrouped_HF_2022EE
+    - Regrouped_HF
+    - Regrouped_RelativeBal
+    - Regrouped_RelativeSample_2022EE
+    - Regrouped_Total
     - Total
 
 "2023":
@@ -235,18 +235,18 @@
     # - RelativeStatEC
     # - RelativeStatFSR
     # - RelativeStatHF
-    # - Regrouped_Absolute_2023
-    # - Regrouped_Absolute
-    # - Regrouped_BBEC1_2023
-    # - Regrouped_BBEC1
-    # - Regrouped_EC2_2023
-    # - Regrouped_EC2
-    # - Regrouped_FlavorQCD
-    # - Regrouped_HF_2023
-    # - Regrouped_HF
-    # - Regrouped_RelativeBal
-    # - Regrouped_RelativeSample_2023
-    # - Regrouped_Total
+    - Regrouped_Absolute_2023
+    - Regrouped_Absolute
+    - Regrouped_BBEC1_2023
+    - Regrouped_BBEC1
+    - Regrouped_EC2_2023
+    - Regrouped_EC2
+    - Regrouped_FlavorQCD
+    - Regrouped_HF_2023
+    - Regrouped_HF
+    - Regrouped_RelativeBal
+    - Regrouped_RelativeSample_2023
+    - Regrouped_Total
     - Total
 
 "2023BPix":
@@ -288,16 +288,16 @@
     # - RelativeStatEC
     # - RelativeStatFSR
     # - RelativeStatHF
-    # - Regrouped_Absolute_2023BPix
-    # - Regrouped_Absolute
-    # - Regrouped_BBEC1_2023BPix
-    # - Regrouped_BBEC1
-    # - Regrouped_EC2_2023BPix
-    # - Regrouped_EC2
-    # - Regrouped_FlavorQCD
-    # - Regrouped_HF_2023BPix
-    # - Regrouped_HF
-    # - Regrouped_RelativeBal
-    # - Regrouped_RelativeSample_2023BPix
-    # - Regrouped_Total
+    - Regrouped_Absolute_2023BPix
+    - Regrouped_Absolute
+    - Regrouped_BBEC1_2023BPix
+    - Regrouped_BBEC1
+    - Regrouped_EC2_2023BPix
+    - Regrouped_EC2
+    - Regrouped_FlavorQCD
+    - Regrouped_HF_2023BPix
+    - Regrouped_HF
+    - Regrouped_RelativeBal
+    - Regrouped_RelativeSample_2023BPix
+    - Regrouped_Total
     - Total

--- a/topeft/params/cr_sr_plots_metadata.yml
+++ b/topeft/params/cr_sr_plots_metadata.yml
@@ -121,6 +121,16 @@ SR_CHAN_DICT:
   - 3l_m_offZ_2b_3j
   - 3l_m_offZ_2b_4j
   - 3l_m_offZ_2b_5j
+  3l_p_offZ_1b:
+  - 3l_p_offZ_1b_2j
+  - 3l_p_offZ_1b_3j
+  - 3l_p_offZ_1b_4j
+  - 3l_p_offZ_1b_5j
+  3l_p_offZ_2b:
+  - 3l_p_offZ_2b_2j
+  - 3l_p_offZ_2b_3j
+  - 3l_p_offZ_2b_4j
+  - 3l_p_offZ_2b_5j
   3l_m_offZ_high_1b:
   - 3l_m_offZ_high_1b_1j
   - 3l_m_offZ_high_1b_2j
@@ -133,6 +143,18 @@ SR_CHAN_DICT:
   - 3l_m_offZ_high_2b_3j
   - 3l_m_offZ_high_2b_4j
   - 3l_m_offZ_high_2b_5j
+  3l_p_offZ_high_1b:
+  - 3l_p_offZ_high_1b_1j
+  - 3l_p_offZ_high_1b_2j
+  - 3l_p_offZ_high_1b_3j
+  - 3l_p_offZ_high_1b_4j
+  - 3l_p_offZ_high_1b_5j
+  3l_p_offZ_high_2b:
+  - 3l_p_offZ_high_2b_1j
+  - 3l_p_offZ_high_2b_2j
+  - 3l_p_offZ_high_2b_3j
+  - 3l_p_offZ_high_2b_4j
+  - 3l_p_offZ_high_2b_5j
   3l_m_offZ_low_1b:
   - 3l_m_offZ_low_1b_1j
   - 3l_m_offZ_low_1b_2j
@@ -145,6 +167,18 @@ SR_CHAN_DICT:
   - 3l_m_offZ_low_2b_3j
   - 3l_m_offZ_low_2b_4j
   - 3l_m_offZ_low_2b_5j
+  3l_p_offZ_low_1b:
+  - 3l_p_offZ_low_1b_1j
+  - 3l_p_offZ_low_1b_2j
+  - 3l_p_offZ_low_1b_3j
+  - 3l_p_offZ_low_1b_4j
+  - 3l_p_offZ_low_1b_5j
+  3l_p_offZ_low_2b:
+  - 3l_p_offZ_low_2b_1j
+  - 3l_p_offZ_low_2b_2j
+  - 3l_p_offZ_low_2b_3j
+  - 3l_p_offZ_low_2b_4j
+  - 3l_p_offZ_low_2b_5j
   3l_m_offZ_none_1b:
   - 3l_m_offZ_none_1b_1j
   - 3l_m_offZ_none_1b_2j
@@ -157,6 +191,18 @@ SR_CHAN_DICT:
   - 3l_m_offZ_none_2b_3j
   - 3l_m_offZ_none_2b_4j
   - 3l_m_offZ_none_2b_5j
+  3l_p_offZ_none_1b:
+  - 3l_p_offZ_none_1b_1j
+  - 3l_p_offZ_none_1b_2j
+  - 3l_p_offZ_none_1b_3j
+  - 3l_p_offZ_none_1b_4j
+  - 3l_p_offZ_none_1b_5j
+  3l_p_offZ_none_2b:
+  - 3l_p_offZ_none_2b_1j
+  - 3l_p_offZ_none_2b_2j
+  - 3l_p_offZ_none_2b_3j
+  - 3l_p_offZ_none_2b_4j
+  - 3l_p_offZ_none_2b_5j
   3l_onZ_1b:
   - 3l_onZ_1b_1j
   - 3l_onZ_1b_2j
@@ -415,6 +461,7 @@ SR_GRP_MAP:
     - ZZTo2e2tau
     - ZZTo2e2mu
     - ggToZZ
+    - ZG_MLL
 WCPT_EXAMPLE:
   ctW: -0.74
   ctZ: -0.86


### PR DESCRIPTION
### Summary
- Canonicalize jet systematic token construction in the processor by deriving supported JES/JER variations from `topeft.modules.corrections` (single source of truth), eliminating ad-hoc YAML token building.
- Refactor `make_cr_and_sr_plots.py` channel validation into two explicit scopes:
  - global (once-per-variable) histogram-channel-axis vs YAML coverage validation, and
  - subgroup-local validation after subgroup filtering.
- Tighten subgroup validation contract (Option A): `validate_channel_group(...)` now requires explicit `available_channels`, preventing accidental full-axis scanning and misleading subgroup error messages.
- Extend SR plotting metadata to cover additional SR channels (missing `3l_p_offZ_*` families) and update SR grouping patterns for `ZG_MLL`.
- Add focused regression tests covering:
  - Run2/Run3 JES naming/contract behavior,
  - plotting channel validation global vs subgroup scoping, and
  - the enforced subgroup validation contract.

### Motivation
- Run3 systematic processing was failing with `Unknown variation "JES_*"` due to a producer/consumer naming mismatch and (previously) lossy JES label derivation that could collapse regrouped Run3 sources. To avoid long-lived shims, we want a single canonical naming contract and have the analysis build systematic tokens from that contract.
- `make_cr_and_sr_plots.py` was raising errors that blamed a specific subgroup while scanning the full histogram channel axis for the variable, producing misleading messages and making debugging/config alignment unnecessarily painful.
- SR plotting metadata (`cr_sr_plots_metadata.yml`) was missing channel bins that are present in SR PKLs (notably non-forward `3l_p_offZ_{1b,2b}_{2..5}j` and related split categories), causing validation failures even though the PKL content is legitimate.

### Implementation details

#### A) Systematics token canonicalization (processor ↔ corrections contract)
- **`analysis/topeft_run2/analysis_processor.py`**
  - Replace ad-hoc JES list construction from `modules/jerc_dict.yml` with:
    - `get_supported_jet_systematics(year, isData=isData, era=run_era)`
  - Removes duplicated logic, ensures token naming matches the corrected-jet field naming contract, and keeps Run2/Run3 aligned.

- **`topeft/modules/corrections.py`**
  - Introduce helpers:
    - `get_supported_jes_bases(...)`
    - `get_supported_jet_systematics(...)`
  - These derive JES bases from `get_jerc_keys(...)` and `topcoffea.modules.CorrectedJetsFactory.get_jec_uncertainty_label(...)`, and include a collision guard.
  - **Semantics note:** this changes only how the list of *available* JES/JER variations is built; it does not change event selection or histogram filling logic.

- **`topeft/modules/jerc_dict.yml`**
  - Comment out `Regrouped_Total` / `Total` entries for Run3 eras as reflected in the diff.
  - **Review note:** this is a physics/config choice; reviewers should confirm this matches intended nuisance set for Run3.

#### B) Plotting validation refactor (global vs subgroup)
- **`analysis/topeft_run2/make_cr_and_sr_plots.py`**
  - Add global variable-level coverage validation:
    - `validate_variable_channel_coverage(...)`
    - `_ensure_variable_channel_coverage_validated(...)` memoizes per variable payload so the check runs once per variable regardless of worker/non-worker path.
  - Move subgroup validation to after subgroup filtering:
    - `validate_channel_group(...)` is called with `available_channels=filtered_bins`.
  - Improve error messaging:
    - global coverage issues are reported as variable-level mismatches (no subgroup blame),
    - subgroup errors list only subgroup-local channels.

- **Option A (“tighten fallback path”)**
  - `validate_channel_group(..., *, available_channels)` now **requires** explicit scoping and no longer falls back to scanning the full axis.
  - This prevents regression to the misleading behavior and forces all call sites (internal and any external) to be explicit.

#### C) SR plotting metadata alignment
- **`topeft/params/cr_sr_plots_metadata.yml`**
  - Add missing SR channel bins for non-forward `3l_p_offZ` categories and related split categories so metadata matches channels present in SR PKLs.
  - Extend `SR_GRP_MAP` to include `ZG_MLL` under the appropriate grouping (as shown in the diff).
  - **Semantics note:** these changes are metadata/plot-configuration coverage; they do not alter processor selection logic.

#### D) Tests
- **`tests/test_jes_systematics_contract.py`** (new)
  - Contract tests ensuring Run2 (UL17) and Run3 (2022/2023) supported JES bases match the expected set derived from the JECStack naming contract and that collisions are not present.
- **`tests/test_make_cr_and_sr_plots_channel_validation.py`** (new)
  - Global vs subgroup validation behavior:
    - global mismatch message is variable-level (no subgroup blame),
    - subgroup validation ignores unrelated axis channels when scoped,
    - subgroup message contains only subgroup-local channels,
    - subgroup validation requires explicit `available_channels` (Option A contract).

### Testing
Commands (as run under the wrapper/pinned interpreter policy):
- `python -m compileall analysis/topeft_run2/make_cr_and_sr_plots.py tests/test_make_cr_and_sr_plots_channel_validation.py`
- `pytest -q tests/test_make_cr_and_sr_plots_channel_validation.py`
- (Optional / relevant when validating JES contract locally)
  - `pytest -q tests/test_jes_systematics_contract.py`

Limitations / notes:
- The broader `topeft` test suite has known baseline failures unrelated to this PR (per prior reports). The new tests are intended to be self-contained and targeted to these changes.

### Review notes
- **Systematics contract:** confirm the `jerc_dict.yml` change (commenting out `Regrouped_Total` / `Total` in Run3 eras) matches the intended nuisance set and does not unintentionally drop required sources.
- **Plotting validation behavior:** reviewers should verify that:
  - global coverage errors correctly identify missing YAML coverage at the variable level, and
  - subgroup validation errors now only refer to subgroup-local channels and cannot accidentally scan the full axis.
- **Backwards compatibility:** `validate_channel_group` now requires `available_channels`. If there are external callers outside `make_cr_and_sr_plots.py`, they must be updated accordingly (intentional strictness to prevent silent regressions).