### PR TITLE
runtime guard: clarify topcoffea ref mismatch guidance + env overrides

### DIFF
--- a/tests/test_dependency_checks.py
+++ b/tests/test_dependency_checks.py
@@ -48,6 +48,9 @@ def test_branch_guard_rejects_mismatched_branch(monkeypatch, tmp_path):
     message = str(excinfo.value)
     assert "coordinated ref" in message
     assert "topcoffea/docs/topeft_integration.md" in message
+    assert "TOPCOFFEA_BRANCH" in message
+    assert "TOPEFT_TOPCOFFEA_EXPECTED" in message
+    assert "ch_update_calcoffea" not in message
 
 
 def test_branch_guard_accepts_env_override(monkeypatch, tmp_path):

--- a/topeft/_dependency_checks.py
+++ b/topeft/_dependency_checks.py
@@ -91,13 +91,13 @@ def ensure_topcoffea_branch(expected_refs: Optional[Sequence[str]] = None) -> No
         return
 
     message = (
-        "topcoffea checkout at {repo} is on '{branch}' but the workflow expects one of "
-        "{expected}. Ensure the installed topcoffea ref matches the coordinated ref for "
-        "this topeft checkout; see topcoffea/docs/topeft_integration.md for compatibility "
-        "policy. You can export TOPCOFFEA_BRANCH to override.".format(
+        "topcoffea checkout at {repo} is on '{branch}' and does not match the coordinated "
+        "ref policy for this topeft checkout. Ensure the installed topcoffea ref matches "
+        "the coordinated ref; see topcoffea/docs/topeft_integration.md for compatibility "
+        "policy. You can export TOPCOFFEA_BRANCH to override the detected ref and "
+        "TOPEFT_TOPCOFFEA_EXPECTED to define the allowed coordinated refs.".format(
             repo=repo_root,
             branch=branch,
-            expected=", ".join(expected),
         )
     )
     raise RuntimeError(message)


### PR DESCRIPTION
### Summary
- Clarify `topcoffea` ref mismatch RuntimeError messaging to point to the coordinated-ref policy and document both override knobs.
- Strengthen the dependency-check unit test to assert the improved guidance and prevent branch-literal regressions.

### Motivation
The `topcoffea` dependency guard is intentionally strict, but its mismatch message should be maximally actionable and consistent with the coordinated-ref policy. In particular, users should immediately see:
- where the compatibility policy is documented, and
- which env vars can override the detected/expected refs for edge cases.

### Implementation details
A) Runtime message wording
- `topeft/_dependency_checks.py`
  - Updated the mismatch RuntimeError message from “expects one of {expected}” to “does not match the coordinated ref policy”.
  - Added explicit guidance for both override env vars:
    - `TOPCOFFEA_BRANCH` (override detected ref)
    - `TOPEFT_TOPCOFFEA_EXPECTED` (define allowed coordinated refs)
  - Kept guard behavior/semantics unchanged (message-only update).

B) Test coverage for message contract
- `tests/test_dependency_checks.py`
  - Extended the mismatch-message assertions to require:
    - `TOPCOFFEA_BRANCH` and `TOPEFT_TOPCOFFEA_EXPECTED` appear in the message, and
    - `ch_update_calcoffea` does **not** appear (prevents branch-literal drift).

### Testing
- `python -m compileall topeft/modules analysis tests`
- `python -m pytest -q`
- (At minimum for this diff) `python -m pytest -q tests/test_dependency_checks.py`

### Review notes
- This PR is intentionally **message-only** in runtime code: guard logic is unchanged.
- Please sanity-check the wording for clarity/actionability and that the env-var descriptions match the existing behavior.
- The new test assertions intentionally lock in “no branch literal in mismatch text” to avoid future policy drift.