### PR TITLE
TaskVine DDR: channel-keyed processors, strict canonical flattening, proxy/preprocess artifacts, and fail-fast collisions

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -489,6 +489,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         debug_logging: bool = False,
         executor_mode: Optional[str] = None,
         suppress_debug_prints: Optional[bool] = None,
+        produce_sidecars: bool = False,
     ):
 
         self._sample = sample
@@ -543,6 +544,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             )
         self._suppress_debug_prints = bool(suppress_debug_prints)
         self._executed_variations: List[Dict[str, Any]] = []
+        self._produce_sidecars = bool(produce_sidecars)
         self._golden_json_path = golden_json_path
         if self._sample.get("isData") and not self._golden_json_path:
             raise ValueError("golden_json_path must be provided for data samples")
@@ -691,8 +693,9 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         self._histogram_key_map = histogram_key_map
 
-        histogram[self.VARIATION_SUMMARY_KEY] = []
-        histogram["region_yields"] = processor.dict_accumulator()
+        if self._produce_sidecars:
+            histogram[self.VARIATION_SUMMARY_KEY] = []
+            histogram["region_yields"] = processor.dict_accumulator()
         self._accumulator = histogram
 
         # Set the energy threshold to cut on
@@ -739,6 +742,8 @@ class AnalysisProcessor(processor.ProcessorABC):
             self._executed_variations = []
         if not hasattr(self, "_debug_logging"):
             self._debug_logging = False
+        if not hasattr(self, "_produce_sidecars"):
+            self._produce_sidecars = False
         if not hasattr(self, "_suppress_debug_prints"):
             self._suppress_debug_prints = bool(
                 os.environ.get("TOPEFT_SUPPRESS_DEBUG_STDOUT")

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -166,6 +166,8 @@ def construct_cat_name(chan_str, njet_str=None, flav_str=None):
 
 @dataclass(frozen=True)
 class DatasetContext:
+    sample_name: str
+    sample_metadata: Mapping[str, Any]
     dataset: str
     trigger_dataset: str
     hist_axis_name: str
@@ -468,6 +470,49 @@ class AnalysisProcessor(processor.ProcessorABC):
     # Internal accumulator slot for per-task variation recaps; RunWorkflow pops
     # this key before serialized outputs are returned to users or saved.
     VARIATION_SUMMARY_KEY = "__topeft_variation_summary__"
+    REGION_YIELDS_KEY = "region_yields"
+
+    @staticmethod
+    def _looks_like_sample_metadata(candidate: Any) -> bool:
+        if not isinstance(candidate, Mapping):
+            return False
+        required_keys = {"histAxisName", "isData", "year", "xsec", "nSumOfWeights"}
+        return required_keys.issubset(set(candidate.keys()))
+
+    @classmethod
+    def _normalise_sample_mapping(
+        cls,
+        sample: Any,
+    ) -> Tuple["OrderedDict[str, Mapping[str, Any]]", Dict[str, str]]:
+        """Return deterministic sample lookups for dataset dispatch."""
+
+        if not isinstance(sample, Mapping):
+            raise TypeError("sample must be a mapping")
+
+        by_name: "OrderedDict[str, Mapping[str, Any]]" = OrderedDict()
+
+        if cls._looks_like_sample_metadata(sample):
+            sample_name = str(sample.get("histAxisName") or "sample")
+            by_name[sample_name] = sample
+        else:
+            for sample_name, sample_info in sample.items():
+                if not cls._looks_like_sample_metadata(sample_info):
+                    continue
+                by_name[str(sample_name)] = sample_info
+
+        if not by_name:
+            raise ValueError(
+                "sample must be a sample metadata mapping or a mapping of sample_name -> sample metadata"
+            )
+
+        aliases: Dict[str, str] = {}
+        for sample_name, sample_info in by_name.items():
+            aliases[sample_name] = sample_name
+            hist_axis_name = sample_info.get("histAxisName")
+            if hist_axis_name is not None:
+                aliases.setdefault(str(hist_axis_name), sample_name)
+
+        return by_name, aliases
 
     def __init__(
         self,
@@ -483,15 +528,19 @@ class AnalysisProcessor(processor.ProcessorABC):
         rebin=False,
         channel_dict=None,
         golden_json_path=None,
+        golden_json_paths: Optional[Mapping[str, str]] = None,
         systematic_variations=None,
         available_systematics=None,
         metadata_path: Optional[str] = None,
         debug_logging: bool = False,
         executor_mode: Optional[str] = None,
         suppress_debug_prints: Optional[bool] = None,
+        produce_sidecars: bool = False,
     ):
 
-        self._sample = sample
+        self._samples_by_name, self._sample_aliases = self._normalise_sample_mapping(sample)
+        # Keep ``_sample`` for backward-compatible call sites and test fixtures.
+        self._sample = next(iter(self._samples_by_name.values()))
         self._wc_names_lst = wc_names_lst
         self._dtype = dtype
         if channel_dict is None:
@@ -542,10 +591,25 @@ class AnalysisProcessor(processor.ProcessorABC):
                 os.environ.get("TOPEFT_SUPPRESS_DEBUG_STDOUT")
             )
         self._suppress_debug_prints = bool(suppress_debug_prints)
+        self._produce_sidecars = bool(produce_sidecars)
         self._executed_variations: List[Dict[str, Any]] = []
         self._golden_json_path = golden_json_path
-        if self._sample.get("isData") and not self._golden_json_path:
-            raise ValueError("golden_json_path must be provided for data samples")
+        self._golden_json_paths: Dict[str, str] = {}
+        if golden_json_path:
+            for sample_name in self._samples_by_name:
+                self._golden_json_paths[sample_name] = str(golden_json_path)
+        if golden_json_paths:
+            for sample_name, path in golden_json_paths.items():
+                resolved_sample_name = self._sample_aliases.get(
+                    str(sample_name), str(sample_name)
+                )
+                self._golden_json_paths[resolved_sample_name] = str(path)
+
+        for sample_name, sample_info in self._samples_by_name.items():
+            if sample_info.get("isData") and sample_name not in self._golden_json_paths:
+                raise ValueError(
+                    f"golden_json_path must be provided for data sample '{sample_name}'"
+                )
 
         if var_info is None:
             raise ValueError("var_info must be provided and cannot be None")
@@ -599,7 +663,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         first_label, first_hist_keys = next(iter(histogram_key_map.items()))
         first_hist_key = first_hist_keys[0]
 
-        var, ch, appl, sample_name, _ = first_hist_key
+        var, ch, appl, _, _ = first_hist_key
 
         self._var = var
         self._channel = ch
@@ -614,17 +678,27 @@ class AnalysisProcessor(processor.ProcessorABC):
         for variation_label, hist_key_entries in histogram_key_map.items():
             base_syst_label = hist_key_entries[0][4]
             self._histogram_label_lookup[variation_label] = base_syst_label
+            sumw2_samples_seen: Set[str] = set()
 
-            for idx, hist_key_entry in enumerate(hist_key_entries):
+            for hist_key_entry in hist_key_entries:
                 key_var, key_ch, key_appl, key_sample, syst_label = hist_key_entry
                 if key_var != self._var or key_appl != self._appregion:
                     raise ValueError(
                         "All histogram keys must refer to the same variable and application"
                     )
-                if key_sample != sample_name:
-                    raise ValueError(
-                        "Histogram keys must refer to the configured sample"
-                    )
+                histogram_sample_name = str(key_sample)
+                canonical_sample_name = self._sample_aliases.get(
+                    histogram_sample_name, histogram_sample_name
+                )
+                if canonical_sample_name not in self._samples_by_name:
+                    if len(self._samples_by_name) == 1:
+                        canonical_sample_name = next(iter(self._samples_by_name.keys()))
+                    else:
+                        raise ValueError(
+                            "Histogram key sample "
+                            f"{key_sample!r} is not present in configured samples "
+                            f"{tuple(self._samples_by_name.keys())!r}"
+                        )
 
                 if key_ch != self._channel:
                     mapped_channel = self._flavored_channel_lookup.get(key_ch)
@@ -647,7 +721,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                 hist_key = self._build_histogram_key(
                     key_var,
                     key_ch,
-                    key_sample,
+                    histogram_sample_name,
                     syst_label,
                     application=key_appl,
                 )
@@ -660,7 +734,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
                 self._hist_keys_to_fill.append(hist_key)
 
-                if idx == 0:
+                if histogram_sample_name not in sumw2_samples_seen:
                     if not rebin and "variable" in info:
                         sumw2_axis = hist.axis.Variable(
                             info["variable"],
@@ -677,7 +751,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                     sumw2_key = self._build_histogram_key(
                         f"{self._var}_sumw2",
                         self._channel,
-                        key_sample,
+                        histogram_sample_name,
                         syst_label,
                         application=self._appregion,
                     )
@@ -688,11 +762,13 @@ class AnalysisProcessor(processor.ProcessorABC):
                         label=r"Events",
                     )
                     self._hist_keys_to_fill.append(sumw2_key)
+                    sumw2_samples_seen.add(histogram_sample_name)
 
         self._histogram_key_map = histogram_key_map
 
-        histogram[self.VARIATION_SUMMARY_KEY] = []
-        histogram["region_yields"] = processor.dict_accumulator()
+        if self._produce_sidecars:
+            histogram[self.VARIATION_SUMMARY_KEY] = []
+            histogram[self.REGION_YIELDS_KEY] = processor.dict_accumulator()
         self._accumulator = histogram
 
         # Set the energy threshold to cut on
@@ -719,7 +795,10 @@ class AnalysisProcessor(processor.ProcessorABC):
                 "systematic_variations must contain at least one entry when provided"
             )
 
-        is_mc_sample = not bool(self._sample.get("isData"))
+        is_mc_sample = any(
+            not bool(sample_info.get("isData"))
+            for sample_info in self._samples_by_name.values()
+        )
         self._allowed_jerc_variations = _build_jerc_allowed_variations(
             self._systematic_variations,
             is_mc=is_mc_sample,
@@ -728,7 +807,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         # Central jet/MET corrections always run regardless of this payload.
         logger.info(
             "Resolved allowed JERC variations for %s: %s",
-            self._sample.get("histAxisName"),
+            ",".join(sorted(self._samples_by_name.keys())),
             self._allowed_jerc_variations,
         )
 
@@ -748,15 +827,39 @@ class AnalysisProcessor(processor.ProcessorABC):
             or self._systematic_variations is None
         ):
             self._systematic_variations = ()
+        if not hasattr(self, "_produce_sidecars"):
+            self._produce_sidecars = False
         if not hasattr(self, "_sample") or self._sample is None:
             self._sample = {}
+        if (
+            not hasattr(self, "_samples_by_name")
+            or self._samples_by_name is None
+            or not self._samples_by_name
+        ):
+            if self._looks_like_sample_metadata(self._sample):
+                sample_name = str(self._sample.get("histAxisName") or "sample")
+                self._samples_by_name = OrderedDict({sample_name: self._sample})
+            else:
+                self._samples_by_name = OrderedDict()
+        if not hasattr(self, "_sample_aliases") or self._sample_aliases is None:
+            self._sample_aliases = {}
+            for sample_name, sample_info in self._samples_by_name.items():
+                self._sample_aliases[str(sample_name)] = str(sample_name)
+                hist_axis_name = sample_info.get("histAxisName")
+                if hist_axis_name is not None:
+                    self._sample_aliases.setdefault(str(hist_axis_name), str(sample_name))
+        if not hasattr(self, "_golden_json_paths") or self._golden_json_paths is None:
+            self._golden_json_paths = {}
         if not hasattr(self, "_accumulator") or self._accumulator is None:
             self._accumulator = {}
         if (
             not hasattr(self, "_allowed_jerc_variations")
             or self._allowed_jerc_variations is None
         ):
-            is_mc_sample = not bool(self._sample.get("isData"))
+            is_mc_sample = any(
+                not bool(sample_info.get("isData"))
+                for sample_info in self._samples_by_name.values()
+            )
             self._allowed_jerc_variations = _build_jerc_allowed_variations(
                 self._systematic_variations,
                 is_mc=is_mc_sample,
@@ -1153,29 +1256,84 @@ class AnalysisProcessor(processor.ProcessorABC):
             systematic,
         )
 
+    def _resolve_sample_for_dataset(
+        self,
+        dataset_name: str,
+    ) -> Tuple[str, Mapping[str, Any]]:
+        """Resolve the configured sample metadata for a dataset label."""
+
+        resolved_name = self._sample_aliases.get(dataset_name, dataset_name)
+        sample_info = self._samples_by_name.get(resolved_name)
+        if sample_info is not None:
+            return resolved_name, sample_info
+
+        if len(self._samples_by_name) == 1:
+            fallback_name, fallback_info = next(iter(self._samples_by_name.items()))
+            logger.warning(
+                "Dataset '%s' was not found in configured sample map; falling back to '%s'.",
+                dataset_name,
+                fallback_name,
+            )
+            return fallback_name, fallback_info
+
+        raise KeyError(
+            "Dataset '%s' is not present in configured samples %s"
+            % (dataset_name, tuple(self._samples_by_name.keys()))
+        )
+
+    def _resolve_golden_json_path_for_sample(
+        self,
+        sample_name: str,
+        sample_info: Mapping[str, Any],
+    ) -> Optional[str]:
+        """Return the golden JSON path for data samples."""
+
+        if not sample_info.get("isData"):
+            return None
+
+        path = self._golden_json_paths.get(sample_name)
+        if path is None:
+            hist_axis_name = sample_info.get("histAxisName")
+            if hist_axis_name is not None:
+                hist_axis_key = str(hist_axis_name)
+                mapped_name = self._sample_aliases.get(hist_axis_key, hist_axis_key)
+                path = self._golden_json_paths.get(mapped_name)
+
+        if path is None:
+            raise ValueError(
+                f"No golden JSON path configured for data sample '{sample_name}'."
+            )
+        return path
+
     def _build_dataset_context(self, events) -> DatasetContext:
         events_metadata = self._metadata_to_mapping(getattr(events, "metadata", None))
         raw_dataset_name = events_metadata.get("dataset")
         if raw_dataset_name is None:
-            raw_dataset_name = self._sample.get("histAxisName")
+            if len(self._samples_by_name) == 1:
+                raw_dataset_name = next(iter(self._samples_by_name.keys()))
+            else:
+                raise KeyError(
+                    "Events metadata is missing a 'dataset' entry and multiple samples are configured."
+                )
         if raw_dataset_name is None:
             raise KeyError("Events metadata is missing a 'dataset' entry")
         raw_dataset_name = str(raw_dataset_name)
+        sample_name, sample_info = self._resolve_sample_for_dataset(raw_dataset_name)
         dataset, trigger_dataset = self._resolve_dataset_names(raw_dataset_name)
 
-        hist_axis_name = self._sample["histAxisName"]
-        is_data = self._sample["isData"]
-        year = self._sample["year"]
-        xsec = self._sample["xsec"]
-        sow = self._sample["nSumOfWeights"]
+        hist_axis_name = sample_info["histAxisName"]
+        is_data = sample_info["isData"]
+        year = sample_info["year"]
+        xsec = sample_info["xsec"]
+        sow = sample_info["nSumOfWeights"]
 
-        is_eft = self._sample["WCnames"] != []
+        is_eft = sample_info["WCnames"] != []
         is_run3 = year.startswith("202")
         is_run2 = not is_run3
 
         run_era = None
         if is_data:
-            run_era = self._sample["path"].split("/")[2].split("-")[0][-1]
+            run_era = sample_info["path"].split("/")[2].split("-")[0][-1]
 
         is_lo_sample = hist_axis_name in get_te_param("lo_xsec_samples")
 
@@ -1189,7 +1347,10 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         lumi_mask = ak.ones_like(events["run"], dtype=bool)
         if is_data:
-            lumi_mask = LumiMask(self._golden_json_path)(
+            golden_json_path = self._resolve_golden_json_path_for_sample(
+                sample_name, sample_info
+            )
+            lumi_mask = LumiMask(golden_json_path)(
                 events["run"], events["luminosityBlock"]
             )
 
@@ -1198,9 +1359,9 @@ class AnalysisProcessor(processor.ProcessorABC):
             if "EFTfitCoefficients" in events.fields
             else None
         )
-        if eft_coeffs is not None and self._sample["WCnames"] != self._wc_names_lst:
+        if eft_coeffs is not None and sample_info["WCnames"] != self._wc_names_lst:
             eft_coeffs = efth.remap_coeffs(
-                self._sample["WCnames"], self._wc_names_lst, eft_coeffs
+                sample_info["WCnames"], self._wc_names_lst, eft_coeffs
             )
         eft_w2_coeffs = (
             efth.calc_w2_coeffs(eft_coeffs, self._dtype)
@@ -1211,6 +1372,8 @@ class AnalysisProcessor(processor.ProcessorABC):
         lumi = 1000.0 * get_tc_param(f"lumi_{year}")
 
         context = DatasetContext(
+            sample_name=sample_name,
+            sample_metadata=sample_info,
             dataset=dataset,
             trigger_dataset=trigger_dataset,
             hist_axis_name=hist_axis_name,
@@ -1527,8 +1690,8 @@ class AnalysisProcessor(processor.ProcessorABC):
                     sow_variations[sow_label] = dataset.sow
                 else:
                     key = sow_variation_key_map.get(sow_label)
-                    if key is not None and key in self._sample:
-                        sow_variations[sow_label] = self._sample[key]
+                    if key is not None and key in dataset.sample_metadata:
+                        sow_variations[sow_label] = dataset.sample_metadata[key]
 
         if variation_type == "object":
             if variation_name not in object_systematics:
@@ -2099,7 +2262,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                 sow_variation_key_map=variation_state.sow_variation_key_map,
                 is_lo_sample=dataset.is_lo_sample,
                 hist_axis_name=histAxisName,
-                sample=self._sample,
+                sample=dataset.sample_metadata,
             )
             for label, args in theory_weight_arguments.items():
                 weights_object.add(label, *args)
@@ -2890,7 +3053,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             channel_entries.append((ch_name, base_channel_label, all_cuts_mask, mask_numpy))
 
         if is_nominal_variation and channel_entries:
-            region_store = self._accumulator.get("region_yields")
+            region_store = self._accumulator.get(self.REGION_YIELDS_KEY)
             for ch_name, base_ch_name, all_cuts_mask, mask_numpy in channel_entries:
                 region_channel_label = ch_name
                 _log_region_yields(

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -169,7 +169,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--chunksize",
         "-s",
         type=int,
-        default=100000,
+        default=500000,
         help="Number of events per chunk",
     )
     parser.add_argument(
@@ -248,6 +248,15 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--produce-sidecars",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help=(
+            "Enable sidecar payloads (variation summaries, region_yields). "
+            "Disabled by default."
+        ),
+    )
+    parser.add_argument(
         "--scenario",
         dest="scenarios",
         action="append",
@@ -310,6 +319,53 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Disable automatic TaskVine port negotiation. When set the first value "
             "from --port is used directly and any allocation failure aborts the run."
+        ),
+    )
+    parser.add_argument(
+        "--ddr-step-size",
+        type=int,
+        default=None,
+        help=(
+            "TaskVine DDR preprocess step size. Defaults to --chunksize when not set."
+        ),
+    )
+    parser.add_argument(
+        "--ddr-x509-proxy",
+        default=None,
+        help=(
+            "Path to an x509 proxy file used by TaskVine DDR workers. "
+            "When set, run_analysis stages it as proxy.pem."
+        ),
+    )
+    parser.add_argument(
+        "--ddr-preprocessed-data",
+        default=None,
+        help=(
+            "Path to preprocessed DDR mapping (JSON or cloudpickle). "
+            "When set, preprocess() is skipped."
+        ),
+    )
+    parser.add_argument(
+        "--ddr-save-preprocess",
+        default=None,
+        help=(
+            "Path where run_analysis writes the DDR preprocess payload after preprocess()."
+        ),
+    )
+    parser.add_argument(
+        "--ddr-auto-save-preprocess",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Automatically save DDR preprocess payload to a deterministic artifact path "
+            "when --ddr-preprocessed-data is not provided."
+        ),
+    )
+    parser.add_argument(
+        "--ddr-preprocess-artifact",
+        default=None,
+        help=(
+            "Override the deterministic default path used by --ddr-auto-save-preprocess."
         ),
     )
     parser.add_argument(

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -313,6 +313,75 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--ddr-processor-key-delim",
+        default="-",
+        help=(
+            "Delimiter used to build TaskVine DDR processor keys from "
+            "(channel, variable, application, systematic_label)."
+        ),
+    )
+    parser.add_argument(
+        "--produce-sidecars",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help=(
+            "Enable sidecar payloads (variation summaries and region yields) in processor output. "
+            "Disabled by default."
+        ),
+    )
+    parser.add_argument(
+        "--ddr-preserve-sidecars",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help=(
+            "When flattening DDR output, keep non-hist sidecars under a reserved key. "
+            "Disabled by default."
+        ),
+    )
+    parser.add_argument(
+        "--ddr-sidecars-key",
+        default="__sidecars__",
+        help="Reserved top-level key used when --ddr-preserve-sidecars is enabled.",
+    )
+    parser.add_argument(
+        "--ddr-output-schema",
+        choices=("flat", "tuple"),
+        default="flat",
+        help=(
+            "Schema used when serializing TaskVine DDR output: "
+            "'flat' -> (sample, channel, var, application, systematic), "
+            "'tuple' -> (var, channel, application, sample, systematic)."
+        ),
+    )
+    parser.add_argument(
+        "--ddr-step-size",
+        type=int,
+        default=None,
+        help="Override DDR step size (events per task chunk). Defaults to --chunksize when unset.",
+    )
+    parser.add_argument(
+        "--ddr-max-task-retries",
+        type=int,
+        default=None,
+        help="Override DDR max task retries.",
+    )
+    parser.add_argument(
+        "--ddr-results-directory",
+        default=None,
+        help="Override the DDR results directory (defaults to taskvine staging logs path).",
+    )
+    parser.add_argument(
+        "--ddr-verbose",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Enable/disable verbose DDR logging at the CoffeaDynamicDataReduction layer.",
+    )
+    parser.add_argument(
+        "--ddr-x509-proxy",
+        default=None,
+        help="Path to an X509 proxy passed to DDR preprocess/compute when provided.",
+    )
+    parser.add_argument(
         "--options",
         default=None,
         help=(

--- a/analysis/topeft_run2/run_analysis_helpers.py
+++ b/analysis/topeft_run2/run_analysis_helpers.py
@@ -290,6 +290,55 @@ def coerce_summary_verbosity(value: Any) -> str:
     )
 
 
+def coerce_ddr_output_schema(value: Any) -> str:
+    """Normalize DDR output schema names."""
+
+    if value is None:
+        return "flat"
+    normalized = str(value).strip().lower()
+    if normalized in {"flat", "tuple"}:
+        return normalized
+    raise ValueError("ddr_output_schema must be one of: flat, tuple")
+
+
+def coerce_mapping(value: Any) -> Optional[Dict[str, Any]]:
+    """Return ``value`` as a dictionary, accepting JSON strings."""
+
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        return {str(key): mapped_value for key, mapped_value in value.items()}
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        loaded = json.loads(stripped)
+        if not isinstance(loaded, Mapping):
+            raise ValueError("Expected a JSON object for mapping configuration")
+        return {str(key): mapped_value for key, mapped_value in loaded.items()}
+    raise TypeError(f"Expected a mapping-compatible value, got {type(value)!r}")
+
+
+def coerce_str_mapping(value: Any) -> Dict[str, str]:
+    """Return ``value`` as a ``str -> str`` mapping."""
+
+    mapped = coerce_mapping(value)
+    if not mapped:
+        return {}
+    return {str(key): str(mapped_value) for key, mapped_value in mapped.items()}
+
+
+def coerce_delimiter(value: Any) -> str:
+    """Return a non-empty delimiter string."""
+
+    if value is None:
+        return "-"
+    delimiter = str(value)
+    if delimiter == "":
+        raise ValueError("ddr_processor_key_delim cannot be empty")
+    return delimiter
+
+
 def coerce_log_level(value: Any) -> Optional[str]:
     """Normalize logging level names to a known uppercase identifier."""
 
@@ -483,6 +532,25 @@ class RunConfig:
     resource_monitor: Optional[str] = "measure"
     resources_mode: Optional[str] = "auto"
     taskvine_print_stdout: bool = True
+    ddr_processor_key_delim: str = "-"
+    produce_sidecars: bool = False
+    ddr_preserve_sidecars: bool = False
+    ddr_sidecars_key: str = "__sidecars__"
+    ddr_output_schema: str = "flat"
+    ddr_step_size: Optional[int] = None
+    ddr_max_task_retries: Optional[int] = None
+    ddr_resources_processing: Optional[Dict[str, Any]] = None
+    ddr_resources_accumulating: Optional[Dict[str, Any]] = None
+    ddr_results_directory: Optional[str] = None
+    ddr_verbose: Optional[bool] = None
+    ddr_x509_proxy: Optional[str] = None
+    ddr_environment_variables: Dict[str, str] = field(default_factory=dict)
+    ddr_preprocess_timeout: Optional[int] = None
+    ddr_preprocess_max_retries: Optional[int] = None
+    ddr_preprocess_batch_size: Optional[int] = None
+    ddr_preprocess_show_progress: Optional[bool] = None
+    ddr_preprocess_kwargs: Optional[Dict[str, Any]] = None
+    ddr_kwargs: Optional[Dict[str, Any]] = None
     ecut: Optional[float] = None
     summary_verbosity: str = "brief"
     log_level: Optional[str] = None
@@ -567,6 +635,61 @@ class RunConfigBuilder:
             "resource_monitor": ("resource_monitor", _coerce_optional_string),
             "resources_mode": ("resources_mode", _coerce_optional_string),
             "taskvine_print_stdout": ("taskvine_print_stdout", coerce_bool),
+            "ddr_processor_key_delim": ("ddr_processor_key_delim", coerce_delimiter),
+            "produce_sidecars": ("produce_sidecars", coerce_bool),
+            "ddr_preserve_sidecars": ("ddr_preserve_sidecars", coerce_bool),
+            "ddr_sidecars_key": (
+                "ddr_sidecars_key",
+                lambda v: "__sidecars__" if v in (None, "") else str(v),
+            ),
+            "ddr_output_schema": ("ddr_output_schema", coerce_ddr_output_schema),
+            "ddr_step_size": (
+                "ddr_step_size",
+                lambda v: coerce_int(v, allow_none=True),
+            ),
+            "ddr_max_task_retries": (
+                "ddr_max_task_retries",
+                lambda v: coerce_int(v, allow_none=True),
+            ),
+            "ddr_resources_processing": (
+                "ddr_resources_processing",
+                coerce_mapping,
+            ),
+            "ddr_resources_accumulating": (
+                "ddr_resources_accumulating",
+                coerce_mapping,
+            ),
+            "ddr_results_directory": (
+                "ddr_results_directory",
+                _coerce_optional_string,
+            ),
+            "ddr_verbose": ("ddr_verbose", coerce_bool),
+            "ddr_x509_proxy": ("ddr_x509_proxy", _coerce_optional_string),
+            "ddr_environment_variables": (
+                "ddr_environment_variables",
+                coerce_str_mapping,
+            ),
+            "ddr_preprocess_timeout": (
+                "ddr_preprocess_timeout",
+                lambda v: coerce_int(v, allow_none=True),
+            ),
+            "ddr_preprocess_max_retries": (
+                "ddr_preprocess_max_retries",
+                lambda v: coerce_int(v, allow_none=True),
+            ),
+            "ddr_preprocess_batch_size": (
+                "ddr_preprocess_batch_size",
+                lambda v: coerce_int(v, allow_none=True),
+            ),
+            "ddr_preprocess_show_progress": (
+                "ddr_preprocess_show_progress",
+                coerce_bool,
+            ),
+            "ddr_preprocess_kwargs": (
+                "ddr_preprocess_kwargs",
+                coerce_mapping,
+            ),
+            "ddr_kwargs": ("ddr_kwargs", coerce_mapping),
             "summary_verbosity": ("summary_verbosity", coerce_summary_verbosity),
             "log_tasks": ("log_tasks", coerce_bool),
             "environment_file": ("environment_file", coerce_environment_file),
@@ -708,6 +831,16 @@ class RunConfigBuilder:
                 "resource_monitor": "resource_monitor",
                 "resources_mode": "resources_mode",
                 "taskvine_print_stdout": "taskvine_print_stdout",
+                "ddr_processor_key_delim": "ddr_processor_key_delim",
+                "produce_sidecars": "produce_sidecars",
+                "ddr_preserve_sidecars": "ddr_preserve_sidecars",
+                "ddr_sidecars_key": "ddr_sidecars_key",
+                "ddr_output_schema": "ddr_output_schema",
+                "ddr_step_size": "ddr_step_size",
+                "ddr_max_task_retries": "ddr_max_task_retries",
+                "ddr_results_directory": "ddr_results_directory",
+                "ddr_verbose": "ddr_verbose",
+                "ddr_x509_proxy": "ddr_x509_proxy",
                 "environment_file": "environment_file",
                 "log_level": "log_level",
                 "futures_status": "futures_status",

--- a/analysis/topeft_run2/run_analysis_helpers.py
+++ b/analysis/topeft_run2/run_analysis_helpers.py
@@ -460,7 +460,7 @@ class RunConfig:
     test: bool = False
     pretend: bool = False
     nworkers: int = 8
-    chunksize: int = 100000
+    chunksize: int = 500000
     nchunks: Optional[int] = None
     outname: str = "plotsTopEFT"
     outpath: str = "histos"
@@ -483,10 +483,17 @@ class RunConfig:
     resource_monitor: Optional[str] = "measure"
     resources_mode: Optional[str] = "auto"
     taskvine_print_stdout: bool = True
+    ddr_step_size: Optional[int] = None
+    ddr_x509_proxy: Optional[str] = None
+    ddr_preprocessed_data: Optional[str] = None
+    ddr_save_preprocess: Optional[str] = None
+    ddr_auto_save_preprocess: bool = True
+    ddr_preprocess_artifact: Optional[str] = None
     ecut: Optional[float] = None
     summary_verbosity: str = "brief"
     log_level: Optional[str] = None
     log_tasks: bool = False
+    produce_sidecars: bool = False
     environment_file: Optional[str] = "cached"
     futures_status: Optional[bool] = None
     futures_tail_timeout: Optional[int] = None
@@ -567,8 +574,24 @@ class RunConfigBuilder:
             "resource_monitor": ("resource_monitor", _coerce_optional_string),
             "resources_mode": ("resources_mode", _coerce_optional_string),
             "taskvine_print_stdout": ("taskvine_print_stdout", coerce_bool),
+            "ddr_step_size": (
+                "ddr_step_size",
+                lambda v: coerce_int(v, allow_none=True),
+            ),
+            "ddr_x509_proxy": ("ddr_x509_proxy", _coerce_optional_string),
+            "ddr_preprocessed_data": ("ddr_preprocessed_data", _coerce_optional_string),
+            "ddr_save_preprocess": ("ddr_save_preprocess", _coerce_optional_string),
+            "ddr_auto_save_preprocess": (
+                "ddr_auto_save_preprocess",
+                lambda v: True if coerce_bool(v) is None else bool(coerce_bool(v)),
+            ),
+            "ddr_preprocess_artifact": (
+                "ddr_preprocess_artifact",
+                _coerce_optional_string,
+            ),
             "summary_verbosity": ("summary_verbosity", coerce_summary_verbosity),
             "log_tasks": ("log_tasks", coerce_bool),
+            "produce_sidecars": ("produce_sidecars", coerce_bool),
             "environment_file": ("environment_file", coerce_environment_file),
             "futures_status": ("futures_status", coerce_bool),
             "futures_tail_timeout": (
@@ -708,8 +731,15 @@ class RunConfigBuilder:
                 "resource_monitor": "resource_monitor",
                 "resources_mode": "resources_mode",
                 "taskvine_print_stdout": "taskvine_print_stdout",
+                "ddr_step_size": "ddr_step_size",
+                "ddr_x509_proxy": "ddr_x509_proxy",
+                "ddr_preprocessed_data": "ddr_preprocessed_data",
+                "ddr_save_preprocess": "ddr_save_preprocess",
+                "ddr_auto_save_preprocess": "ddr_auto_save_preprocess",
+                "ddr_preprocess_artifact": "ddr_preprocess_artifact",
                 "environment_file": "environment_file",
                 "log_level": "log_level",
+                "produce_sidecars": "produce_sidecars",
                 "futures_status": "futures_status",
                 "futures_tail_timeout": "futures_tail_timeout",
                 "futures_memory": "futures_memory",

--- a/analysis/topeft_run2/workflow.py
+++ b/analysis/topeft_run2/workflow.py
@@ -29,9 +29,11 @@ import importlib
 import json
 import logging
 import os
+import shutil
 import tempfile
 import time
 import warnings
+from collections import OrderedDict
 from dataclasses import asdict, dataclass, field
 from functools import partial
 from pathlib import Path
@@ -103,6 +105,116 @@ def _merge_region_yields(
             target[key] = arr
         else:
             target[key] = np.asarray(current, dtype=float) + arr
+
+
+def _normalize_systematic_label(systematic: Any) -> str:
+    """Return a stable string label for systematic identifiers."""
+
+    if isinstance(systematic, (tuple, list)):
+        return ":".join(str(component) for component in systematic)
+    return str(systematic)
+
+
+def _merge_ddr_histograms(
+    target: Dict[Tuple[str, str, str, str, str], Any],
+    key: Tuple[str, str, str, str, str],
+    histogram: Any,
+) -> None:
+    """Merge histogram payloads for duplicate flattened DDR keys."""
+
+    if key not in target:
+        target[key] = histogram
+        return
+
+    current = target[key]
+    try:
+        current += histogram
+    except Exception as exc:
+        try:
+            target[key] = current + histogram
+        except Exception as add_exc:
+            raise TypeError(
+                f"Failed to merge duplicate DDR histogram key {key!r}."
+            ) from add_exc
+        else:
+            return
+    if current is None:
+        raise TypeError(f"Accumulator merge returned None for key {key!r}.")
+    target[key] = current
+
+
+def flatten_ddr_result_payload(
+    payload: Mapping[Any, Any],
+) -> "OrderedDict[Tuple[str, str, str, str, str], Any]":
+    """Convert nested DDR output to canonical (sample, channel, var, app, syst) keys."""
+
+    flat: Dict[Tuple[str, str, str, str, str], Any] = {}
+
+    def _walk(node: Mapping[Any, Any]) -> None:
+        for key, value in node.items():
+            if isinstance(key, tuple) and len(key) == 5:
+                var, channel, application, sample, systematic = key
+                canonical_key = (
+                    str(sample),
+                    str(channel),
+                    str(var),
+                    str(application),
+                    _normalize_systematic_label(systematic),
+                )
+                _merge_ddr_histograms(flat, canonical_key, value)
+                continue
+            if isinstance(value, Mapping):
+                _walk(value)
+
+    _walk(payload)
+    return OrderedDict(sorted(flat.items(), key=lambda item: item[0]))
+
+
+def _resolve_ddr_preprocess_paths(
+    config: RunConfig,
+    *,
+    results_dir: Path,
+) -> Tuple[Optional[str], Optional[str]]:
+    """Resolve preprocess input/output artifact paths for DDR execution."""
+
+    preprocessed_data_path = getattr(config, "ddr_preprocessed_data", None)
+    explicit_save_path = getattr(config, "ddr_save_preprocess", None)
+    auto_save = bool(getattr(config, "ddr_auto_save_preprocess", True))
+    artifact_override = getattr(config, "ddr_preprocess_artifact", None)
+
+    save_path: Optional[str] = None
+    if preprocessed_data_path:
+        # Reuse mode skips preprocess() unless the user explicitly asks for a save.
+        if explicit_save_path:
+            save_path = str(Path(explicit_save_path).expanduser())
+    elif explicit_save_path:
+        save_path = str(Path(explicit_save_path).expanduser())
+    elif auto_save:
+        if artifact_override:
+            save_path = str(Path(artifact_override).expanduser())
+        else:
+            save_path = str((results_dir / "ddr_preprocessed_data.json").resolve())
+
+    if preprocessed_data_path:
+        preprocessed_data_path = str(Path(preprocessed_data_path).expanduser())
+    return preprocessed_data_path, save_path
+
+
+def stage_ddr_proxy(proxy_path: str, *, staging_dir: Path) -> Path:
+    """Copy a user proxy to ``staging_dir/proxy.pem`` and validate readability."""
+
+    source_path = Path(proxy_path).expanduser()
+    if not source_path.exists():
+        raise FileNotFoundError(f"DDR proxy file does not exist: {source_path}")
+    if not source_path.is_file():
+        raise FileNotFoundError(f"DDR proxy path is not a file: {source_path}")
+    if not os.access(source_path, os.R_OK):
+        raise PermissionError(f"DDR proxy file is not readable: {source_path}")
+
+    staging_dir.mkdir(parents=True, exist_ok=True)
+    staged_proxy = staging_dir / "proxy.pem"
+    shutil.copyfile(source_path, staged_proxy)
+    return staged_proxy
 
 
 topcoffea_utils = _import_topcoffea_submodule("utils")
@@ -998,6 +1110,7 @@ class RunWorkflow:
             metadata_path=self._metadata_path,
             executor_mode=self._config.executor,
             debug_logging=_DEV_DEBUG,
+            produce_sidecars=bool(getattr(self._config, "produce_sidecars", False)),
         )
         if not isinstance(processor_instance, coffea_processor_module.ProcessorABC):
             raise TypeError(
@@ -1096,22 +1209,62 @@ class RunWorkflow:
 
         results_dir = context.logs_dir.parent / "taskvine-results"
         results_dir.mkdir(parents=True, exist_ok=True)
+        preprocessed_data_path, save_preprocess_path = _resolve_ddr_preprocess_paths(
+            self._config,
+            results_dir=results_dir,
+        )
+        extra_files = list(context.extra_input_files)
+        ddr_environment_variables: Dict[str, str] = {}
+        ddr_proxy_path: Optional[str] = None
+        if self._config.ddr_x509_proxy:
+            staged_proxy = stage_ddr_proxy(
+                self._config.ddr_x509_proxy,
+                staging_dir=context.staging_dir,
+            )
+            ddr_proxy_path = str(staged_proxy)
+            extra_files.append(ddr_proxy_path)
+            ddr_environment_variables.setdefault("X509_USER_PROXY", "proxy.pem")
+
+        ddr_step_size = self._config.ddr_step_size
+        if ddr_step_size is None:
+            ddr_step_size = self._config.chunksize
+        if ddr_step_size is None:
+            raise ValueError("DDR step size could not be resolved from config.")
+        ddr_step_size = max(int(ddr_step_size), 1)
+
         ddr_kwargs = {
             "results_directory": str(results_dir),
             "resources_processing": {"cores": max(1, int(self._config.nworkers or 1))},
+            "step_size": ddr_step_size,
         }
+        if ddr_environment_variables:
+            ddr_kwargs["environment_variables"] = ddr_environment_variables
+        if ddr_proxy_path:
+            ddr_kwargs["x509_proxy"] = ddr_proxy_path
+
+        preprocess_kwargs: Optional[Dict[str, Any]] = None
+        if ddr_proxy_path:
+            preprocess_kwargs = {
+                "x509_proxy": ddr_proxy_path,
+                "environment_variables": dict(ddr_environment_variables),
+            }
 
         try:
-            return ddr_helpers.run_ddr(
+            raw_output = ddr_helpers.run_ddr(
                 manager=manager,
                 data=data,
                 processors=processors,
-                accumulator=analysis_processor_module.AnalysisProcessor,
                 schema=NanoAODSchema,
-                extra_files=list(context.extra_input_files),
+                extra_files=extra_files,
                 tree_name=self._config.treename or "Events",
+                preprocessed_data_path=preprocessed_data_path,
+                save_preprocess_path=save_preprocess_path,
+                preprocess_kwargs=preprocess_kwargs,
                 ddr_kwargs=ddr_kwargs,
             )
+            if isinstance(raw_output, Mapping):
+                return flatten_ddr_result_payload(raw_output)
+            return raw_output
         finally:
             try:
                 manager.shutdown()

--- a/analysis/topeft_run2/workflow.py
+++ b/analysis/topeft_run2/workflow.py
@@ -23,6 +23,7 @@ task.
 
 from __future__ import annotations
 
+from collections import OrderedDict
 import getpass
 import gzip
 import importlib
@@ -103,6 +104,205 @@ def _merge_region_yields(
             target[key] = arr
         else:
             target[key] = np.asarray(current, dtype=float) + arr
+
+
+def _normalise_systematic_label(systematic: Any) -> str:
+    """Return a stable string representation for systematic labels."""
+
+    if isinstance(systematic, (tuple, list)):
+        return ":".join(str(component) for component in systematic)
+    return str(systematic)
+
+
+def build_ddr_processor_key(
+    channel: Any,
+    variable: Any,
+    application: Any,
+    systematic_label: Any,
+    *,
+    delim: str = "-",
+) -> str:
+    """Build a delimiter-safe DDR processor key.
+
+    The key layout is:
+    ``<channel><DELIM><var><DELIM><application><DELIM><systematic_label>``.
+    """
+
+    delimiter = str(delim)
+    if delimiter == "":
+        raise ValueError("DDR processor key delimiter cannot be empty.")
+
+    components = {
+        "channel": str(channel),
+        "var": str(variable),
+        "application": str(application),
+        "systematic_label": str(systematic_label),
+    }
+    for field_name, field_value in components.items():
+        if delimiter in field_value:
+            raise ValueError(
+                "Cannot build DDR processor key with delimiter collision: "
+                f"{field_name}={field_value!r} contains delimiter {delimiter!r}."
+            )
+
+    return delimiter.join(
+        (
+            components["channel"],
+            components["var"],
+            components["application"],
+            components["systematic_label"],
+        )
+    )
+
+
+def _parse_ddr_processor_key(
+    key: str,
+    *,
+    delim: str = "-",
+) -> Tuple[str, str, str, str]:
+    """Parse a DDR processor key built by :func:`build_ddr_processor_key`."""
+
+    delimiter = str(delim)
+    if delimiter == "":
+        raise ValueError("DDR processor key delimiter cannot be empty.")
+
+    parts = str(key).split(delimiter)
+    if len(parts) != 4:
+        raise ValueError(
+            "Malformed DDR processor key "
+            f"{key!r}: expected 4 fields split by {delimiter!r}, found {len(parts)}."
+        )
+    return parts[0], parts[1], parts[2], parts[3]
+
+
+def _tuple_sort_key(key: Tuple[str, str, str, str, str]) -> Tuple[str, str, str, str, str]:
+    """Return a deterministic tuple sort key."""
+
+    return tuple(str(piece) for piece in key)
+
+
+def flatten_ddr_output(
+    ddr_payload: Mapping[str, Any],
+    *,
+    delim: str = "-",
+    output_schema: str = "flat",
+    preserve_sidecars: bool = False,
+    sidecars_key: str = "__sidecars__",
+) -> "OrderedDict[Any, Any]":
+    """Flatten DDR nested output into canonical 5-tuple histogram mappings."""
+
+    if not isinstance(ddr_payload, Mapping):
+        raise TypeError(
+            "DDR output must be a mapping of processor_key -> dataset payload."
+        )
+
+    schema_name = str(output_schema).strip().lower()
+    if schema_name not in {"flat", "tuple"}:
+        raise ValueError("output_schema must be 'flat' or 'tuple'.")
+
+    flattened: Dict[Tuple[str, str, str, str, str], Any] = {}
+    sidecars: Dict[Tuple[str, str], "OrderedDict[str, Any]"] = {}
+
+    for processor_key, dataset_payload in ddr_payload.items():
+        if not isinstance(dataset_payload, Mapping):
+            raise TypeError(
+                f"DDR output for processor {processor_key!r} must be a mapping, got {type(dataset_payload)!r}."
+            )
+
+        key_channel, key_var, key_application, key_systematic = _parse_ddr_processor_key(
+            str(processor_key),
+            delim=delim,
+        )
+
+        for dataset_name, leaf_output in dataset_payload.items():
+            if not isinstance(leaf_output, Mapping):
+                raise TypeError(
+                    "DDR dataset payload must be a mapping of histogram keys; "
+                    f"processor={processor_key!r} dataset={dataset_name!r} type={type(leaf_output)!r}."
+                )
+
+            for leaf_key, leaf_value in leaf_output.items():
+                if not isinstance(leaf_key, tuple):
+                    if preserve_sidecars:
+                        bucket = sidecars.setdefault(
+                            (str(processor_key), str(dataset_name)),
+                            OrderedDict(),
+                        )
+                        bucket[str(leaf_key)] = leaf_value
+                    continue
+
+                if len(leaf_key) != 5:
+                    raise ValueError(
+                        "DDR leaf histogram keys must be 5-tuples "
+                        "(var, channel, application, sample, systematic). "
+                        f"Found key {leaf_key!r} under processor {processor_key!r}."
+                    )
+
+                tuple_var, tuple_channel, tuple_application, tuple_sample, tuple_systematic = leaf_key
+                tuple_systematic_label = _normalise_systematic_label(tuple_systematic)
+                if (
+                    str(tuple_channel) != key_channel
+                    or str(tuple_var) != key_var
+                    or str(tuple_application) != key_application
+                    or tuple_systematic_label != key_systematic
+                ):
+                    raise ValueError(
+                        "DDR schema mismatch between processor key and histogram key: "
+                        f"processor={processor_key!r}, histogram_key={leaf_key!r}."
+                    )
+
+                sample_label = str(tuple_sample)
+                if schema_name == "flat":
+                    target_key = (
+                        sample_label,
+                        str(tuple_channel),
+                        str(tuple_var),
+                        str(tuple_application),
+                        tuple_systematic_label,
+                    )
+                else:
+                    target_key = (
+                        str(tuple_var),
+                        str(tuple_channel),
+                        str(tuple_application),
+                        sample_label,
+                        tuple_systematic_label,
+                    )
+
+                existing = flattened.get(target_key)
+                if existing is None:
+                    flattened[target_key] = leaf_value
+                    continue
+
+                if not hasattr(existing, "__iadd__"):
+                    raise TypeError(
+                        "Collision detected for flattened DDR key "
+                        f"{target_key!r} but value type {type(existing)!r} "
+                        "does not support in-place accumulation."
+                    )
+                try:
+                    existing += leaf_value
+                except Exception as exc:
+                    raise TypeError(
+                        f"Failed to merge duplicate flattened DDR key {target_key!r}."
+                    ) from exc
+
+    ordered_output: "OrderedDict[Any, Any]" = OrderedDict()
+    for key in sorted(flattened.keys(), key=_tuple_sort_key):
+        ordered_output[key] = flattened[key]
+
+    if preserve_sidecars and sidecars:
+        reserved_key = str(sidecars_key or "__sidecars__")
+        if reserved_key in ordered_output:
+            raise ValueError(
+                f"Cannot store preserved sidecars because reserved key {reserved_key!r} collides with histogram keys."
+            )
+        ordered_sidecars: "OrderedDict[Tuple[str, str], OrderedDict[str, Any]]" = OrderedDict()
+        for sidecar_bucket_key in sorted(sidecars.keys()):
+            ordered_sidecars[sidecar_bucket_key] = sidecars[sidecar_bucket_key]
+        ordered_output[reserved_key] = ordered_sidecars
+
+    return ordered_output
 
 
 topcoffea_utils = _import_topcoffea_submodule("utils")
@@ -401,7 +601,7 @@ class HistogramTask:
     variations: Tuple[Any, ...]
     hist_keys: Mapping[str, Tuple[Tuple[Any, ...], ...]]
     variable_info: Mapping[str, Any]
-    available_systematics: Sequence[str]
+    available_systematics: Mapping[str, Sequence[str]]
     channel_metadata: Mapping[str, Any]
 
 
@@ -981,23 +1181,42 @@ class RunWorkflow:
         coffea_processor_module: Any,
         golden_jsons: Mapping[str, str],
         ecut_threshold: Optional[float],
+        hist_keys: Optional[Mapping[str, Tuple[Tuple[Any, ...], ...]]] = None,
+        systematic_variations: Optional[Sequence[Any]] = None,
+        available_systematics: Optional[Mapping[str, Sequence[str]]] = None,
+        golden_json_paths: Optional[Mapping[str, str]] = None,
     ) -> Any:
-        golden_json_path = self._resolve_golden_json(sample_dict, golden_jsons)
+        if hist_keys is None:
+            hist_keys = task.hist_keys
+        if systematic_variations is None:
+            systematic_variations = task.variations
+        if available_systematics is None:
+            available_systematics = {
+                key: tuple(values)
+                for key, values in (task.available_systematics or {}).items()
+            }
+
+        golden_json_path = None
+        if "isData" in sample_dict:
+            golden_json_path = self._resolve_golden_json(sample_dict, golden_jsons)
+
         processor_instance = analysis_processor_module.AnalysisProcessor(
             sample_dict,
             self._config.wc_list,
-            hist_keys=task.hist_keys,
+            hist_keys=hist_keys,
             var_info=task.variable_info,
             ecut_threshold=ecut_threshold,
             do_errors=self._config.do_errors,
             split_by_lepton_flavor=self._config.split_lep_flavor,
             channel_dict=channel_dict,
             golden_json_path=golden_json_path,
-            systematic_variations=task.variations,
-            available_systematics=task.available_systematics,
+            golden_json_paths=golden_json_paths,
+            systematic_variations=systematic_variations,
+            available_systematics=available_systematics,
             metadata_path=self._metadata_path,
             executor_mode=self._config.executor,
             debug_logging=_DEV_DEBUG,
+            produce_sidecars=bool(getattr(self._config, "produce_sidecars", False)),
         )
         if not isinstance(processor_instance, coffea_processor_module.ProcessorABC):
             raise TypeError(
@@ -1096,10 +1315,62 @@ class RunWorkflow:
 
         results_dir = context.logs_dir.parent / "taskvine-results"
         results_dir.mkdir(parents=True, exist_ok=True)
-        ddr_kwargs = {
-            "results_directory": str(results_dir),
-            "resources_processing": {"cores": max(1, int(self._config.nworkers or 1))},
-        }
+        resources_processing = (
+            dict(self._config.ddr_resources_processing)
+            if getattr(self._config, "ddr_resources_processing", None)
+            else {"cores": max(1, int(self._config.nworkers or 1))}
+        )
+        resources_accumulating = (
+            dict(self._config.ddr_resources_accumulating)
+            if getattr(self._config, "ddr_resources_accumulating", None)
+            else None
+        )
+        step_size = (
+            int(self._config.ddr_step_size)
+            if getattr(self._config, "ddr_step_size", None) is not None
+            else int(self._config.chunksize)
+        )
+        max_task_retries = (
+            int(self._config.ddr_max_task_retries)
+            if getattr(self._config, "ddr_max_task_retries", None) is not None
+            else None
+        )
+        results_directory = (
+            str(self._config.ddr_results_directory)
+            if getattr(self._config, "ddr_results_directory", None)
+            else str(results_dir)
+        )
+        ddr_verbose = (
+            bool(self._config.ddr_verbose)
+            if getattr(self._config, "ddr_verbose", None) is not None
+            else None
+        )
+        x509_proxy = getattr(self._config, "ddr_x509_proxy", None)
+        environment_variables = dict(
+            getattr(self._config, "ddr_environment_variables", {}) or {}
+        )
+        if x509_proxy and "X509_USER_PROXY" not in environment_variables:
+            environment_variables["X509_USER_PROXY"] = str(x509_proxy)
+
+        preprocess_kwargs = dict(
+            getattr(self._config, "ddr_preprocess_kwargs", {}) or {}
+        )
+        if getattr(self._config, "ddr_preprocess_timeout", None) is not None:
+            preprocess_kwargs["timeout"] = int(self._config.ddr_preprocess_timeout)
+        if getattr(self._config, "ddr_preprocess_max_retries", None) is not None:
+            preprocess_kwargs["max_retries"] = int(
+                self._config.ddr_preprocess_max_retries
+            )
+        if getattr(self._config, "ddr_preprocess_batch_size", None) is not None:
+            preprocess_kwargs["batch_size"] = int(self._config.ddr_preprocess_batch_size)
+        if getattr(self._config, "ddr_preprocess_show_progress", None) is not None:
+            preprocess_kwargs["show_progress"] = bool(
+                self._config.ddr_preprocess_show_progress
+            )
+
+        extra_files = list(context.extra_input_files)
+        if x509_proxy and os.path.exists(str(x509_proxy)):
+            extra_files.append(str(x509_proxy))
 
         try:
             return ddr_helpers.run_ddr(
@@ -1108,9 +1379,18 @@ class RunWorkflow:
                 processors=processors,
                 accumulator=analysis_processor_module.AnalysisProcessor,
                 schema=NanoAODSchema,
-                extra_files=list(context.extra_input_files),
+                extra_files=extra_files,
                 tree_name=self._config.treename or "Events",
-                ddr_kwargs=ddr_kwargs,
+                step_size=step_size,
+                max_task_retries=max_task_retries,
+                resources_processing=resources_processing,
+                resources_accumulating=resources_accumulating,
+                results_directory=results_directory,
+                verbose=ddr_verbose,
+                x509_proxy=x509_proxy,
+                environment_variables=environment_variables or None,
+                preprocess_kwargs=preprocess_kwargs or None,
+                ddr_kwargs=dict(getattr(self._config, "ddr_kwargs", {}) or {}),
             )
         finally:
             try:
@@ -1129,6 +1409,8 @@ class RunWorkflow:
         ecut_threshold: Optional[float],
     ) -> Dict[str, Any]:
         processors: Dict[str, Any] = {}
+        grouped_processors: Dict[str, Dict[str, Any]] = {}
+        processor_key_delim = getattr(self._config, "ddr_processor_key_delim", "-")
         total_tasks = len(histogram_plan.tasks)
         for idx, task in enumerate(histogram_plan.tasks):
             channel_dict = task.channel_metadata
@@ -1150,24 +1432,122 @@ class RunWorkflow:
                     task.clean_channel,
                 )
                 continue
+
+            if not isinstance(task.available_systematics, Mapping):
+                raise TypeError(
+                    "HistogramTask.available_systematics must be a mapping of systematic categories to names."
+                )
+
+            variations_by_name = {
+                getattr(variation, "name", None): variation for variation in task.variations
+            }
+            if not variations_by_name:
+                raise ValueError(
+                    f"Task {idx} ({task.sample}/{task.clean_channel}) has no systematic variations."
+                )
+
+            for variation_label, hist_entries in task.hist_keys.items():
+                if variation_label not in variations_by_name:
+                    raise KeyError(
+                        f"Variation label '{variation_label}' is missing from task variations for "
+                        f"sample={task.sample} channel={task.clean_channel} var={task.variable} app={task.application}."
+                    )
+                if not hist_entries:
+                    continue
+
+                systematic_label = _normalise_systematic_label(hist_entries[0][4])
+                processor_key = build_ddr_processor_key(
+                    task.clean_channel,
+                    task.variable,
+                    task.application,
+                    systematic_label,
+                    delim=processor_key_delim,
+                )
+
+                grouped_entry = grouped_processors.get(processor_key)
+                if grouped_entry is None:
+                    grouped_entry = {
+                        "task_template": task,
+                        "channel_dict": channel_dict,
+                        "variation_label": variation_label,
+                        "variation": variations_by_name[variation_label],
+                        "sample_dict": OrderedDict(),
+                        "hist_entries": [],
+                        "hist_entries_set": set(),
+                        "available_systematics": {
+                            key: set(value)
+                            for key, value in task.available_systematics.items()
+                        },
+                        "golden_json_paths": {},
+                    }
+                    grouped_processors[processor_key] = grouped_entry
+                else:
+                    if grouped_entry["variation_label"] != variation_label:
+                        raise ValueError(
+                            "Conflicting variations mapped to the same DDR processor key "
+                            f"{processor_key!r}: {grouped_entry['variation_label']!r} vs {variation_label!r}."
+                        )
+                    for key, value in task.available_systematics.items():
+                        grouped_entry["available_systematics"].setdefault(key, set()).update(value)
+
+                grouped_entry["sample_dict"][sample_name] = sample_info
+                if sample_info.get("isData"):
+                    golden_json_path = self._resolve_golden_json(sample_info, golden_jsons)
+                    grouped_entry["golden_json_paths"][sample_name] = golden_json_path
+
+                for hist_entry in hist_entries:
+                    normalized_entry = tuple(hist_entry)
+                    if len(normalized_entry) != 5:
+                        raise ValueError(
+                            "DDR histogram entries must be 5-tuples "
+                            f"(found {normalized_entry!r} for processor key {processor_key!r})."
+                        )
+                    entry_systematic = _normalise_systematic_label(normalized_entry[4])
+                    if entry_systematic != systematic_label:
+                        raise ValueError(
+                            "DDR histogram entry systematic does not match processor grouping key: "
+                            f"processor_key={processor_key!r}, entry={normalized_entry!r}."
+                        )
+                    if normalized_entry in grouped_entry["hist_entries_set"]:
+                        continue
+                    grouped_entry["hist_entries_set"].add(normalized_entry)
+                    grouped_entry["hist_entries"].append(normalized_entry)
+
+        for processor_key in sorted(grouped_processors.keys()):
+            grouped_entry = grouped_processors[processor_key]
+            task_template = grouped_entry["task_template"]
+            hist_entries = tuple(grouped_entry["hist_entries"])
+            if not hist_entries:
+                continue
+            variation_label = grouped_entry["variation_label"]
+            hist_keys = {variation_label: hist_entries}
+            available_systematics = {
+                key: tuple(sorted(values))
+                for key, values in grouped_entry["available_systematics"].items()
+            }
+
             processor_instance = self._build_processor_instance(
-                task=task,
-                sample_dict=sample_info,
-                channel_dict=channel_dict,
+                task=task_template,
+                sample_dict=grouped_entry["sample_dict"],
+                channel_dict=grouped_entry["channel_dict"],
                 analysis_processor_module=analysis_processor_module,
                 coffea_processor_module=coffea_processor_module,
                 golden_jsons=golden_jsons,
                 ecut_threshold=ecut_threshold,
+                hist_keys=hist_keys,
+                systematic_variations=(grouped_entry["variation"],),
+                available_systematics=available_systematics,
+                golden_json_paths=grouped_entry["golden_json_paths"] or None,
             )
-            processor_key = self._ddr_processor_key(idx, task)
             processors[processor_key] = processor_instance
             logger.debug(
-                "[taskvine] Added processor %s for sample=%s channel=%s variable=%s application=%s",
+                "[taskvine] Added processor %s for %d samples (channel=%s variable=%s application=%s variation=%s)",
                 processor_key,
-                task.sample,
-                task.clean_channel,
-                task.variable,
-                task.application,
+                len(grouped_entry["sample_dict"]),
+                task_template.clean_channel,
+                task_template.variable,
+                task_template.application,
+                variation_label,
             )
         logger.info(
             "[taskvine] Constructed %d processors from %d histogram tasks",
@@ -1175,10 +1555,6 @@ class RunWorkflow:
             total_tasks,
         )
         return processors
-
-    @staticmethod
-    def _ddr_processor_key(index: int, task: HistogramTask) -> str:
-        return f"{index:05d}:{task.sample}:{task.clean_channel}:{task.variable}:{task.application}"
 
     def _create_ddr_manager(self, context: TaskVineContext) -> Any:
         import ndcctools.taskvine as vine
@@ -1296,7 +1672,7 @@ class RunWorkflow:
         self._config.executor = executor_mode
 
         if executor_mode == "taskvine":
-            output = self._execute_ddr(
+            ddr_output = self._execute_ddr(
                 histogram_plan=histogram_plan,
                 samplesdict=samplesdict,
                 flist=flist,
@@ -1305,6 +1681,27 @@ class RunWorkflow:
                 analysis_processor_module=analysis_processor,
                 coffea_processor_module=coffea_processor,
             )
+            output_schema = getattr(self._config, "ddr_output_schema", "flat")
+            if output_schema == "flat":
+                output = flatten_ddr_output(
+                    ddr_output,
+                    delim=getattr(self._config, "ddr_processor_key_delim", "-"),
+                    output_schema="flat",
+                    preserve_sidecars=bool(getattr(self._config, "ddr_preserve_sidecars", False)),
+                    sidecars_key=str(getattr(self._config, "ddr_sidecars_key", "__sidecars__")),
+                )
+            elif output_schema == "tuple":
+                output = flatten_ddr_output(
+                    ddr_output,
+                    delim=getattr(self._config, "ddr_processor_key_delim", "-"),
+                    output_schema="tuple",
+                    preserve_sidecars=bool(getattr(self._config, "ddr_preserve_sidecars", False)),
+                    sidecars_key=str(getattr(self._config, "ddr_sidecars_key", "__sidecars__")),
+                )
+            else:
+                raise ValueError(
+                    f"Unsupported ddr_output_schema '{output_schema}'. Expected 'flat' or 'tuple'."
+                )
             dt = time.time() - tstart
             if nevts_total:
                 logger.info(

--- a/analysis/topeft_run2/workflow.py
+++ b/analysis/topeft_run2/workflow.py
@@ -203,6 +203,7 @@ def flatten_ddr_output(
         raise ValueError("output_schema must be 'flat' or 'tuple'.")
 
     flattened: Dict[Tuple[str, str, str, str, str], Any] = {}
+    flattened_origins: Dict[Tuple[str, str, str, str, str], Tuple[str, str, Tuple[Any, ...]]] = {}
     sidecars: Dict[Tuple[str, str], "OrderedDict[str, Any]"] = {}
 
     for processor_key, dataset_payload in ddr_payload.items():
@@ -271,23 +272,26 @@ def flatten_ddr_output(
                         tuple_systematic_label,
                     )
 
-                existing = flattened.get(target_key)
-                if existing is None:
+                if target_key not in flattened:
                     flattened[target_key] = leaf_value
+                    flattened_origins[target_key] = (
+                        str(processor_key),
+                        str(dataset_name),
+                        tuple(leaf_key),
+                    )
                     continue
 
-                if not hasattr(existing, "__iadd__"):
-                    raise TypeError(
-                        "Collision detected for flattened DDR key "
-                        f"{target_key!r} but value type {type(existing)!r} "
-                        "does not support in-place accumulation."
-                    )
-                try:
-                    existing += leaf_value
-                except Exception as exc:
-                    raise TypeError(
-                        f"Failed to merge duplicate flattened DDR key {target_key!r}."
-                    ) from exc
+                first_processor, first_dataset, first_leaf_key = flattened_origins[target_key]
+                raise ValueError(
+                    "Duplicate flattened DDR key collision detected: "
+                    f"key={target_key!r}, "
+                    f"first_origin=(processor={first_processor!r}, dataset={first_dataset!r}, "
+                    f"histogram_key={first_leaf_key!r}), "
+                    f"second_origin=(processor={processor_key!r}, dataset={dataset_name!r}, "
+                    f"histogram_key={leaf_key!r}). "
+                    "Duplicate key indicates unexpected DDR duplication; check processor grouping "
+                    "or systematic labeling."
+                )
 
     ordered_output: "OrderedDict[Any, Any]" = OrderedDict()
     for key in sorted(flattened.keys(), key=_tuple_sort_key):

--- a/tests/test_analysis_processor_jetmet_cacheless.py
+++ b/tests/test_analysis_processor_jetmet_cacheless.py
@@ -147,6 +147,8 @@ def _build_processor():
     )
 
     dataset = ap.DatasetContext(
+        sample_name="sample",
+        sample_metadata={"histAxisName": "sample"},
         dataset="sample",
         trigger_dataset="sample",
         hist_axis_name="sample",

--- a/tests/test_analysis_processor_variations.py
+++ b/tests/test_analysis_processor_variations.py
@@ -113,6 +113,8 @@ def _patch_common(monkeypatch):
 
 def _make_dataset_context(**overrides):
     defaults = dict(
+        sample_name="sample",
+        sample_metadata={"histAxisName": "sample"},
         dataset="sample",
         trigger_dataset="sample",
         hist_axis_name="sample",

--- a/tests/test_ddr_output_schema.py
+++ b/tests/test_ddr_output_schema.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from analysis.topeft_run2 import analysis_processor
+from analysis.topeft_run2 import workflow
+
+
+class _DummyAccumulator:
+    def __init__(self, value: int):
+        self.value = value
+
+    def __iadd__(self, other: "_DummyAccumulator"):
+        self.value += other.value
+        return self
+
+
+def _minimal_processor_inputs():
+    sample_info = {
+        "sampleA": {
+            "histAxisName": "sampleA",
+            "isData": False,
+            "year": "2018",
+            "xsec": 1.0,
+            "nSumOfWeights": 1.0,
+            "WCnames": [],
+            "path": "/store/mc/sampleA",
+        }
+    }
+    hist_keys = {
+        "nominal": (("njets", "2lss", "isSR_2lSS", "sampleA", "nominal"),),
+    }
+    var_info = {
+        "definition": "njets",
+        "label": "N_{jets}",
+        "regular": (4, 0, 4),
+    }
+    channel_dict = {
+        "jet_selection": "atleast_2j",
+        "chan_def_lst": ["2lss"],
+        "lep_flav_lst": (),
+        "appl_region": "isSR_2lSS",
+        "features": (),
+    }
+    return sample_info, hist_keys, var_info, channel_dict
+
+
+def test_build_ddr_processor_key_rejects_delimiter_in_fields():
+    try:
+        workflow.build_ddr_processor_key(
+            "2lss-contains-delim",
+            "njets",
+            "isSR_2lSS",
+            "nominal",
+            delim="-",
+        )
+        assert False, "Expected ValueError for delimiter collision"
+    except ValueError as exc:
+        assert "contains delimiter" in str(exc)
+
+
+def test_ddr_processor_key_roundtrip():
+    key = workflow.build_ddr_processor_key(
+        "2lss",
+        "njets",
+        "isSR_2lSS",
+        "nominal",
+        delim="-",
+    )
+    channel, variable, application, systematic = workflow._parse_ddr_processor_key(
+        key,
+        delim="-",
+    )
+    assert (channel, variable, application, systematic) == (
+        "2lss",
+        "njets",
+        "isSR_2lSS",
+        "nominal",
+    )
+
+
+def test_flatten_ddr_output_uses_canonical_schema_and_drops_sidecars_by_default():
+    processor_key = workflow.build_ddr_processor_key(
+        "2lss",
+        "njets",
+        "isSR_2lSS",
+        "nominal",
+        delim="-",
+    )
+    payload = {
+        processor_key: {
+            "dataset_A": {
+                ("njets", "2lss", "isSR_2lSS", "sampleA", "nominal"): _DummyAccumulator(
+                    2
+                ),
+                "region_yields": {"ignored": True},
+            },
+            "dataset_B": {
+                ("njets", "2lss", "isSR_2lSS", "sampleA", "nominal"): _DummyAccumulator(
+                    5
+                )
+            },
+        }
+    }
+
+    flattened = workflow.flatten_ddr_output(payload, delim="-", output_schema="flat")
+    expected_key = ("sampleA", "2lss", "njets", "isSR_2lSS", "nominal")
+    assert list(flattened.keys()) == [expected_key]
+    assert flattened[expected_key].value == 7
+    assert "__sidecars__" not in flattened
+
+    flattened_with_sidecars = workflow.flatten_ddr_output(
+        payload,
+        delim="-",
+        output_schema="flat",
+        preserve_sidecars=True,
+        sidecars_key="__sidecars__",
+    )
+    assert "__sidecars__" in flattened_with_sidecars
+
+
+def test_analysis_processor_sidecars_disabled_by_default():
+    sample_info, hist_keys, var_info, channel_dict = _minimal_processor_inputs()
+
+    processor_default = analysis_processor.AnalysisProcessor(
+        sample=sample_info,
+        wc_names_lst=[],
+        hist_keys=hist_keys,
+        var_info=var_info,
+        channel_dict=channel_dict,
+        available_systematics={},
+        systematic_variations=(),
+    )
+    assert analysis_processor.AnalysisProcessor.VARIATION_SUMMARY_KEY not in processor_default.accumulator
+    assert analysis_processor.AnalysisProcessor.REGION_YIELDS_KEY not in processor_default.accumulator
+
+    processor_with_sidecars = analysis_processor.AnalysisProcessor(
+        sample=sample_info,
+        wc_names_lst=[],
+        hist_keys=hist_keys,
+        var_info=var_info,
+        channel_dict=channel_dict,
+        available_systematics={},
+        systematic_variations=(),
+        produce_sidecars=True,
+    )
+    assert analysis_processor.AnalysisProcessor.VARIATION_SUMMARY_KEY in processor_with_sidecars.accumulator
+    assert analysis_processor.AnalysisProcessor.REGION_YIELDS_KEY in processor_with_sidecars.accumulator

--- a/tests/test_ddr_output_schema.py
+++ b/tests/test_ddr_output_schema.py
@@ -96,7 +96,7 @@ def test_flatten_ddr_output_uses_canonical_schema_and_drops_sidecars_by_default(
                 "region_yields": {"ignored": True},
             },
             "dataset_B": {
-                ("njets", "2lss", "isSR_2lSS", "sampleA", "nominal"): _DummyAccumulator(
+                ("njets", "2lss", "isSR_2lSS", "sampleB", "nominal"): _DummyAccumulator(
                     5
                 )
             },
@@ -104,9 +104,11 @@ def test_flatten_ddr_output_uses_canonical_schema_and_drops_sidecars_by_default(
     }
 
     flattened = workflow.flatten_ddr_output(payload, delim="-", output_schema="flat")
-    expected_key = ("sampleA", "2lss", "njets", "isSR_2lSS", "nominal")
-    assert list(flattened.keys()) == [expected_key]
-    assert flattened[expected_key].value == 7
+    expected_key_a = ("sampleA", "2lss", "njets", "isSR_2lSS", "nominal")
+    expected_key_b = ("sampleB", "2lss", "njets", "isSR_2lSS", "nominal")
+    assert list(flattened.keys()) == [expected_key_a, expected_key_b]
+    assert flattened[expected_key_a].value == 2
+    assert flattened[expected_key_b].value == 5
     assert "__sidecars__" not in flattened
 
     flattened_with_sidecars = workflow.flatten_ddr_output(
@@ -117,6 +119,35 @@ def test_flatten_ddr_output_uses_canonical_schema_and_drops_sidecars_by_default(
         sidecars_key="__sidecars__",
     )
     assert "__sidecars__" in flattened_with_sidecars
+
+
+def test_flatten_ddr_output_raises_on_duplicate_collision():
+    processor_key = workflow.build_ddr_processor_key(
+        "2lss",
+        "njets",
+        "isSR_2lSS",
+        "nominal",
+        delim="-",
+    )
+    duplicate_key = ("sampleA", "2lss", "njets", "isSR_2lSS", "nominal")
+    payload = {
+        processor_key: {
+            "dataset_A": {
+                ("njets", "2lss", "isSR_2lSS", "sampleA", "nominal"): _DummyAccumulator(2),
+            },
+            "dataset_B": {
+                ("njets", "2lss", "isSR_2lSS", "sampleA", "nominal"): _DummyAccumulator(5),
+            },
+        }
+    }
+
+    with pytest.raises(ValueError) as exc:
+        workflow.flatten_ddr_output(payload, delim="-", output_schema="flat")
+    message = str(exc.value)
+    assert "Duplicate flattened DDR key collision detected" in message
+    assert str(duplicate_key) in message
+    assert "dataset_A" in message
+    assert "dataset_B" in message
 
 
 def test_flatten_ddr_output_raises_on_processor_key_mismatch():

--- a/tests/test_ddr_preprocess_proxy_policy.py
+++ b/tests/test_ddr_preprocess_proxy_policy.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from analysis.topeft_run2.run_analysis_helpers import RunConfig
+from analysis.topeft_run2.workflow import (
+    _resolve_ddr_preprocess_paths,
+    flatten_ddr_result_payload,
+    stage_ddr_proxy,
+)
+
+
+def test_stage_ddr_proxy_copies_to_proxy_pem(tmp_path: Path) -> None:
+    source_proxy = tmp_path / "user_proxy.pem"
+    source_proxy.write_text("proxy-data", encoding="utf-8")
+    staging_dir = tmp_path / "staging"
+
+    staged_proxy = stage_ddr_proxy(str(source_proxy), staging_dir=staging_dir)
+
+    assert staged_proxy == staging_dir / "proxy.pem"
+    assert staged_proxy.exists()
+    assert staged_proxy.read_text(encoding="utf-8") == "proxy-data"
+
+
+def test_stage_ddr_proxy_missing_path_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        stage_ddr_proxy(str(tmp_path / "missing_proxy.pem"), staging_dir=tmp_path / "staging")
+
+
+def test_preprocess_paths_auto_save_defaults_to_results_dir(tmp_path: Path) -> None:
+    config = RunConfig(executor="taskvine")
+    preprocessed_data_path, save_path = _resolve_ddr_preprocess_paths(
+        config,
+        results_dir=tmp_path,
+    )
+
+    assert preprocessed_data_path is None
+    assert save_path == str((tmp_path / "ddr_preprocessed_data.json").resolve())
+
+
+def test_preprocess_paths_explicit_save_overrides_auto(tmp_path: Path) -> None:
+    explicit_save = tmp_path / "custom-preprocessed.json"
+    config = RunConfig(
+        executor="taskvine",
+        ddr_save_preprocess=str(explicit_save),
+    )
+    _, save_path = _resolve_ddr_preprocess_paths(
+        config,
+        results_dir=tmp_path,
+    )
+
+    assert save_path == str(explicit_save)
+
+
+def test_preprocess_paths_reuse_mode_disables_auto_save(tmp_path: Path) -> None:
+    config = RunConfig(
+        executor="taskvine",
+        ddr_preprocessed_data=str(tmp_path / "existing-preprocessed.json"),
+        ddr_auto_save_preprocess=True,
+    )
+    preprocessed_data_path, save_path = _resolve_ddr_preprocess_paths(
+        config,
+        results_dir=tmp_path,
+    )
+
+    assert preprocessed_data_path == str(tmp_path / "existing-preprocessed.json")
+    assert save_path is None
+
+
+def test_preprocess_paths_reuse_mode_keeps_explicit_save(tmp_path: Path) -> None:
+    explicit_save = tmp_path / "explicit-save.json"
+    config = RunConfig(
+        executor="taskvine",
+        ddr_preprocessed_data=str(tmp_path / "existing-preprocessed.json"),
+        ddr_save_preprocess=str(explicit_save),
+    )
+    _, save_path = _resolve_ddr_preprocess_paths(
+        config,
+        results_dir=tmp_path,
+    )
+
+    assert save_path == str(explicit_save)
+
+
+def test_flatten_ddr_result_payload_uses_canonical_key_order() -> None:
+    payload = {
+        "proc_a": {
+            "dataset_a": {
+                ("ptbl", "2lss", "isSR_2l", "TTW", "nominal"): 1,
+                ("ptbl", "2lss", "isSR_2l", "TTW", ("JES", "Up")): 2,
+                "region_yields": {"ignored": True},
+            }
+        }
+    }
+
+    flattened = flatten_ddr_result_payload(payload)
+
+    assert list(flattened.keys()) == [
+        ("TTW", "2lss", "ptbl", "isSR_2l", "JES:Up"),
+        ("TTW", "2lss", "ptbl", "isSR_2l", "nominal"),
+    ]
+    assert flattened[("TTW", "2lss", "ptbl", "isSR_2l", "nominal")] == 1
+    assert flattened[("TTW", "2lss", "ptbl", "isSR_2l", "JES:Up")] == 2
+
+
+def test_flatten_ddr_result_payload_merges_duplicates() -> None:
+    payload = {
+        "proc_a": {"dataset": {("ptbl", "2lss", "isSR_2l", "TTW", "nominal"): 1}},
+        "proc_b": {"dataset": {("ptbl", "2lss", "isSR_2l", "TTW", "nominal"): 2}},
+    }
+
+    flattened = flatten_ddr_result_payload(payload)
+
+    assert flattened[("TTW", "2lss", "ptbl", "isSR_2l", "nominal")] == 3

--- a/tests/test_jets_layout.py
+++ b/tests/test_jets_layout.py
@@ -131,6 +131,8 @@ def test_jets_and_masks_have_flat_counts(monkeypatch):
     )
 
     dataset = ap.DatasetContext(
+        sample_name="sample",
+        sample_metadata={"histAxisName": "sample"},
         dataset="sample",
         trigger_dataset="sample",
         hist_axis_name="sample",

--- a/tests/test_nanoevents_without_caches.py
+++ b/tests/test_nanoevents_without_caches.py
@@ -88,6 +88,8 @@ def _build_minimal_processor(monkeypatch):
 
     variation_objects = ap.VariationObjects.from_base(base_objects)
     dataset = ap.DatasetContext(
+        sample_name="sample",
+        sample_metadata={"histAxisName": "sample"},
         dataset="sample",
         trigger_dataset="sample",
         hist_axis_name="sample",


### PR DESCRIPTION
### Summary
- Refactor TaskVine+DDR submission to build DDR processors keyed by `<channel><delim><var><delim><application><delim><systematic_label>` (delimiter-safe, fail-fast).
- Default output schema becomes a strict canonical flat dict keyed by `(sample, channel, var, application, systematic_label)`, derived from DDR nested output.
- Enforce strict schema matching between DDR processor keys and tuple histogram keys; fail immediately on mismatch.
- Implement fail-fast collision policy for flattened keys (no silent merge); raise with origin diagnostics.
- Align proxy/preprocess artifact workflow with ttbarEFT-style behavior:
  - stage `proxy.pem` in TaskVine staging, ship via `extra_files`, set `X509_USER_PROXY=proxy.pem`
  - auto-save preprocess mapping to deterministic `taskvine-results/ddr_preprocessed_data.json` unless reuse path is provided
- Make sidecars opt-in: processor will not create `__topeft_variation_summary__`, `region_yields`, etc. unless explicitly requested.

### Motivation
- Current DDR usage produced nested outputs and processor-key schemes that were harder to reason about and harder to align with the ttbarEFT benchmark.
- We want:
  - channel-keyed DDR processor dict construction (with your existing granularity at the `(channel,var,application,systematic_label)` level)
  - a deterministic, canonical flattened output schema suitable for downstream consumption and stable across runs
  - reproducible proxy handling and preprocess artifact reuse for faster iteration
  - “fail fast” behavior for delimiter collisions, schema mismatch, and flattened key collisions to avoid silently corrupting outputs.

### Implementation details

A) AnalysisProcessor: multi-sample dispatch + sidecars default-off (`analysis/topeft_run2/analysis_processor.py`)
- `DatasetContext` now carries `sample_name` and `sample_metadata` to support grouped-sample dispatch under channel-keyed DDR processors.
- `AnalysisProcessor` can accept:
  - a single sample metadata mapping, or
  - a mapping of `sample_name -> sample metadata`, with deterministic normalization and alias handling.
- Golden JSON handling is extended to support per-sample paths (`golden_json_paths`) for grouped sample maps.
- Sidecars are now controlled by `produce_sidecars` (default `False`):
  - only when enabled are `__topeft_variation_summary__` and `region_yields` stored in the accumulator.

B) DDR processor key schema + delimiter safety (`analysis/topeft_run2/workflow.py`)
- Added `build_ddr_processor_key(...)` and `_parse_ddr_processor_key(...)` with:
  - configurable delimiter (default `-`)
  - hard error if any component contains the delimiter (fail-fast normalization policy)
- DDR processor dict now uses keys:
  - `<channel><delim><var><delim><application><delim><systematic_label>`
- Processor grouping is performed at `(channel, var, application, systematic_label)` while still handling per-sample metadata internally.

C) Canonical flattening (default) with strict validation (`analysis/topeft_run2/workflow.py`)
- Implemented `flatten_ddr_output(...)` to convert DDR nested output (`processor -> dataset -> leaf`) into a flat mapping:
  - default schema: `(sample, channel, var, application, systematic_label)`
- Strictness:
  - the processor-key fields must match the tuple histogram key `(var, channel, application, sample, systematic)` after systematic normalization
  - mismatches raise immediately.
- Collision policy:
  - fail-fast: duplicate flattened keys raise `ValueError` including first/second origin context:
    - `(processor, dataset, histogram_key)` for both sides.

D) Proxy policy (ttbarEFT-style) (`analysis/topeft_run2/workflow.py`)
- When `--ddr-x509-proxy` is provided:
  - copy to `<staging_dir>/proxy.pem`
  - ship `proxy.pem` via `extra_files`
  - set `X509_USER_PROXY=proxy.pem` in DDR/preprocess environment variables if not overridden.

E) Preprocess artifact reuse/save + deterministic default (`analysis/topeft_run2/workflow.py`, config/CLI wiring)
- Deterministic default auto-save path:
  - `<taskvine-results>/ddr_preprocessed_data.json`
- New knobs (CLI + RunConfig):
  - `--ddr-preprocessed-data` (reuse; skip preprocess)
  - `--ddr-save-preprocess` (persist mapping)
  - `--ddr-auto-save-preprocess/--no-ddr-auto-save-preprocess` (default on)
  - `--ddr-preprocess-artifact` (override deterministic default)
- Persist/load semantics: JSON-first with cloudpickle fallback (implemented in topcoffea helper; invoked via topeft wiring).

F) Run config and CLI surface (`analysis/topeft_run2/run_analysis.py`, `analysis/topeft_run2/run_analysis_helpers.py`)
- Set `--chunksize` default to `500000` and forward to DDR step size by default.
- Expose DDR knobs:
  - delimiter, output schema (flat/tuple), sidecar preservation knobs
  - step size override, retries/resources/verbosity, proxy path
  - preprocess reuse/save knobs above

G) Tests
- Updated existing tests to account for new `DatasetContext` fields.
- Added targeted DDR schema tests:
  - delimiter collision rejection
  - parse roundtrip
  - flatten strictness mismatch failure
  - fail-fast duplicate collision diagnostics
  - sidecars default-off behavior
- Added targeted proxy + preprocess policy tests (including ensuring env var uses `proxy.pem` basename).

### Testing
- `python -m compileall topeft/modules analysis tests`
- `python -m pytest -q` (passes; see CI/local output)

### Review notes
- Please focus review on:
  - the processor-key schema (`<channel>-<var>-<application>-<systematic_label>`) and delimiter collision fail-fast policy
  - strictness of flattening validation vs processor keys and tuple histogram keys
  - fail-fast collision behavior (this is intended and may surface latent duplication in real configs)
  - sidecars default-off change (sidecars should only be produced when explicitly requested)
  - proxy/preprocess artifact behavior matching ttbarEFT style (proxy.pem staging + deterministic preprocess artifact)

### Comparison with ttbarEFT benchmark
- Reference benchmark: `ttbarEFT/analysis/run_processor_vineReduce.py` in raw nested DDR mode.
- ttbarEFT defaults to producing raw nested DDR output and then applying a default postprocessing grouping block (`aggregate=True`).
- topeft defaults to strict canonical flattened output with schema validation and fail-fast collisions.
- These layers are treated as conceptually equivalent normalization steps; differences are documented and follow-ups can be proposed if raw nested interoperability is ever required.