### PR TITLE
Enforce options-only wrapper and centralize worker CLI policy for Run-2 workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Top quark EFT analyses using the Coffea framework
 ## Start here
 
 New to the project? Start with the [workflow and YAML hub](docs/workflow_and_yaml_hub.md).  
-It walks through the shared `coffea2025` environment, the Run‑2/Run‑3 YAML presets, and how to choose between the TaskVine and futures executors before handing you off to the Run‑2 quickstart and plotting guides. Consult [docs/index.md](docs/index.md) for a full map of the documentation tracks.
+For day-to-day execution, use [How to run an analysis workflow](docs/how_to_run_analysis_workflow.md), which documents the options-only `full_run.sh` entrypoint and TaskVine DDR-first defaults. Consult [docs/index.md](docs/index.md) for the full documentation map.
 
 ## Repository contents
 
@@ -47,7 +47,9 @@ triggers.
 Explore the rest of the documentation via:
 
 - [Workflow & YAML hub](docs/workflow_and_yaml_hub.md) – start here.
+- [How to run an analysis workflow](docs/how_to_run_analysis_workflow.md) – options-first `full_run.sh` usage.
 - [Documentation index](docs/index.md) – curated doc tracks.
+- [Schema reference](docs/schemas.md) – canonical tuple/flat contracts and DDR flattening rules.
 - [TaskVine workflow quickstart](docs/taskvine_workflow.md) – distributed execution focus.
 - [Datacard fitting workflow](docs/fitting.md) – canonical datacard/fit handoff.
 - [Run 2 metadata scenarios](docs/run2_scenarios.md) – scenario definitions and validators.
@@ -196,10 +198,10 @@ The [v0.5 tag](https://github.com/TopEFT/topcoffea/releases/tag/v0.5) was used t
 
     ```bash
     cd analysis/topeft_run2
-    ./full_run.sh --cr -y run2 --options configs/fullR2_run.yml --outdir histos/run2_ref --tag top22006
+    ./full_run.sh --options configs/fullR2_run.yml:cr
     ```
 
-2. Run the datacard maker to obtain the cards and templates from SM (from the pickled histogram file produced in Step 1, be sure to use the version with the nonprompt estimation, i.e. the one with `_np` appended to the name you specified with the ``--tag``/``--outdir`` pair in ``full_run.sh``). This step would also produce scalings-preselect.json file which the later version is necessary for IM workspace making. Note that command option `--wc-scalings` is not mandatory but to enforce the ordering of wcs in scalings. Add command `-A` to include all EFT templates in datacards for previous AAC model. Add option `-C` to run on condor.
+2. Run the datacard maker to obtain the cards and templates from SM (from the pickled histogram file produced in Step 1, be sure to use the version with the nonprompt estimation, i.e. the one with `_np` appended to the configured output stem). This step would also produce scalings-preselect.json file which the later version is necessary for IM workspace making. Note that command option `--wc-scalings` is not mandatory but to enforce the ordering of wcs in scalings. Add command `-A` to include all EFT templates in datacards for previous AAC model. Add option `-C` to run on condor.
     ```
     time python make_cards.py /path/to/your/examplename_np.pkl.gz --do-nuisance --var-lst lj0pt ptz -d /scratch365/you/somedir --unblind --do-mc-stat --wc-scalings cQQ1 cQei cQl3i cQlMi cQq11 cQq13 cQq81 cQq83 cQt1 cQt8 cbW cpQ3 cpQM cpt cptb ctG ctW ctZ ctei ctlSi ctlTi ctli ctp ctq1 ctq8 ctt1
     ```

--- a/analysis/extreme_events_study/run_extreme_events.py
+++ b/analysis/extreme_events_study/run_extreme_events.py
@@ -60,7 +60,6 @@ parser = argparse.ArgumentParser(
 )
 parser.add_argument('inputFiles'            , nargs='?', default='', help = 'JSON or CFG file(s) containing sample metadata')
 parser.add_argument('--chunksize','-s'      , default=100000, type=int, help = 'Number of events per chunk')
-parser.add_argument('--nworkers','-n'       , default=8, type=int, help = 'Number of workers')
 parser.add_argument('--max-files','-N'      , default=0, type=int, help = 'Limit the number of ROOT files per sample (useful for testing)')
 parser.add_argument('--nchunks','-c'        , default=0, type=int, help = 'Limit the number of chunks processed')
 parser.add_argument('--outname','-o'        , default='flipTopEFT', help = 'Base name for the output histogram file')

--- a/analysis/extreme_events_study/run_extreme_events.py
+++ b/analysis/extreme_events_study/run_extreme_events.py
@@ -60,6 +60,7 @@ parser = argparse.ArgumentParser(
 )
 parser.add_argument('inputFiles'            , nargs='?', default='', help = 'JSON or CFG file(s) containing sample metadata')
 parser.add_argument('--chunksize','-s'      , default=100000, type=int, help = 'Number of events per chunk')
+parser.add_argument('--nworkers','-n'       , default=8, type=int, help = 'Number of workers')
 parser.add_argument('--max-files','-N'      , default=0, type=int, help = 'Limit the number of ROOT files per sample (useful for testing)')
 parser.add_argument('--nchunks','-c'        , default=0, type=int, help = 'Limit the number of chunks processed')
 parser.add_argument('--outname','-o'        , default='flipTopEFT', help = 'Base name for the output histogram file')
@@ -100,7 +101,7 @@ outpath    = args.outpath
 treename   = args.treename
 xrd        = args.xrd
 max_files  = args.max_files
-futures_workers = executor_config.futures.workers
+nworkers = executor_config.futures.workers
 futures_status = executor_config.futures.status
 futures_tail_timeout = executor_config.futures.tailtimeout
 
@@ -146,7 +147,7 @@ tstart = time.time()
 if executor == "futures":
     exec_instance = build_futures_executor(
         processor,
-        workers=futures_workers,
+        workers=nworkers,
         status=futures_status,
         tailtimeout=futures_tail_timeout,
     )

--- a/analysis/flip_measurement/run_flip.py
+++ b/analysis/flip_measurement/run_flip.py
@@ -92,6 +92,13 @@ parser.add_argument(
     help="Number of events per chunk",
 )
 parser.add_argument(
+    "--nworkers",
+    "-n",
+    default=8,
+    type=int,
+    help="Number of workers",
+)
+parser.add_argument(
     "--max-files",
     "-N",
     default=0,
@@ -242,14 +249,14 @@ def _run_executor(
     processor_instance,
     extra_input_files_lst,
 ):
-    futures_workers = executor_config.futures.workers
+    nworkers = executor_config.futures.workers
     futures_status = executor_config.futures.status
     futures_tail_timeout = executor_config.futures.tailtimeout
 
     if executor_name == "futures":
         exec_instance = build_futures_executor(
             processor,
-            workers=futures_workers,
+            workers=nworkers,
             status=futures_status,
             tailtimeout=futures_tail_timeout,
         )

--- a/analysis/flip_measurement/run_flip.py
+++ b/analysis/flip_measurement/run_flip.py
@@ -92,13 +92,6 @@ parser.add_argument(
     help="Number of events per chunk",
 )
 parser.add_argument(
-    "--nworkers",
-    "-n",
-    default=8,
-    type=int,
-    help="Number of workers",
-)
-parser.add_argument(
     "--max-files",
     "-N",
     default=0,

--- a/analysis/topeft_run2/configs/fullR2_run.yml
+++ b/analysis/topeft_run2/configs/fullR2_run.yml
@@ -39,8 +39,10 @@ profiles:
     jsonFiles:
       - ../../input_samples/cfgs/mc_background_samples_cr_NDSkim.cfg
     skip_sr: true
-    split_lep_flavor: true
-    executor: futures
-    chunksize: 50
-    nchunks: 1
+    split_lep_flavor: false
+    executor: taskvine
+    # chunksize: 50
+    # nchunks: 1
     outname: refact_250901_c1_CRs
+    log_level: none
+    environment_file: auto

--- a/analysis/topeft_run2/full_run.sh
+++ b/analysis/topeft_run2/full_run.sh
@@ -1,664 +1,99 @@
 #!/usr/bin/env bash
-# Unified wrapper for launching run_analysis.py with TaskVine, Coffea futures,
-# or the local iterative executor now that Run-2 scenarios are driven by
-# run2_scenarios.yaml.
+# Options-only wrapper for analysis/topeft_run2/run_analysis.py.
 #
-# Expectations before running (same as before):
-#   1. Activate the shared Conda environment shipped with this repository
-#      (name: coffea2025) or another compatible setup so the topeft and
-#      topcoffea editable installs are available. This script assumes the
-#      environment is already active and does not attempt to activate it.
-#   2. For TaskVine runs, stage the packaged environment tarball by running
-#      `python -m topcoffea.modules.remote_environment` after activation.  The
-#      script reuses the returned path as the --environment-file argument.
-#   3. When using TaskVine, launch a pool of workers that point at the manager
-#      name used in this script (defaults to "${USER}-taskvine-coffea") via
-#      vine_submit_workers or vine_worker.  Workers should run in the same
-#      environment tarball reported by the remote_environment helper.
+# This entrypoint intentionally accepts only --options (plus --help) so a
+# single YAML profile remains the sole run configuration source.
 #
-# The run_analysis workflow emits histogram pickles keyed by
-# (variable, channel, application, sample, systematic) 5-tuples; downstream
-# tools assume this schema when combining outputs.
+# Notes:
+#   - TaskVine + DDR is the recommended production path and is configured in YAML.
+#   - TaskVine DDR output defaults to the canonical flat schema
+#     (sample, channel, var, application, systematic_label).
+#   - Futures/iterative debug profiles may still produce tuple-keyed outputs.
+#   - Preprocess artifacts default to taskvine-results/ddr_preprocessed_data.json
+#     unless overridden in YAML.
+#   - If ddr_x509_proxy is configured, the workflow stages proxy.pem and sets
+#     X509_USER_PROXY=proxy.pem for worker tasks.
 
 set -euo pipefail
 
-PrintUsage() {
+print_usage() {
   cat <<'USAGE'
-Usage: full_run.sh [-y YEAR [YEAR ...]] [-t TAG] [--cr | --sr] \
-                   [--executor {taskvine,futures,iterative}] [--outdir PATH] [--manager NAME] \
-                   [--samples PATH [PATH ...]] [--scenario NAME] [--log-level LEVEL] \
-                   [--dry-run] [extra run_analysis args]
+Usage:
+  full_run.sh --options <path[:profile]>
+  full_run.sh --help
+
+Description:
+  Wrapper around run_analysis.py in strict options-only mode.
+
+Rules:
+  - --options is required for execution.
+  - No other CLI flags are accepted by this wrapper.
+  - Profile auto-selection is handled by RunConfigBuilder:
+    pass path.yml and use default_profile in YAML when desired.
 
 Examples:
-  # Control-region TaskVine run over Run-3 bundles using defaults defined in the
-  # Run-3 configs (user-supplied --options forwarded via extra args).
-  full_run.sh --cr -y run3 -t dev_validation --executor taskvine \
-      --outdir histos/run3_validation --dry-run
+  ./full_run.sh --options analysis/topeft_run2/configs/fullR2_run.yml:sr
+  ./full_run.sh --options analysis/topeft_run2/configs/fullR2_run.yml
 
-  # Signal-region futures launch for UL17 using explicit sample JSONs.
-  full_run.sh --sr -y UL17 --executor futures --outdir histos/local_debug \
-      --samples ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \
-      --scenario TOP_22_006 --chunksize 4000 --dry-run
-
-  # Run-2 superset (all_analysis) using futures and the default Run-2 profile.
-  full_run.sh --sr -y run2 --executor futures --outdir histos/run2_all \
-      --scenario all_analysis --dry-run
-
-Notes:
-  * YEARS accept explicit values (2022, 2022EE, UL17, etc.) or bundles
-    (run2 -> UL16 UL16APV UL17 UL18, run3 -> 2022 2022EE).  Unknown entries
-    are rejected so mis-typed eras fail fast.
-  * Run-2 invocations without an explicit --scenario will prefer the default
-    run_analysis options file (analysis/topeft_run2/configs/fullR2_run.yml) and
-    select the SR/CR profile automatically.  Provide --scenario or --options
-    explicitly to override this behaviour.
-  * Required input cfg/json files live under input_samples/cfgs/ and are
-    selected automatically per year when --samples is not specified.  Supply
-    --samples to point at bespoke JSONs.  Append additional run_analysis flags
-    (for example --options configs/fullR2_run.yml:sr or --split-lep-flavor)
-    after the recognized wrapper arguments.
-  * The default output name is <YEARS>_(CRs|SRs)_<TAG>, saved to the specified
-    output directory with the 5-tuple histogram schema used throughout this
-    branch.  Use --dry-run to print the resolved command without launching
-    Python.  Use --log-level LEVEL to tweak the Python logging verbosity seen in
-    run_analysis.py (allowed: none, info, warning, error).
+Tips:
+  - Pin chunksize in YAML defaults (recommended: 500000).
+  - Set executor: taskvine and DDR knobs in YAML for production runs.
+  - Use dedicated futures/iterative debug profiles in YAML for local smoke tests.
 USAGE
 }
 
-check_active_env() {
-  local target_env="coffea2025"
-  if [[ -n "${CONDA_DEFAULT_ENV:-}" && "${CONDA_DEFAULT_ENV}" != "$target_env" ]]; then
-    echo "Warning: CONDA_DEFAULT_ENV='${CONDA_DEFAULT_ENV}' (expected '${target_env}' or a compatible environment)." >&2
-  elif [[ -z "${CONDA_DEFAULT_ENV:-}" ]]; then
-    echo "Note: no active conda environment detected; ensure '${target_env}' or another compatible environment is already activated." >&2
-  fi
-}
-
-stage_environment() {
-  python -m topcoffea.modules.remote_environment
-}
-
 main() {
+  local options_spec=""
+
   if [[ $# -eq 0 ]]; then
-    PrintUsage
-    return 0
+    echo "Error: --options is required." >&2
+    print_usage >&2
+    return 1
   fi
-
-  local default_year="2022"
-  local default_tag
-  default_tag=$(git rev-parse --short HEAD 2>/dev/null || date +%y%m%d)
-
-  local flag_cr=false
-  local flag_sr=false
-  local -a extra_args=()
-  local -a years=()
-  local -a expanded_years=()
-  local -a resolved_years=()
-  local -a user_samples=()
-  local -a scenario_args=()
-  local scenario_specified=false
-  local user_chunk_override=false
-  local user_env_override=false
-  local user_options_override=false
-  local outdir="histos"
-  local manager_name="${USER:-coffea}-taskvine-coffea"
-  local tag=""
-  local executor_choice=""
-  local workers=""
-  local futures_prefetch=1
-  local futures_retries=0
-  local futures_retry_wait=5.0
-  local dry_run=false
-  local log_level=""
-  local auto_options_spec=""
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      -y|--year)
-        shift
-        if [[ $# -eq 0 || "$1" == -* ]]; then
-          echo "Error: -y|--year requires at least one argument" >&2
-          return 1
-        fi
-        while [[ $# -gt 0 ]]; do
-          case "$1" in
-            -*)
-              break
-              ;;
-            *)
-              years+=("$1")
-              shift
-              ;;
-          esac
-        done
-        ;;
-      -t|--tag)
-        tag="$2"
-        shift 2
-        ;;
-      --outdir)
-        outdir="$2"
-        shift 2
-        ;;
-      --manager)
-        manager_name="$2"
-        shift 2
-        ;;
-      --workers)
-        workers="$2"
-        shift 2
-        ;;
-      --samples)
-        shift
-        if [[ $# -eq 0 || "$1" == -* ]]; then
-          echo "Error: --samples requires at least one argument" >&2
-          return 1
-        fi
-        while [[ $# -gt 0 ]]; do
-          case "$1" in
-            -*)
-              break
-              ;;
-            *)
-              user_samples+=("$1")
-              shift
-              ;;
-          esac
-        done
-        ;;
-      --futures-prefetch)
-        futures_prefetch="$2"
-        shift 2
-        ;;
-      --futures-retries)
-        futures_retries="$2"
-        shift 2
-        ;;
-      --futures-retry-wait)
-        futures_retry_wait="$2"
-        shift 2
-        ;;
-      --executor)
-        executor_choice="$2"
-        shift 2
-        ;;
-      --executor=*)
-        executor_choice="${1#*=}"
-        shift
-        ;;
-      --taskvine)
-        executor_choice="taskvine"
-        shift
-        ;;
-      --futures)
-        executor_choice="futures"
-        shift
-        ;;
-      --iterative)
-        executor_choice="iterative"
-        shift
-        ;;
-      --cr)
-        flag_cr=true
-        shift
-        ;;
-      --sr)
-        flag_sr=true
-        shift
-        ;;
-      -s|--chunksize|--chunksize=*)
-        user_chunk_override=true
-        extra_args+=("$1")
-        shift
-        ;;
-      -x)
-        executor_choice="$2"
-        shift 2
-        ;;
       -h|--help)
-        PrintUsage
+        print_usage
         return 0
         ;;
-      --dry-run)
-        dry_run=true
-        shift
-        ;;
-      --log-level)
-        log_level="$2"
-        shift 2
-        ;;
-      --log-level=*)
-        log_level="${1#*=}"
-        shift
-        ;;
       --options)
-        user_options_override=true
-        if [[ $# -lt 2 ]]; then
-          echo "Error: --options expects a value" >&2
+        if [[ -n "$options_spec" ]]; then
+          echo "Error: --options was provided more than once." >&2
           return 1
         fi
-        extra_args+=("$1" "$2")
+        if [[ $# -lt 2 ]]; then
+          echo "Error: --options expects a non-empty value." >&2
+          return 1
+        fi
+        options_spec="$2"
         shift 2
         ;;
       --options=*)
-        user_options_override=true
-        extra_args+=("$1")
-        shift
-        ;;
-      --scenario)
-        scenario_specified=true
-        shift
-        if [[ $# -eq 0 || "$1" == -* ]]; then
-          echo "Error: --scenario expects a name" >&2
+        if [[ -n "$options_spec" ]]; then
+          echo "Error: --options was provided more than once." >&2
           return 1
         fi
-        scenario_args+=("$1")
+        options_spec="${1#*=}"
         shift
-        ;;
-      --scenario=*)
-        scenario_specified=true
-        local scenario_value="${1#*=}"
-        if [[ -z "$scenario_value" ]]; then
-          echo "Error: --scenario expects a name" >&2
-          return 1
-        fi
-        scenario_args+=("$scenario_value")
-        shift
-        ;;
-      --environment-file|--environment-file=*)
-        user_env_override=true
-        extra_args+=("$1")
-        shift
-        ;;
-      --)
-        shift
-        extra_args+=("$@")
-        break
         ;;
       *)
-        extra_args+=("$1")
-        shift
+        echo "Error: unsupported argument '$1'. This wrapper only accepts --options and --help." >&2
+        print_usage >&2
+        return 1
         ;;
     esac
   done
 
-  if [[ "$flag_cr" == false && "$flag_sr" == false ]] || [[ "$flag_cr" == true && "$flag_sr" == true ]]; then
-    echo "Error: specify exactly one of --cr or --sr" >&2
-    echo
-    PrintUsage
+  if [[ -z "${options_spec// }" ]]; then
+    echo "Error: --options value cannot be empty." >&2
     return 1
-  fi
-
-  if [[ "$user_options_override" == true && "$scenario_specified" == true ]]; then
-    echo "Error: --scenario cannot be combined with --options; encode the scenario inside the options profile instead." >&2
-    return 1
-  fi
-
-  if [[ "$user_options_override" == false && ${#extra_args[@]} -gt 0 ]]; then
-    for passthrough_arg in "${extra_args[@]}"; do
-      case "$passthrough_arg" in
-        --options|--options=*)
-          echo "Error: '--options' supplied after '--'. Pass --options before the passthrough separator so the wrapper can enforce the scenario/options guard (or drop --scenario)." >&2
-          return 1
-          ;;
-      esac
-    done
-  fi
-
-  if [[ ${#years[@]} -eq 0 ]]; then
-    echo "Warning: YEAR not provided, using default YEAR=$default_year"
-    years=("$default_year")
-  fi
-
-  local year
-  for year in "${years[@]}"; do
-    case "${year,,}" in
-      run2)
-        expanded_years+=(UL16 UL16APV UL17 UL18)
-        ;;
-      run3)
-        expanded_years+=(2022 2022EE)
-        ;;
-      --cr)
-        flag_cr=true
-        ;;
-      --sr)
-        flag_sr=true
-        ;;
-      *)
-        expanded_years+=("$year")
-        ;;
-    esac
-  done
-
-  declare -A seen_year=()
-  for year in "${expanded_years[@]}"; do
-    if [[ -z "${seen_year[$year]:-}" ]]; then
-      resolved_years+=("$year")
-      seen_year[$year]=1
-    fi
-  done
-
-  if [[ ${#resolved_years[@]} -eq 0 ]]; then
-    echo "Error: no valid years resolved from the provided arguments." >&2
-    return 1
-  fi
-
-  if [[ -z "$tag" ]]; then
-    echo "Warning: TAG not provided, using default TAG=$default_tag"
-    tag="$default_tag"
-  fi
-
-  local executor
-  if [[ -n "$executor_choice" ]]; then
-    executor="$executor_choice"
-  else
-    executor="taskvine"
-  fi
-
-  if [[ "$executor" != "taskvine" && "$executor" != "futures" && "$executor" != "iterative" ]]; then
-    echo "Error: executor must be one of taskvine, futures, or iterative (got '$executor')" >&2
-    return 1
-  fi
-
-  local year_label
-  year_label=$(IFS=-; echo "${resolved_years[*]}")
-
-  local out_name
-  if [[ "$flag_cr" == true ]]; then
-    out_name="${year_label}_CRs_${tag}"
-  else
-    out_name="${year_label}_SRs_${tag}"
   fi
 
   local script_dir
   script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-  local repo_root
-  repo_root=$(cd "$script_dir/../.." && pwd)
-  cd "$script_dir"
 
-  check_active_env
-  local env_tarball=""
-  if [[ "$executor" == "taskvine" && "$user_env_override" == false && "$dry_run" == false ]]; then
-    env_tarball=$(stage_environment)
-  fi
-
-  local cfgs_path="$repo_root/input_samples/cfgs"
-  local -a cfgs_list=()
-  local -A run2_year_map=(
-    [2016]=2016
-    [2016apv]=2016APV
-    [2017]=2017
-    [2018]=2018
-    [ul16]=UL16
-    [ul16apv]=UL16APV
-    [ul17]=UL17
-    [ul18]=UL18
-  )
-
-  local -a run2_cfgs_sr=(
-    "$cfgs_path/mc_signal_samples_NDSkim.cfg"
-    "$cfgs_path/mc_background_samples_NDSkim.cfg"
-    "$cfgs_path/data_samples_NDSkim.cfg"
-  )
-  local -a run2_cfgs_cr=(
-    "$cfgs_path/mc_signal_samples_NDSkim.cfg"
-    "$cfgs_path/mc_background_samples_NDSkim.cfg"
-    "$cfgs_path/mc_background_samples_cr_NDSkim.cfg"
-    "$cfgs_path/data_samples_NDSkim.cfg"
-  )
-  local -a run3_cfgs_2022_sr=(
-    "$cfgs_path/2022_mc_signal_samples.cfg"
-    "$cfgs_path/2022_mc_background_samples.cfg"
-    "$cfgs_path/2022_data_samples.cfg"
-  )
-  local -a run3_cfgs_2022_cr=(
-    "$cfgs_path/2022_mc_background_samples.cfg"
-    "$cfgs_path/2022_data_samples.cfg"
-  )
-  local -a run3_cfgs_2022ee_sr=(
-    "$cfgs_path/2022_mc_signal_samples.cfg"
-    "$cfgs_path/2022_mc_background_samples.cfg"
-    "$cfgs_path/2022EE_data_samples.cfg"
-  )
-  local -a run3_cfgs_2022ee_cr=(
-    "$cfgs_path/2022_mc_background_samples.cfg"
-    "$cfgs_path/2022EE_data_samples.cfg"
-  )
-
-  local has_run2=false
-  local has_run3=false
-  for year in "${resolved_years[@]}"; do
-    local lower_year=${year,,}
-    if [[ -n "${run2_year_map[$lower_year]:-}" ]]; then
-      has_run2=true
-    elif [[ "$year" == "2022" || "$year" == "2022EE" ]]; then
-      has_run3=true
-    fi
-  done
-
-  if [[ "$has_run2" == true && "$has_run3" == true ]]; then
-    echo "Error: mixing Run-2 and Run-3 eras in a single invocation is not supported." >&2
-    return 1
-  fi
-
-  if [[ "$scenario_specified" == false ]]; then
-    # Default scenarios mirror the canonical Run-2/Run-3 bundles wired through
-    # analysis/topeft_run2/metadata_authority.py.
-    if [[ "$has_run2" == true ]]; then
-      scenario_args=("TOP_22_006")
-    elif [[ "$has_run3" == true ]]; then
-      scenario_args=("fwd_analysis")
-    fi
-  fi
-
-  if [[ ${#scenario_args[@]} -gt 1 ]]; then
-    echo "Error: only one --scenario can be specified per run (requested: ${scenario_args[*]})." >&2
-    return 1
-  fi
-
-  local scenario_name=""
-  if [[ ${#scenario_args[@]} -eq 1 ]]; then
-    scenario_name="${scenario_args[0]}"
-  fi
-
-  if [[ "$scenario_specified" == false && "$user_options_override" == false && \
-        "$has_run2" == true && "$has_run3" == false ]]; then
-    local run2_options_path="$script_dir/configs/fullR2_run.yml"
-    if [[ -f "$run2_options_path" ]]; then
-      local profile_name
-      if [[ "$flag_cr" == true ]]; then
-        profile_name="cr"
-      else
-        profile_name="sr"
-      fi
-      auto_options_spec="$run2_options_path:$profile_name"
-    fi
-  fi
-
-  declare -A seen_cfgs=()
-  add_cfg() {
-    local cfg_file="$1"
-    if [[ ! -f "$cfg_file" ]]; then
-      echo "Error: required cfg/json file not found: $cfg_file" >&2
-      return 1
-    fi
-    if [[ -n "${seen_cfgs[$cfg_file]:-}" ]]; then
-      return 0
-    fi
-    cfgs_list+=("$cfg_file")
-    seen_cfgs[$cfg_file]=1
-    return 0
-  }
-
-  local year_key
-  local run2_bundle_added=false
-  for year in "${resolved_years[@]}"; do
-    year_key=${year,,}
-    if [[ -n "${run2_year_map[$year_key]:-}" ]]; then
-      if [[ "$run2_bundle_added" == false ]]; then
-        if [[ "$flag_cr" == true ]]; then
-          for cfg in "${run2_cfgs_cr[@]}"; do
-            add_cfg "$cfg" || return 1
-          done
-        else
-          for cfg in "${run2_cfgs_sr[@]}"; do
-            add_cfg "$cfg" || return 1
-          done
-        fi
-        run2_bundle_added=true
-      fi
-      continue
-    fi
-
-    case "$year" in
-      2022)
-        if [[ "$flag_cr" == true ]]; then
-          for cfg in "${run3_cfgs_2022_cr[@]}"; do
-            add_cfg "$cfg" || return 1
-          done
-        else
-          for cfg in "${run3_cfgs_2022_sr[@]}"; do
-            add_cfg "$cfg" || return 1
-          done
-        fi
-        ;;
-      2022EE)
-        if [[ "$flag_cr" == true ]]; then
-          for cfg in "${run3_cfgs_2022ee_cr[@]}"; do
-            add_cfg "$cfg" || return 1
-          done
-        else
-          for cfg in "${run3_cfgs_2022ee_sr[@]}"; do
-            add_cfg "$cfg" || return 1
-          done
-        fi
-        ;;
-      *)
-        echo "Error: unrecognized YEAR '$year'" >&2
-        return 1
-        ;;
-    esac
-  done
-
-  local -a input_specs=()
-  if [[ ${#user_samples[@]} -gt 0 ]]; then
-    for sample_path in "${user_samples[@]}"; do
-      if [[ ! -e "$sample_path" ]]; then
-        echo "Error: sample override not found: $sample_path" >&2
-        return 1
-      fi
-      input_specs+=("$sample_path")
-    done
-  else
-    input_specs=("${cfgs_list[@]}")
-  fi
-
-  if [[ ${#input_specs[@]} -eq 0 ]]; then
-    echo "Error: no cfg/json inputs resolved" >&2
-    return 1
-  fi
-
-  local cfgs
-  cfgs=$(IFS=,; echo "${input_specs[*]}")
-
-  local options_in_effect=false
-  if [[ "$user_options_override" == true || -n "$auto_options_spec" ]]; then
-    options_in_effect=true
-  fi
-
-  echo "Resolved years: ${resolved_years[*]}"
-  echo "Resolved cfg inputs: $cfgs"
-  echo "Executor: $executor"
-  if [[ "$executor" == "taskvine" ]]; then
-    echo "TaskVine manager: $manager_name"
-    if [[ -n "$env_tarball" ]]; then
-      echo "Environment archive: $env_tarball"
-    elif [[ "$dry_run" == false && "$user_env_override" == false ]]; then
-      echo "Warning: TaskVine environment tarball not set"
-    fi
-  else
-    echo "Futures prefetch: $futures_prefetch | retries: $futures_retries"
-  fi
-  if [[ "$options_in_effect" == true ]]; then
-    if [[ -n "$auto_options_spec" ]]; then
-      echo "Options profile: $auto_options_spec (auto-selected)"
-    else
-      echo "Options profile: supplied via CLI"
-    fi
-    echo "Scenario: controlled by options profile"
-  elif [[ -n "$scenario_name" ]]; then
-    echo "Scenario: $scenario_name"
-  fi
-
-  if [[ -z "$workers" ]]; then
-    case "$executor" in
-      taskvine)
-        workers=8
-        ;;
-      futures)
-        workers=4
-        ;;
-      iterative)
-        workers=1
-        ;;
-    esac
-  fi
-
-  local -a options=(
-    --outname "$out_name"
-    --outpath "$outdir"
-    --nworkers "$workers"
-    --summary-verbosity brief
-    --executor "$executor"
-  )
-
-  if [[ "$user_chunk_override" == false ]]; then
-    options+=(--chunksize 50000)
-  fi
-  if [[ "$executor" == "taskvine" ]]; then
-    options+=(--manager-name "$manager_name")
-    if [[ "$user_env_override" == false && -n "$env_tarball" ]]; then
-      options+=(--environment-file "$env_tarball")
-    fi
-  elif [[ "$executor" == "futures" ]]; then
-    options+=(--futures-prefetch "$futures_prefetch")
-    options+=(--futures-retries "$futures_retries")
-    options+=(--futures-retry-wait "$futures_retry_wait")
-  fi
-
-  if [[ "$flag_cr" == true ]]; then
-    options+=(--skip-sr)
-  else
-    options+=(--skip-cr --do-systs)
-  fi
-
-  if [[ -n "$log_level" ]]; then
-    options+=(--log-level "$log_level")
-  fi
-
-  local -a run_cmd=(python run_analysis.py "$cfgs")
-  run_cmd+=("${options[@]}")
-  if [[ -n "$auto_options_spec" ]]; then
-    run_cmd+=(--options "$auto_options_spec")
-  fi
-  if [[ "$options_in_effect" == false && -n "$scenario_name" ]]; then
-    run_cmd+=(--scenario "$scenario_name")
-  fi
-  run_cmd+=("${extra_args[@]}")
-
-  printf "\nResolved command:\n%s\n\n" "${run_cmd[*]}"
-  if [[ "$dry_run" == true ]]; then
-    return 0
-  fi
-
-  time "${run_cmd[@]}"
+  exec python "$script_dir/run_analysis.py" --options "$options_spec"
 }
 
 main "$@"
-exit_code=$?
-if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
-  exit "$exit_code"
-else
-  return "$exit_code"
-fi

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -97,7 +97,6 @@ EXECUTOR_CLI = ExecutorCLIHelper(
     remote_environment=remote_environment,
     futures_spec=FuturesArgumentSpec(
         workers_default=8,
-        include_workers=False,
         include_status=True,
         include_tail_timeout=True,
         include_memory=True,

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -667,7 +667,7 @@ def main(argv: Sequence[str] | None = None) -> None:
         metadata_provenance,
     )
     logger.info(
-        "Resolved equivalent CLI without --options:\n  %s",
+        "Informational (best-effort): resolved equivalent CLI without --options:\n  %s",
         _build_equivalent_cli_call(
             config,
             scenario_name=scenario_name,

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -161,13 +161,6 @@ def build_parser() -> argparse.ArgumentParser:
     )
     EXECUTOR_CLI.configure_parser(parser)
     parser.add_argument(
-        "--nworkers",
-        "-n",
-        type=int,
-        default=8,
-        help="Number of workers",
-    )
-    parser.add_argument(
         "--chunksize",
         "-s",
         type=int,

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -7,8 +7,9 @@ Purpose:
 
 Inputs/outputs:
 - Reads sample manifests (JSON/CFG) plus optional YAML option profiles.
-- Writes tuple-keyed histogram pickles and run summaries to the configured
-  output directory.
+- Writes histogram pickles and run summaries to the configured output
+  directory. TaskVine DDR runs default to the canonical flattened schema,
+  while local futures/iterative execution preserves tuple-keyed outputs.
 
 Side effects:
 - Creates output files/directories and may dispatch tasks to futures/TaskVine.
@@ -23,6 +24,7 @@ from __future__ import annotations
 import argparse
 import importlib
 import logging
+import shlex
 import sys
 from typing import Sequence
 
@@ -474,22 +476,127 @@ def _apply_scenario_metadata_defaults(
     return scenario_name, bundle, provenance
 
 
-def _argument_supplied(
-    argv: Sequence[str],
-    long_opt: str,
-    short_opt: str | None = None,
-) -> bool:
-    """Return True when ``long_opt``/``short_opt`` appear in ``argv``."""
+def _build_equivalent_cli_call(
+    config: RunConfig,
+    *,
+    scenario_name: str,
+    metadata_path: str,
+) -> str:
+    """Return a deterministic equivalent CLI command without ``--options``."""
 
-    for token in argv:
-        if token == long_opt or token.startswith(f"{long_opt}="):
-            return True
-        if short_opt:
-            if token == short_opt:
-                return True
-            if token.startswith(short_opt) and token != short_opt:
-                return True
-    return False
+    tokens: list[str] = ["python", "analysis/topeft_run2/run_analysis.py"]
+    tokens.extend(str(path) for path in config.json_files if str(path).strip())
+
+    if config.prefix:
+        tokens.extend(["--prefix", str(config.prefix)])
+    if config.test:
+        tokens.append("--test")
+    if config.pretend:
+        tokens.append("--pretend")
+
+    tokens.extend(["--executor", str(config.executor or "taskvine")])
+    tokens.extend(["--nworkers", str(config.nworkers)])
+    tokens.extend(["--chunksize", str(config.chunksize)])
+    if config.nchunks is not None:
+        tokens.extend(["--nchunks", str(config.nchunks)])
+    tokens.extend(["--outname", str(config.outname)])
+    tokens.extend(["--outpath", str(config.outpath)])
+    tokens.extend(["--treename", str(config.treename)])
+    tokens.extend(["--metadata", str(metadata_path)])
+    tokens.extend(["--scenario", str(scenario_name)])
+
+    if config.do_errors:
+        tokens.append("--do-errors")
+    if config.do_systs:
+        tokens.append("--do-systs")
+    if config.split_lep_flavor:
+        tokens.append("--split-lep-flavor")
+    if config.skip_sr:
+        tokens.append("--skip-sr")
+    if config.skip_cr:
+        tokens.append("--skip-cr")
+    if config.do_np:
+        tokens.append("--do-np")
+    if config.do_renormfact_envelope:
+        tokens.append("--do-renormfact-envelope")
+    if config.wc_list:
+        tokens.append("--wc-list")
+        tokens.extend(str(value) for value in config.wc_list)
+    if config.ecut is not None:
+        tokens.extend(["--ecut", str(config.ecut)])
+    if not config.channel_groups_strict:
+        tokens.append("--allow-partial-channel-groups")
+
+    if config.summary_verbosity:
+        tokens.extend(["--summary-verbosity", str(config.summary_verbosity)])
+    if config.log_level:
+        tokens.extend(["--log-level", str(config.log_level).lower()])
+    if config.log_tasks:
+        tokens.append("--log-tasks")
+
+    if config.port:
+        tokens.extend(["--port", str(config.port)])
+    if not config.negotiate_manager_port:
+        tokens.append("--no-port-negotiation")
+    if config.manager_name:
+        tokens.extend(["--manager-name", str(config.manager_name)])
+    if config.manager_name_template:
+        tokens.extend(["--manager-name-template", str(config.manager_name_template)])
+    if config.scratch_dir:
+        tokens.extend(["--scratch-dir", str(config.scratch_dir)])
+    if config.resource_monitor:
+        tokens.extend(["--resource-monitor", str(config.resource_monitor)])
+    if config.resources_mode:
+        tokens.extend(["--resources-mode", str(config.resources_mode)])
+    if config.environment_file:
+        tokens.extend(["--environment-file", str(config.environment_file)])
+    if not config.taskvine_print_stdout:
+        tokens.append("--no-taskvine-print-stdout")
+
+    if config.futures_status is not None:
+        tokens.append("--futures-status" if config.futures_status else "--no-futures-status")
+    if config.futures_tail_timeout is not None:
+        tokens.extend(["--futures-tail-timeout", str(config.futures_tail_timeout)])
+    if config.futures_memory is not None:
+        tokens.extend(["--futures-memory", str(config.futures_memory)])
+    if config.futures_prefetch is not None:
+        tokens.extend(["--futures-prefetch", str(config.futures_prefetch)])
+    tokens.extend(["--futures-retries", str(config.futures_retries)])
+    tokens.extend(["--futures-retry-wait", str(config.futures_retry_wait)])
+
+    if config.produce_sidecars:
+        tokens.append("--produce-sidecars")
+    tokens.extend(["--ddr-processor-key-delim", str(config.ddr_processor_key_delim)])
+    tokens.extend(["--ddr-output-schema", str(config.ddr_output_schema)])
+    if config.ddr_preserve_sidecars:
+        tokens.append("--ddr-preserve-sidecars")
+    if config.ddr_sidecars_key and (
+        config.ddr_preserve_sidecars or config.ddr_sidecars_key != "__sidecars__"
+    ):
+        tokens.extend(["--ddr-sidecars-key", str(config.ddr_sidecars_key)])
+    if config.ddr_step_size is not None:
+        tokens.extend(["--ddr-step-size", str(config.ddr_step_size)])
+    if config.ddr_max_task_retries is not None:
+        tokens.extend(["--ddr-max-task-retries", str(config.ddr_max_task_retries)])
+    if config.ddr_results_directory:
+        tokens.extend(["--ddr-results-directory", str(config.ddr_results_directory)])
+    if config.ddr_verbose is not None:
+        tokens.append("--ddr-verbose" if config.ddr_verbose else "--no-ddr-verbose")
+    if config.ddr_x509_proxy:
+        tokens.extend(["--ddr-x509-proxy", str(config.ddr_x509_proxy)])
+    if config.ddr_preprocessed_data:
+        tokens.extend(["--ddr-preprocessed-data", str(config.ddr_preprocessed_data)])
+    if config.ddr_save_preprocess:
+        tokens.extend(["--ddr-save-preprocess", str(config.ddr_save_preprocess)])
+    tokens.append(
+        "--ddr-auto-save-preprocess"
+        if config.ddr_auto_save_preprocess
+        else "--no-ddr-auto-save-preprocess"
+    )
+    if config.ddr_preprocess_artifact:
+        tokens.extend(["--ddr-preprocess-artifact", str(config.ddr_preprocess_artifact)])
+
+    return " ".join(shlex.quote(token) for token in tokens)
 
 
 def main(argv: Sequence[str] | None = None) -> None:
@@ -505,10 +612,6 @@ def main(argv: Sequence[str] | None = None) -> None:
 
     args = parser.parse_args(argv_list)
 
-    executor_from_cli = _argument_supplied(argv_list, "--executor", "-x")
-    chunksize_from_cli = _argument_supplied(argv_list, "--chunksize", "-s")
-    nchunks_from_cli = _argument_supplied(argv_list, "--nchunks", "-c")
-    metadata_from_cli = _argument_supplied(argv_list, "--metadata")
     executor_default = _normalize_executor_name(getattr(parser_defaults, "executor", ""))
     if not executor_default:
         executor_default = "taskvine"
@@ -526,7 +629,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     except (ValueError, TypeError, KeyError) as exc:
         parser.error(str(exc))
 
-    metadata_cli_value = getattr(args, "metadata", None) if metadata_from_cli else None
+    metadata_cli_value = getattr(args, "metadata", None)
     if config.options_path:
         metadata_cli_value = None
     try:
@@ -542,16 +645,7 @@ def main(argv: Sequence[str] | None = None) -> None:
             logger.error("Failed to resolve metadata scenario")
         sys.exit(1)
 
-    if chunksize_from_cli:
-        config.chunksize = getattr(args, "chunksize", config.chunksize)
-    if nchunks_from_cli:
-        config.nchunks = getattr(args, "nchunks", config.nchunks)
-
-    current_executor = _normalize_executor_name(getattr(config, "executor", ""))
-    if executor_from_cli:
-        current_executor = executor_choice
-    elif not current_executor:
-        current_executor = executor_choice
+    current_executor = _normalize_executor_name(getattr(config, "executor", "")) or executor_choice
     _ensure_supported_executor(current_executor)
     config.executor = current_executor
 
@@ -571,6 +665,14 @@ def main(argv: Sequence[str] | None = None) -> None:
         scenario_name,
         metadata_bundle.metadata_path,
         metadata_provenance,
+    )
+    logger.info(
+        "Resolved equivalent CLI without --options:\n  %s",
+        _build_equivalent_cli_call(
+            config,
+            scenario_name=scenario_name,
+            metadata_path=str(metadata_bundle.metadata_path),
+        ),
     )
 
     config.log_level = effective_log_level

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -97,6 +97,7 @@ EXECUTOR_CLI = ExecutorCLIHelper(
     remote_environment=remote_environment,
     futures_spec=FuturesArgumentSpec(
         workers_default=8,
+        include_workers=False,
         include_status=True,
         include_tail_timeout=True,
         include_memory=True,

--- a/analysis/topeft_run2/run_sow.py
+++ b/analysis/topeft_run2/run_sow.py
@@ -61,6 +61,7 @@ parser = argparse.ArgumentParser(
 )
 parser.add_argument('inputFiles'       , nargs='?', default='', help = 'JSON or CFG file(s) containing sample metadata')
 parser.add_argument('--chunksize','-s' , default=100000, type=int, help = 'Number of events per chunk')
+parser.add_argument('--nworkers','-n'  , default=8, type=int, help = 'Number of workers')
 parser.add_argument('--max-files','-N' , default=0, type=int, help = 'Limit the number of ROOT files per sample (useful for tests)')
 parser.add_argument('--nchunks','-c'   , default=0, type=int, help = 'Limit the number of chunks processed')
 parser.add_argument('--outname','-o'   , default='sowTopEFT', help = 'Base name for the output histogram file')
@@ -100,6 +101,7 @@ executor_config = EXECUTOR_CLI.parse_args(args)
 inputFiles = args.inputFiles.replace(' ','').split(',')  # Remove whitespace and split by commas
 executor   = executor_config.executor
 chunksize  = args.chunksize
+nworkers   = executor_config.futures.workers
 nchunks    = args.nchunks if args.nchunks else None
 outname    = args.outname
 outpath    = args.outpath
@@ -108,7 +110,6 @@ xrd        = args.xrd
 max_files  = args.max_files
 wc_lst     = args.wc_list if args.wc_list is not None else []
 debug_mode = args.debug
-futures_workers = executor_config.futures.workers
 futures_status = executor_config.futures.status
 futures_tail_timeout = executor_config.futures.tailtimeout
 futures_memory = executor_config.futures.memory
@@ -171,7 +172,7 @@ tstart = time.time()
 if executor == "futures":
     exec_instance = build_futures_executor(
         processor,
-        workers=futures_workers,
+        workers=nworkers,
         status=futures_status,
         tailtimeout=futures_tail_timeout,
     )

--- a/analysis/topeft_run2/run_sow.py
+++ b/analysis/topeft_run2/run_sow.py
@@ -61,7 +61,6 @@ parser = argparse.ArgumentParser(
 )
 parser.add_argument('inputFiles'       , nargs='?', default='', help = 'JSON or CFG file(s) containing sample metadata')
 parser.add_argument('--chunksize','-s' , default=100000, type=int, help = 'Number of events per chunk')
-parser.add_argument('--nworkers','-n'  , default=8, type=int, help = 'Number of workers')
 parser.add_argument('--max-files','-N' , default=0, type=int, help = 'Limit the number of ROOT files per sample (useful for tests)')
 parser.add_argument('--nchunks','-c'   , default=0, type=int, help = 'Limit the number of chunks processed')
 parser.add_argument('--outname','-o'   , default='sowTopEFT', help = 'Base name for the output histogram file')

--- a/docs/analysis_processing.md
+++ b/docs/analysis_processing.md
@@ -1,191 +1,42 @@
 # Workflow and processor reference
 
-This page documents how the ``analysis/topeft_run2`` helpers cooperate once the
-configuration is built.  It focuses on the execution phase that starts inside
-:func:`analysis.topeft_run2.workflow.run_workflow`, covers the systematic
-handshake with :class:`analysis.topeft_run2.analysis_processor.AnalysisProcessor`,
-and highlights the primary extension points.  For a primer on the dataclasses
-and metadata structures produced before this stage, see the
-[Run configuration dataclasses and metadata overview](dataclasses_and_metadata.md).
+This page summarizes execution flow for `analysis/topeft_run2` and points to
+stable references for schema and data-flow details.
 
-The high-level flow is:
+## End-to-end flow
 
-1. :class:`analysis.topeft_run2.workflow.RunWorkflow` validates the
-   :class:`analysis.topeft_run2.run_analysis_helpers.RunConfig` generated during
-   the CLI/YAML merge.
-2. :class:`analysis.topeft_run2.run_analysis_helpers.SampleLoader` expands the
-   input manifests and returns a normalized ``samplesdict`` together with the
-   expanded file list per sample.
-3. :class:`analysis.topeft_run2.workflow.ChannelPlanner` resolves the metadata
-   scenarios declared in ``analysis/metadata/run2_scenarios.yaml`` (via
-   `analysis/topeft_run2/metadata_authority.py`) and attaches the resulting
-   channel dictionaries to each histogram task.
-4. :class:`analysis.topeft_run2.workflow.HistogramPlanner` enumerates histogram
-   combinations by crossing samples, channel metadata, Coffea applications, and
-   systematic toggles.  The result is a :class:`HistogramPlan` which records the
-  ``(variable, channel, application, sample, systematic)`` tuples described in
-  the shared [tuple-key reference](tuple_key_audit.md)
-  before the tasks are processed.
-5. An :class:`analysis.topeft_run2.workflow.ExecutorFactory` creates the
-   requested backend runner (``futures``, ``iterative`` or ``taskvine``).  Each
-   histogram task is turned into an :class:`AnalysisProcessor` instance with the
-   correct per-sample metadata and systematic configuration before being
-   submitted to the executor.
+1. `run_analysis.py` builds `RunConfig` from CLI/YAML.
+2. `metadata_authority.load_metadata_bundle(...)` resolves metadata/scenario.
+3. `SampleLoader` expands JSON/CFG inputs into `samplesdict` and filesets.
+4. `ChannelPlanner` and `HistogramPlanner` build histogram tasks.
+5. `ExecutorFactory` dispatches tasks through `futures`, `iterative`, or
+   TaskVine DDR.
+6. `AnalysisProcessor` applies selections/systematics and fills histograms.
 
-## Architecture overview
+## Internal keying vs serialized output
 
-At a high level, :mod:`analysis.topeft_run2.run_analysis` collects CLI flags and
-YAML options, then hands them to
-:class:`analysis.topeft_run2.run_analysis_helpers.RunConfigBuilder`. The builder
-merges the inputs into a single :class:`RunConfig`, honouring the CLI/YAML
-precedence rules described in
-[run_analysis_configuration.md](run_analysis_configuration.md). The Run‑2
-quickstart helpers return the same dataclass so notebook-driven runs can reuse
-it directly.
+Inside planning/processor code, histogram keys remain 5-tuples:
 
-:class:`analysis.topeft_run2.workflow.RunWorkflow` consumes the ``RunConfig``:
-:class:`SampleLoader` expands JSON/CFG inputs,
-:class:`ChannelPlanner` resolves metadata scenarios, and
-:class:`HistogramPlanner` enumerates the histogram tasks fed to the Coffea
-executors. Each task carries the metadata required to instantiate
-:class:`AnalysisProcessor`, including channel features and systematic labels.
-When ``summary_verbosity`` is ``"brief"`` or ``"full"``, the workflow emits the
-list of unique samples, channels, applications, and variation labels before
-submitting any work so you can confirm the run contents.
+- `(var, channel, application, sample, systematic)`
 
-Execution is delegated to :class:`analysis.topeft_run2.workflow.ExecutorFactory`.
-It builds either a local ``futures`` runner, the legacy ``iterative`` backend,
-or a distributed ``taskvine`` executor, forwarding the relevant knobs from the
-``RunConfig``. Each executor receives a fully configured ``AnalysisProcessor``
-instance together with the metadata bundle for that histogram task.
+Serialized output depends on executor path:
 
-The processor produces tuple-keyed histograms labelled as
-``(variable, channel, application, sample, systematic)``. The tuple contract is
-documented in detail in [tuple_key_audit.md](tuple_key_audit.md). Pickled outputs
-preserve those tuples so downstream helpers—such as
-``analysis/topeft_run2/make_cr_and_sr_plots.py`` or custom plotting scripts—can
-select channels and systematics without relying on categorical histogram axes.
-The [Run 2 quickstart pipeline](quickstart_run2.md) walks through this entire
-architecture with concrete commands.
+- TaskVine DDR default serialization: flat canonical tuples
+  `(sample, channel, var, application, systematic_label)`
+- Futures/iterative serialization: tuple keys as filled by processor
 
-## AnalysisProcessor responsibilities
+See [schemas.md](schemas.md) for the canonical contract.
 
-The :class:`AnalysisProcessor` class is a Coffea processor responsible for
-building selections, applying corrections, and filling histograms.  A few key
-aspects are worth keeping in mind when extending it:
+## Sidecars
 
-* **Channel metadata** – the processor expects the ``channel_dict`` passed by
-  the workflow to provide ``jet_selection``, ``chan_def_lst``, ``lep_flav_lst``,
-  ``appl_region`` and an optional ``features`` collection.  The flags are
-  derived from the active metadata scenarios (for example, the tau, forward, or
-  off-Z refinements) and inform specialised paths such as ``requires_tau`` or
-  ``offz_split``.
-* **Systematics** – the ``available_systematics`` mapping is produced by the
-  :class:`SystematicsHelper` inside the workflow.  It contains the full matrix of
-  weight variations, object shifts, and fake-factor toggles that the metadata
-  describes.  The processor caches both the tuple lists (for histogram
-  enumeration) and set views (for fast membership checks) so that custom
-  systematic categories can be added without rewriting the ``process`` method.
-  Newer Coffea releases no longer attach ``NanoEvents.caches`` objects, so the
-  Run 2 processor operates directly on the event record without relying on
-  cache-provided lazy arrays.
-* **Golden JSONs** – when processing data samples the workflow injects the
-  appropriate ``golden_json_path`` so that :class:`coffea.lumi_tools.LumiMask`
-  can be used directly inside the ``process`` method.  Missing entries raise a
-  ``ValueError`` before any event loop is started.
-* **Histogram keys** – the processor accepts either a single 5-tuple or a list
-  of tuples per systematic label.  The normalization in the constructor ensures
-  that the internal representation always uses ordered tuples, making it safe to
-  extend the histogram planning logic without breaking call sites.  The
-  pickled histograms keep the full ``(variable, channel, application, sample,
-  systematic)`` tuple so downstream data-driven estimation helpers (for
-  example :class:`topeft.modules.dataDrivenEstimation.DataDrivenProducer`)
-  receive the application tag without relying on categorical axes.
-* **Forward-jet bookkeeping** – forward-jet selections recompute the per-event
-  counts from their masks with ``ak.num`` and immediately cast them to numeric
-  arrays (filling missing entries with zeros) before histogramming so that
-  ``fwdjet_mask`` remains a flat boolean array even when events lack forward
-  jets.
-* **Jet multiplicities** – Run 2 histogram filling keeps the corrected jet
-  collection jagged and derives multiplicities with ``ak.num(cleaned_jets.pt,
-  axis=-1)`` immediately before applying jet-category selections.  The counts
-  are cast to 1D integer arrays with missing values filled as zeros so
-  comparisons such as ``exactly_4j`` or ``atmost_3j`` operate on per-event
-  scalars while retaining the jagged per-jet structure for other observables.
+Sidecar payloads are default-off (`produce_sidecars: false`).
 
-Because the constructor performs strict validation (checking for ``None``
-arguments, verifying tuple lengths, etc.), deviations are caught early.  The
-workflow reuses the same processor class for both quickstart and production runs,
-so new options should prefer optional keyword arguments with sensible defaults.
+- Enable creation with `produce_sidecars: true`.
+- Preserve sidecars in flattened DDR output with
+  `ddr_preserve_sidecars: true` and optional `ddr_sidecars_key`.
 
-## Systematic catalogue
+## Where detailed internals live
 
-Systematic variations originate from two sources and meet inside the workflow:
-
-* **Weight variations** – collected via
-  :func:`analysis.topeft_run2.run_analysis_helpers.weight_variations_from_metadata`
-  and attached to each sample during ``SampleLoader.load``.  The workflow checks
-  that every MC sample declares the required ``nSumOfWeights`` entries.
-* **Application variations** – defined in ``analysis/metadata/metadata.yml`` under
-  the ``systematics`` block.  :class:`SystematicsHelper` projects them onto the
-  selected channel features and returns a dictionary with the variations grouped
-  by type.  The processor interprets those labels to register weight and object
-  shifts.
-
-The workflow always starts the summary with compact bullet lists describing the
-unique samples, channel/application pairs, variables, and systematic labels that
-will be processed when ``RunConfig.summary_verbosity`` is ``"brief"`` or
-``"full"``.  Selecting ``"full"`` retains the per-combination table and
-structured YAML (or JSON) payload printed previously.  When
-``split_lep_flavor`` is enabled, the detailed table also reminds readers that
-flavored channels reuse the processor task constructed for their base channel.
-These summaries are particularly useful when validating that the requested
-systematics match team expectations after editing metadata.
-
-## Extending the workflow
-
-The helpers were designed to be replaced piecemeal.  A few concrete patterns are
-listed below:
-
-* **Custom executor backends** – subclass :class:`ExecutorFactory` or supply an
-  object exposing a compatible ``create_runner`` method.  The runner only needs
-  ``submit`` and ``finish`` methods, making it straightforward to integrate
-  site-specific schedulers.
-* **Selective histogram planning** – provide an alternate
-  :class:`HistogramPlanner` that filters variables or channels based on the
-  :class:`RunConfig`.  Because the planner builds :class:`HistogramTask`
-  instances, new metadata (for example, systematic tags) can be attached without
-  touching the executor or processor code.
-* **Channel overrides** – wrap :class:`ChannelPlanner` to inject or filter
-  metadata-driven channel groups programmatically.  This is useful for dry runs
-  that focus on validation categories or to introduce new experimental regions
-  while metadata changes are still under review.
-
-## Reusing the workflow from Python
-
-While ``run_analysis.py`` remains the canonical entry point, the module-level
-API makes it easy to script runs from notebooks or CI tasks:
-
-```python
-from analysis.topeft_run2.run_analysis import build_parser
-from analysis.topeft_run2.run_analysis_helpers import RunConfigBuilder
-from analysis.topeft_run2.workflow import run_workflow
-
-parser = build_parser()
-args = parser.parse_args([
-    "input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json",
-    "--options", "analysis/topeft_run2/configs/fullR2_run.yml:sr",
-])
-
-builder = RunConfigBuilder()
-config = builder.build(args, options_spec=args.options)
-run_workflow(config=config)
-```
-
-The ``config`` returned here is the same structure used by the quickstart
-utilities.  Persisting it (for example via ``dataclasses.asdict``) provides a
-compact audit trail that complements the stored output pickle.
-
-When ``--options`` is present the YAML file becomes authoritative and other CLI
-flags are rejected so the captured configuration remains reproducible. Drop the
-argument entirely for ad-hoc runs driven purely from the command line.
+- [Analysis processor data flow](analysis_processor_data_flow.md)
+- [DDR preprocess + proxy policy](ddr_preprocess_proxy_policy.md)
+- [CLI reference](run_analysis_cli_reference.md)

--- a/docs/analysis_processing.md
+++ b/docs/analysis_processing.md
@@ -1,42 +1,66 @@
 # Workflow and processor reference
 
-This page summarizes execution flow for `analysis/topeft_run2` and points to
-stable references for schema and data-flow details.
+This page summarizes workflow execution in `analysis/topeft_run2` at medium
+depth. It focuses on how configuration, metadata authority, planners, and
+executors connect. For processor internals and object-level runtime details,
+use [analysis_processor_data_flow.md](analysis_processor_data_flow.md).
 
-## End-to-end flow
+## Workflow execution overview
 
-1. `run_analysis.py` builds `RunConfig` from CLI/YAML.
-2. `metadata_authority.load_metadata_bundle(...)` resolves metadata/scenario.
-3. `SampleLoader` expands JSON/CFG inputs into `samplesdict` and filesets.
-4. `ChannelPlanner` and `HistogramPlanner` build histogram tasks.
-5. `ExecutorFactory` dispatches tasks through `futures`, `iterative`, or
-   TaskVine DDR.
-6. `AnalysisProcessor` applies selections/systematics and fills histograms.
+1. `run_analysis.py` parses CLI arguments and enforces options-only behavior.
+When `--options <path[:profile]>` is provided, options YAML becomes the single
+configuration source and conflicting CLI flags are rejected.
 
-## Internal keying vs serialized output
+2. `RunConfigBuilder` builds a normalized `RunConfig`.
+It merges YAML sections in this order: `defaults` -> selected `profiles`
+entry -> top-level passthrough keys. Without `--options`, explicit CLI values
+override parser defaults.
 
-Inside planning/processor code, histogram keys remain 5-tuples:
+3. Metadata and scenario are resolved through the single authority:
+`analysis/topeft_run2/metadata_authority.py`.
+`metadata_authority.load_metadata_bundle(...)` validates the selected scenario
+against canonical scenario definitions in
+`analysis/metadata/run2_scenarios.yaml`, resolves metadata source/provenance,
+and returns the bundle consumed by workflow planning.
 
-- `(var, channel, application, sample, systematic)`
+4. `SampleLoader` expands input specs into concrete samples:
+JSON files, CFG manifests, and directories are normalized into a `samplesdict`
+plus filesets. Numeric metadata fields are coerced early so planning/execution
+receive consistent types.
 
-Serialized output depends on executor path:
+5. Planning creates the executable histogram task graph:
+`ChannelPlanner` resolves scenario channel groups and feature tags from the
+metadata bundle, `SystematicsHelper` derives the variation matrix, and
+`HistogramPlanner` enumerates `(var, channel, application, sample, systematic)`
+combinations. `summary_verbosity` controls how much of this plan is logged.
 
-- TaskVine DDR default serialization: flat canonical tuples
+6. `ExecutorFactory` dispatches the plan:
+`futures` and `iterative` execute local runner tasks; `taskvine` uses
+Coffea Dynamic Data Reduction (DDR) manager/worker execution. TaskVine-specific
+settings (ports, manager naming, staging, DDR preprocess artifacts, proxy
+staging) are read from the same `RunConfig`.
+
+7. Output serialization depends on executor path:
+futures/iterative retain tuple-keyed processor outputs, while TaskVine DDR
+defaults to the canonical flat schema. Sidecars are off by default and can be
+preserved explicitly when flattening DDR output.
+
+8. Pretend-mode behavior is intentionally lightweight:
+with `pretend: true`, the workflow validates config + plan and exits before
+task submission and output writing.
+
+## Output schema at a glance
+
+- Processor/planner internal keys: `(var, channel, application, sample, systematic)`
+- TaskVine DDR default serialized keys:
   `(sample, channel, var, application, systematic_label)`
-- Futures/iterative serialization: tuple keys as filled by processor
+- Optional DDR tuple schema preserves tuple-style output for compatibility.
 
-See [schemas.md](schemas.md) for the canonical contract.
+See [schemas.md](schemas.md) for the authoritative schema contract and failure
+policies.
 
-## Sidecars
-
-Sidecar payloads are default-off (`produce_sidecars: false`).
-
-- Enable creation with `produce_sidecars: true`.
-- Preserve sidecars in flattened DDR output with
-  `ddr_preserve_sidecars: true` and optional `ddr_sidecars_key`.
-
-## Where detailed internals live
+## Detailed references
 
 - [Analysis processor data flow](analysis_processor_data_flow.md)
-- [DDR preprocess + proxy policy](ddr_preprocess_proxy_policy.md)
-- [CLI reference](run_analysis_cli_reference.md)
+- [CLI and YAML reference](run_analysis_cli_reference.md)
+- [DDR preprocess and proxy policy](ddr_preprocess_proxy_policy.md)

--- a/docs/analysis_processor_data_flow.md
+++ b/docs/analysis_processor_data_flow.md
@@ -1,0 +1,108 @@
+# AnalysisProcessor data flow
+
+This document describes the data flow inside
+`analysis/topeft_run2/analysis_processor.py` and how workflow-level planning
+connects to processor runtime behavior.
+
+## 1) Inputs from workflow planning
+
+`RunWorkflow` builds `AnalysisProcessor` instances with:
+
+- `sample`: single or multi-sample metadata mapping
+- `channel_dict`: resolved channel/app metadata from metadata authority
+- `hist_keys`: per-variation histogram-key payloads
+- `available_systematics`: grouped systematic definitions
+- `golden_json_path` / `golden_json_paths` for data samples
+- `produce_sidecars` gate (default false)
+
+For TaskVine DDR, workflow groups tasks into channel-keyed processors while
+passing sample maps and histogram tuples that are already systematic-aligned.
+
+## 2) DatasetContext resolution
+
+At event processing time, `_build_dataset_context()` resolves a
+`DatasetContext` object containing:
+
+- sample identity (`sample_name`, `sample_metadata`)
+- dataset/trigger dataset labels
+- data/MC/EFT flags
+- year, run-era, xsec/sum-of-weights
+- lumi mask/lumi values
+- EFT coefficient arrays when present
+
+Dataset resolution rules:
+
+- Primary lookup uses event metadata dataset name with alias support.
+- If multiple samples are configured and lookup fails, processing fails fast.
+- If exactly one sample exists, fallback is allowed with warning.
+
+## 3) Sample metadata mapping semantics
+
+`_normalise_sample_mapping()` allows both legacy single-sample and mapping
+inputs, then stores:
+
+- `_samples_by_name`: canonical per-sample metadata
+- `_sample_aliases`: dataset/histAxis alias map
+
+This supports DDR grouped processors that run multiple datasets through one
+processor instance while preserving per-sample metadata correctness.
+
+## 4) Golden JSON routing for data
+
+Golden JSON routing is sample-aware:
+
+- Constructor stores explicit `golden_json_paths` (preferred) or
+  legacy `golden_json_path` fallback.
+- Data samples without a configured path fail fast during initialization.
+- `_resolve_golden_json_path_for_sample()` resolves by sample name and alias,
+  then applies `LumiMask` in `_build_dataset_context()`.
+
+## 5) Histogram-key normalization and systematics
+
+`hist_keys` are normalized to ordered 5-tuples:
+
+- `(var, channel, application, sample, systematic)`
+
+Validation rules include:
+
+- every entry must be a 5-tuple
+- all keys for a processor instance must share variable/application
+- sample keys must map to configured sample metadata
+- flavored channel aliases must map back to base channel consistently
+
+`available_systematics` is stored both as ordered tuples and set views for
+fast membership checks in variation dispatch.
+
+## 6) Sidecar gating
+
+Sidecars are controlled by `produce_sidecars`:
+
+- default (`false`): histogram accumulator contains only histogram payloads
+- enabled (`true`): accumulator also includes
+  - `__topeft_variation_summary__`
+  - `region_yields`
+
+This gate is required for predictable DDR flattening output defaults.
+
+## 7) Accumulator contents by execution mode
+
+### Futures/iterative path
+
+Accumulator is emitted directly from processor execution and remains keyed by
+internal tuple keys `(var, channel, application, sample, systematic)`.
+
+### TaskVine DDR path
+
+DDR returns nested payloads (`processor_key -> dataset -> leaf_output`).
+Workflow then flattens (strictly) into canonical serialized output by default:
+
+- `(sample, channel, var, application, systematic_label)`
+
+The strict flatten layer enforces processor-key/tuple-key consistency and
+fail-fast collision behavior.
+
+## 8) Related references
+
+- [schemas.md](schemas.md)
+- [ddr_preprocess_proxy_policy.md](ddr_preprocess_proxy_policy.md)
+- [analysis_processing.md](analysis_processing.md)

--- a/docs/dataclasses_and_metadata.md
+++ b/docs/dataclasses_and_metadata.md
@@ -135,7 +135,8 @@ Use this checklist when introducing or modifying Run‑2 metadata:
 3. **Smoke-test the workflow**
    - Use the [Run 2 quickstart pipeline](quickstart_run2.md) or
      ``analysis/topeft_run2/full_run.sh`` with the updated YAML to confirm the
-     new metadata runs end to end (``--dry-run`` first, then a short futures pass).
+     new metadata runs end to end (for plan-only checks, set ``pretend: true`` in
+     the selected YAML profile before running the wrapper).
    - Keep scenario names consistent with ``run2_scenarios.yaml`` so CLI
      invocations and presets (like ``fullR2_run.yml:sr``) continue to work.
 4. **Share presets wisely**

--- a/docs/ddr_preprocess_proxy_policy.md
+++ b/docs/ddr_preprocess_proxy_policy.md
@@ -1,0 +1,62 @@
+# DDR preprocess and proxy policy
+
+This page documents TaskVine DDR operational behavior for preprocess artifacts
+and proxy handling.
+
+## Proxy handling policy
+
+When `ddr_x509_proxy` is configured:
+
+1. Workflow validates source path exists/is readable.
+2. Proxy is copied into TaskVine staging as exactly `proxy.pem`.
+3. `proxy.pem` is shipped with DDR tasks via `extra_files`.
+4. Worker environment is populated with:
+   - `X509_USER_PROXY=proxy.pem`
+
+This basename contract matches the TaskVine worker-side lookup pattern.
+
+## Preprocess reuse/save policy
+
+### Reuse mode
+
+Set `ddr_preprocessed_data: <path>` to load a preprocessed mapping from disk and
+skip `preprocess()`.
+
+### Save mode
+
+Set `ddr_save_preprocess: <path>` to persist preprocess output to the requested
+path.
+
+### Auto-save default
+
+If reuse is not requested and `ddr_auto_save_preprocess: true` (default):
+
+- artifact path defaults to
+  `taskvine-results/ddr_preprocessed_data.json`
+- can be overridden with `ddr_preprocess_artifact: <path>`
+
+Reuse precedence:
+
+- When reuse path is set, auto-save is not emitted unless an explicit save path
+  is also set.
+
+## Serialization format for preprocess artifacts
+
+`topcoffea.modules.dynamic_data_reduction.run_ddr` uses:
+
+1. JSON first (preferred, deterministic key sorting)
+2. cloudpickle fallback when payload is not JSON-serializable
+
+Loading follows the same order (JSON first, then cloudpickle fallback).
+
+## Where this behavior is implemented
+
+- topeft workflow orchestration:
+  `analysis/topeft_run2/workflow.py`
+- DDR helper load/save and preprocess control:
+  `topcoffea/modules/dynamic_data_reduction.py`
+
+## Related references
+
+- [schemas.md](schemas.md)
+- [run_analysis CLI reference](run_analysis_cli_reference.md)

--- a/docs/how_to_run_analysis_workflow.md
+++ b/docs/how_to_run_analysis_workflow.md
@@ -1,0 +1,67 @@
+# How to run an analysis workflow
+
+This is the operator-facing guide for current Run-2 execution.
+
+## Wrapper contract
+
+`analysis/topeft_run2/full_run.sh` is strict options-only.
+
+- Accepted: `--options <path[:profile]>`, `--help`
+- Rejected: all other flags
+
+Run all configuration from YAML options files.
+
+## Standard TaskVine DDR run (recommended)
+
+```bash
+cd analysis/topeft_run2
+./full_run.sh --options configs/fullR2_run.yml:sr
+```
+
+Recommended YAML defaults for production profiles:
+
+- `executor: taskvine`
+- `chunksize: 500000`
+- `ddr_output_schema: flat`
+- `produce_sidecars: false`
+
+## Preprocess reuse pattern
+
+Use YAML keys in the selected profile:
+
+- `ddr_preprocessed_data: <path>` to reuse/skip preprocess
+- `ddr_save_preprocess: <path>` to force save
+- `ddr_auto_save_preprocess: true` for deterministic auto-save
+- `ddr_preprocess_artifact: <path>` to override auto-save target
+
+Default deterministic artifact target (when auto-save is active and no override
+is set): `taskvine-results/ddr_preprocessed_data.json`.
+
+## Proxy policy
+
+Set `ddr_x509_proxy` in YAML.
+
+- Workflow copies proxy to `proxy.pem` in TaskVine staging
+- Worker env gets `X509_USER_PROXY=proxy.pem`
+
+## Debug profiles
+
+Keep separate YAML profiles for debug flows:
+
+- Futures debug profile: `executor: futures`, limited `nchunks`
+- Iterative smoke profile: `executor: iterative`, tiny chunks
+- Plan-only profile: `pretend: true`
+
+Invoke the same wrapper command with the chosen profile suffix.
+
+## Equivalent CLI logging
+
+`run_analysis.py` now logs an equivalent command without `--options` after
+config resolution. This is informational only and helps auditing resolved values.
+
+## Related references
+
+- [Schema reference](schemas.md)
+- [DDR preprocess/proxy policy](ddr_preprocess_proxy_policy.md)
+- [Analysis processor data flow](analysis_processor_data_flow.md)
+- [CLI reference](run_analysis_cli_reference.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,8 @@ overlapping quickstarts.
 
 - [Workflow and YAML hub](workflow_and_yaml_hub.md) – **Start here** for
   prerequisites, YAML merging, and executor choices.
+- [How to run an analysis workflow](how_to_run_analysis_workflow.md) –
+  options-first operator guide for `full_run.sh`.
 - [Run 2 quickstart pipeline](quickstart_run2.md) – Primary end-to-end Run‑2
   walkthrough (environment → run → plot).
 - [Run and plot quickstart](run_and_plot_quickstart.md) – Legacy plotting
@@ -22,6 +24,10 @@ overlapping quickstarts.
   walkthrough of CLI/YAML merging and workflow helpers.
 - [`run_analysis.py` CLI and YAML reference](run_analysis_cli_reference.md) –
   Flag-by-flag lookup table.
+- [Schema reference](schemas.md) – Canonical internal/output schema contracts
+  and DDR flattening fail-fast rules.
+- [DDR preprocess + proxy policy](ddr_preprocess_proxy_policy.md) – TaskVine
+  operational defaults for proxy staging and preprocess artifacts.
 - [TaskVine workflow quickstart](taskvine_workflow.md) – Distributed executor
   focus, including environment packaging pointers.
 - [Datacard fitting workflow](fitting.md) – Canonical handoff from histogram
@@ -55,6 +61,8 @@ overlapping quickstarts.
 
 - [Workflow and processor reference](analysis_processing.md) – Processor ↔
   workflow architecture and execution flow.
+- [Analysis processor data flow](analysis_processor_data_flow.md) – Detailed
+  `AnalysisProcessor` runtime flow from dataset context to accumulator output.
 - [Tuple key audit](tuple_key_audit.md) – 5‑tuple conventions for histogram
   keys across the repository.
 - [Run 2 legacy notes](run2_legacy_notes.md) – Maintainer-focused legacy

--- a/docs/quickstart_run2.md
+++ b/docs/quickstart_run2.md
@@ -1,274 +1,79 @@
 # Run 2 quickstart pipeline
 
-This is the single entry point for running a small Run‑2 job end to end: prepare
-an input JSON, launch the helper or wrapper, then make a first plot. It assumes
-you have already read the [workflow & YAML hub](workflow_and_yaml_hub.md) and
-set up the shared `coffea2025` environment plus the sibling
-[`topcoffea`](https://github.com/TopEFT/topcoffea) checkout.
+This quickstart is the shortest path from sample JSON to a first output pickle.
+It uses the options-first wrapper and mirrors current TaskVine DDR defaults.
 
 ## Prerequisites
 
-1. Follow the “Start here” hub to create/activate the shared environment, install
-   both repositories in editable mode, and build the TaskVine environment
-   tarball (when needed).
-2. Keep `topcoffea` on a coordinated ref (matching release tags or aligned
-   feature refs) so cache-free jet/MET corrections match the workflow
-   expectations. For compatibility policy, see
-   `topcoffea/docs/topeft_integration.md`.
-3. Pick a sample manifest such as
-   `input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json`. The
-   helper accepts directories and `.cfg` bundles as well; see
-   [sample_metadata_reference.md](sample_metadata_reference.md) for schema
-   details.
-
-With the prerequisites in place, you can validate the workflow locally in a few
-minutes using the quickstart module below.
-
-### Cache-free jet/MET corrections
-
-Run 2 processing now assumes the cache-free jet and MET correction interfaces
-provided by coordinated `topcoffea` refs. The helper and full workflow no
-longer rely on NanoEvents caches when building corrected jets or propagating jet
-variations into MET; the updated APIs materialise the corrections directly. Make
-sure your environment uses a matching `topcoffea` checkout (or a release
-containing the same cache-free helpers) so the processor can run end-to-end
-without attaching a `lazy_cache` to the NanoEvents object.
-
-Run 2 histogramming expects Awkward's native implementations of helpers such as
-`ak.stack` and relies on in-memory arithmetic instead of array-of-arrays
-coercions. Ensure your environment pulls a recent Awkward build (the Coffea
-2025.7 bundle does) so the masks remain regular arrays; Awkward 2.x is the
-supported baseline. B-tag and jet multiplicities are derived directly from
-numeric fields (for example, ``ak.num(cleaned_jets.pt)`` with ``ak.fill_none``
-and integer casts) rather than cached Records, so custom pre-processing that
-produces jagged or optional counts will raise during histogram filling.
-
-## Step 1 – Run the quickstart helper
-
-Launch the lightweight helper module from the repository root:
+1. Activate the shared `coffea2025` environment.
+2. Install `topeft` and sibling `topcoffea` checkouts in editable mode.
+3. If running TaskVine profiles, prepare the environment tarball:
 
 ```bash
-python -m topeft.quickstart \
-    input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \
-    --prefix root://cmsxrootd.fnal.gov/ \
-    --output quickstart-output
+python -m topcoffea.modules.remote_environment
 ```
 
-The helper:
+## Step 1: run a tiny local smoke test
 
-1. Resolves the manifest (directories and `.cfg` bundles also work), validates
-   the requested scenario, and prints a summary of the discovered samples.
-2. Runs a trimmed `AnalysisProcessor` job with `nchunks=2`, a local futures
-   executor, and a single histogram so the end-to-end test finishes quickly.
+Use a futures debug profile in YAML and launch via wrapper:
 
-The output histogram pickle is stored in the requested directory:
-`quickstart-output/quickstart.pkl.gz`.
-
-## Step 2 – Try the unified run wrapper
-
-When you want to exercise the full workflow, use
-`analysis/topeft_run2/full_run.sh`. It expands the `run2`/`run3` presets,
-resolves cfg/json bundles, and selects sensible defaults for both TaskVine and
-futures executors.
-
-```
+```bash
 cd analysis/topeft_run2
-./full_run.sh --sr -y UL17 \
-    --executor futures \
-    --samples ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \
-    --outdir histos/local_debug \
-    --tag quickstart --dry-run
+./full_run.sh --options configs/fullR2_run.yml:sr
 ```
 
-Drop `--dry-run` to execute the command. TaskVine is still the default backend;
-append `--executor taskvine` (and make sure workers connect with the advertised
-manager name) to run distributed jobs. The wrapper honours the `fullR2_run.yml`
-profiles by default and selects SR/CR bundles based on the `--sr/--cr` choice.
+For lightweight smoke tests, keep a dedicated YAML profile with:
 
-## Step 3 – Plot the results
+- `executor: futures` (or `iterative`)
+- small `nchunks`
+- small `chunksize`
+- `pretend: true` for plan-only validation
 
-Once a helper or wrapper run finishes you will have tuple-keyed histogram
-pickles such as `histos/local_debug/plotsTopEFT.pkl.gz` (wrapper) or
-`quickstart-output/quickstart.pkl.gz` (module). Use the existing plotting helper
-to turn them into quick validation plots:
+The wrapper accepts only `--options`; all tuning must be done in YAML.
+
+## Step 2: run TaskVine DDR profile
+
+Switch to a TaskVine production profile in YAML:
+
+- `executor: taskvine`
+- `chunksize: 500000`
+- `ddr_output_schema: flat`
+
+Then launch:
+
+```bash
+cd analysis/topeft_run2
+./full_run.sh --options configs/fullR2_run.yml:cr
+```
+
+## Step 3: inspect outputs
+
+Output schema depends on executor path:
+
+- TaskVine DDR serialized output defaults to flat canonical tuples:
+  `(sample, channel, var, application, systematic_label)`
+- Futures/iterative outputs are tuple-keyed:
+  `(var, channel, application, sample, systematic)`
+
+See [schemas.md](schemas.md) for complete details.
+
+## Step 4: plot
 
 ```bash
 cd analysis/topeft_run2
 python make_cr_and_sr_plots.py \
-    -f histos/local_debug/plotsTopEFT.pkl.gz \
-    -o plots/local_debug \
-    -n plots \
-    -y 2017 \
-    --skip-syst
+  -f histos/plotsTopEFT.pkl.gz \
+  -o plots/quickstart \
+  -n plots \
+  -y 2017 \
+  --skip-syst
 ```
 
-For notebook-driven checks you can also materialise the tuple summaries from
-Python:
+## Metadata/scenario authority
 
-```python
-import gzip, pickle
-from topeft.modules.runner_output import materialise_tuple_dict
+Run-2 scenario resolution is controlled by:
 
-with gzip.open("histos/local_debug/plotsTopEFT.pkl.gz", "rb") as handle:
-    tuple_summary = materialise_tuple_dict(pickle.load(handle))
-print(list(tuple_summary.items())[:2])
-```
+- `analysis/metadata/run2_scenarios.yaml`
+- `analysis/topeft_run2/metadata_authority.py`
 
-Both paths assume the stored histogram tuples follow the canonical
-`(variable, channel, application, sample, systematic)` convention described in
-[analysis_processing.md](analysis_processing.md).
-
-## Understanding the quickstart inputs
-
-### Samples JSON
-
-The quickstart helpers use the same JSON description as the full workflow.
-Refer to the [sample metadata reference](sample_metadata_reference.md) for a
-complete breakdown of required keys, optional systematic sums of weights, and
-common validation fixes.  A minimal example targeting a public CMS Run 2 file is
-shown below:
-
-```json
-{
-  "xsec": 0.2151,
-  "year": "2017",
-  "treeName": "Events",
-  "histAxisName": "ttHJet_UL17_quickstart",
-  "files": [
-    "/store/mc/RunIISummer20UL17NanoAODv9/TTZToLLNuNu_M-10_TuneCP5_13TeV-amcatnlo-pythia8/\n     NANOAODSIM/106X_mc2017_realistic_v9-v1/130000/0A1884EE-9F60-6F4F-B423-13F6179B611D.root"
-  ],
-  "nEvents": 418590,
-  "nGenEvents": 418590,
-  "nSumOfWeights": 418590,
-  "isData": false
-}
-```
-
-Saving the snippet as ``ttz_quickstart.json`` allows you to run the helper with
-``python -m topeft.quickstart ttz_quickstart.json --prefix root://cmsxrootd.fnal.gov/``.
-The prefix ensures that the remote EOS path is opened via XRootD.
-
-## Metadata configuration
-
-Quickstart jobs lean entirely on ``analysis/metadata/metadata.yml`` to decide which
-regions, histograms, and weight variations to run.  Before editing the file,
-consult the [metadata configuration guide](run_analysis_configuration.md#metadata-configuration)
-for a full breakdown of each section.  The highlights are:
-
-* ``channels.groups`` enumerate the signal/control regions and include any
-  per-region histogram include/exclude lists.
-* ``variables`` provides the histogram catalogue (binning, labels, callable
-  definitions) consumed by the Coffea processor.
-* ``scenarios`` expose friendly names that map to channel bundles and power the
-  ``--scenario`` flag used throughout the quickstarts.
-* ``systematics`` lists the available weight/object variations.  The helper
-  inspects this block whenever ``--do-systs`` is requested.
-
-To test custom metadata, copy ``analysis/metadata/metadata.yml`` to a new location,
-edit the clone, and pass it to the helper via ``--metadata``.  Keeping the clone
-under version control (for example ``analysis/topeft_run2/configs/metadata_dev.yml``)
-makes it easy to promote the same configuration to the full workflow once the
-quickstart validation looks good.  When you are ready to run
-``analysis/topeft_run2/run_analysis.py``, reference the same clone from a YAML
-profile launched with ``--options`` by adding ``metadata: configs/metadata_dev.yml``
-near the top of the file.  This keeps custom metadata tied to the profile while
-allowing the CLI to keep relying on the scenario registry for standard runs.
-
-### Metadata scenarios
-
-The Run 2 metadata (``analysis/metadata/metadata.yml``) defines the channel bundles
-exposed by the quickstart helpers.  Channel activation is now controlled solely
-through the scenario list:
-
-* ``TOP_22_006`` – Baseline reinterpretation categories, including the refined
-  off-Z trilepton split.
-* ``tau_analysis`` – Extends the baseline with the tau-enriched regions.
-* ``fwd_analysis`` – Adds the forward-jet selections on top of the shared
-  control suite.  Forward-jet counts are recomputed as integer per-event
-  tallies before histogramming to avoid Awkward broadcasting pitfalls.
-
-Pass ``--scenario`` one or more times to request the combinations you need.  For
-example, ``--scenario TOP_22_006 --scenario tau_analysis`` layers the tau
-categories onto the baseline job, while adding ``--scenario fwd_analysis`` in
-the same command keeps the forward selections active as well.  For a
-step-by-step walkthrough of each scenario—including how to mix them in YAML—see
-the [Run 2 metadata scenarios guide](run2_scenarios.md).
-
-During :func:`prepare_samples`, the scenario names are validated via the
-:class:`analysis.topeft_run2.workflow.ChannelPlanner`.  Passing unknown
-identifiers raises a ``ValueError`` before any processing starts so that
-misconfigurations are caught early.
-
-### Next steps {#run2-quickstart-next-steps}
-
-!!! note "Next steps"
-    Keep the workflow lightweight while layering on additional validation
-    targets.  The [Run 2 metadata scenarios guide](run2_scenarios.md) walks
-    through each bundle in detail.  To reuse this helper for the tau- or
-    forward-focused reinterpretations, add the scenario switches directly on the
-    command line:
-
-    ```bash
-    python -m topeft.quickstart \
-        input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \
-        --prefix root://cmsxrootd.fnal.gov/ \
-        --scenario tau_analysis
-    ```
-
-    Swap ``tau_analysis`` for ``fwd_analysis`` to validate the forward
-    categories, or request both in a single run when you want to confirm the
-    combined configuration:
-
-    ```bash
-    python -m topeft.quickstart \
-        input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \
-        --prefix root://cmsxrootd.fnal.gov/ \
-        --scenario TOP_22_006 \
-        --scenario tau_analysis \
-        --scenario fwd_analysis
-    ```
-
-    To keep the combined scenario close at hand for the full workflow, mirror
-    the same list in a YAML override for :mod:`run_analysis.py` before scaling
-    up.  Start by copying ``analysis/topeft_run2/configs/fullR2_run.yml`` to
-    ``analysis/topeft_run2/configs/fullR2_run_tau_fwd.yml`` so all of the other
-    defaults remain aligned, then update the new file's metadata pointer, sample
-    list, and scenarios as shown below:
-
-    ```yaml
-    # analysis/topeft_run2/configs/fullR2_run_tau_fwd.yml
-    metadata: configs/metadata_dev.yml
-    # (clone analysis/metadata/metadata.yml to configs/metadata_dev.yml before editing)
-    jsonFiles:
-      - ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json
-    scenarios:
-      - TOP_22_006
-      - tau_analysis
-      - fwd_analysis
-    ```
-
-    Launching ``python run_analysis.py --options configs/fullR2_run_tau_fwd.yml``
-    keeps the validation fast while aligning the configuration with the
-    quickstart dry run.  To activate an alternate profile defined in the same
-    YAML, append the desired name after a colon—for example,
-    ``--options configs/fullR2_run.yml:sr`` selects the signal-region preset.
-    Remember that once ``--options`` is provided, command-line flags are ignored
-    in favour of the YAML contents, so bake any overrides into the file before
-    submitting the run.
-
-### Systematic toggles
-
-Systematic variations are disabled by default to keep the run lightweight.
-Add ``--do-systs`` when you want to exercise the same code paths used in the
-full analysis.  The helper automatically inspects
-``analysis/metadata/metadata.yml`` to determine which sum-of-weights variations are
-available and enables them in the Coffea processor.  Because only a single
-histogram is processed, enabling systematics keeps the runtime manageable while
-still producing variations in the output pickle.
-
-When you are ready to explore more advanced options, you can pass the same
-arguments used by the main workflow (``--split-lep-flavor``, ``--skip-sr``,
-``--skip-cr`` and custom ``--wc`` lists are all supported by the helper).  Any
-run generated through the quickstart utilities is reproducible via the returned
-:class:`analysis.topeft_run2.run_analysis_helpers.RunConfig`, which records all
-relevant switches.
+For wrapper-driven runs, place `scenarios:` in YAML options.

--- a/docs/run2_scenarios.md
+++ b/docs/run2_scenarios.md
@@ -14,8 +14,8 @@ Two layers work together:
   resolve scenarios and metadata paths through `metadata_authority`, which is
   the single authority for `--scenario` and YAML profiles.
 
-When `run_analysis.py` or `full_run.sh` receives a `--scenario` value, the
-workflow:
+When `run_analysis.py` resolves a scenario (or when a wrapper-selected YAML
+profile provides `scenarios:`), the workflow:
 
 1. Resolves the scenario through `metadata_authority.py` to find the metadata
    document and scenario definition.
@@ -42,7 +42,7 @@ metadata bundle.
 
 ## Combining scenarios
 
-Scenarios can be combined on the CLI or inside YAML:
+Scenarios can be combined on the CLI (without `--options`) or inside YAML:
 
 ```bash
 python analysis/topeft_run2/run_analysis.py \
@@ -71,8 +71,8 @@ profiles:
 ```
 
 Remember that the CLI enforces a mutual exclusion rule: `--scenario` cannot be
-combined with `--options`. The wrapper (`full_run.sh`) surfaces the same guard
-for convenience.
+combined with `--options`. The wrapper is options-only, so scenario selection
+for wrapper launches must be encoded in YAML.
 
 ## Adding or modifying a scenario
 
@@ -99,6 +99,6 @@ for convenience.
    the validators also echo the SR-channel counts (43 / 68 / 48 / 121 / 148),
    providing a quick sanity check that your metadata has not drifted.
 
-By following these steps the CLI, quickstart helpers, and `full_run.sh` wrapper
-will all recognize the scenario automatically, keeping the Run‑2 documentation
-and workflow in sync with the metadata source of truth.
+By following these steps, CLI and options-driven wrapper launches will recognize
+the scenario automatically, keeping Run‑2 documentation and workflow behavior in
+sync with the metadata source of truth.

--- a/docs/run_analysis_cli_reference.md
+++ b/docs/run_analysis_cli_reference.md
@@ -1,93 +1,101 @@
 # `run_analysis.py` CLI and YAML reference
 
-This page is the authoritative flag reference for
+This page is the authoritative CLI and options-YAML mapping for
 `analysis/topeft_run2/run_analysis.py`.
+
+The single metadata/scenario authority is
+`analysis/topeft_run2/metadata_authority.py`, with canonical scenario
+definitions in `analysis/metadata/run2_scenarios.yaml`.
 
 ## Options exclusivity rule
 
-When `--options <path[:profile]>` is provided, options YAML is the only
-configuration source.
+When `--options <path[:profile]>` is present, options YAML is the single source
+of truth.
 
-- Allowed alongside `--options`: `--help` (and `--version` only if present).
-- Disallowed alongside `--options`: all other config flags, including
-  `--metadata`, `--executor`, `--chunksize`, `--scenario`, `--pretend`, etc.
+- Allowed with `--options`: `--help` and `--version` (only if the parser
+  exposes `--version`).
+- Disallowed with `--options`: all other config flags, including `--metadata`,
+  `--executor`, `--chunksize`, `--scenario`, `--pretend`, etc.
+- Wrapper note: `analysis/topeft_run2/full_run.sh` is stricter and accepts only
+  `--options` and `--help`.
 
-## Key defaults
+## CLI to YAML mapping
 
-- `--executor`: `taskvine`
-- `--chunksize`: `500000`
-- `--ddr-output-schema`: `flat`
-- `--produce-sidecars`: disabled
+Keys marked with `*` are accepted aliases for backward compatibility in YAML.
 
-## Core flags
+| CLI flag(s) | YAML key(s) | Type after coercion | Default | Notes |
+| --- | --- | --- | --- | --- |
+| `jsonFiles` (positional) | `jsonFiles`, `json_files`* | list of strings | `[]` | Accepts one path, comma-separated string, or YAML list. |
+| `--options` | n/a (selector) | `path[:profile]` string | unset | Selects options file/profile. Not a `RunConfig` value by itself. |
+| `--prefix`, `-r` | `prefix` | string | `""` | Prefix/redirector applied during sample loading. |
+| `--executor`, `-x` | `executor` | string | `taskvine` | Supported: `taskvine`, `futures`, `iterative`. |
+| `--test`, `-t` | `test` | bool | `false` | Fast smoke mode; only local executors support this path. |
+| `--pretend` | `pretend` | bool | `false` | Validates configuration and histogram plan, then exits before execution/output write. |
+| `--nworkers`, `-n` | `nworkers` | int | `8` | Worker count used by workflow execution paths. |
+| `--futures-workers` | n/a | int | `8` | Parsed by shared executor helper but currently not consumed by `run_analysis.py`; use `nworkers`. |
+| `--chunksize`, `-s` | `chunksize` | int | `500000` | Events per chunk. |
+| `--nchunks`, `-c` | `nchunks` | optional int | `None` | Maximum number of chunks to process. |
+| `--outname`, `-o` | `outname` | string | `plotsTopEFT` | Output filename stem. |
+| `--outpath`, `-p` | `outpath` | string | `histos` | Output directory. |
+| `--treename` | `treename` | string | `Events` | Input tree name. |
+| `--metadata` | `metadata`, `metadata_path`* | optional string | `None` | CLI metadata path. Forbidden when `--options` is supplied. |
+| `--scenario` (repeatable) | `scenarios` | list of strings | `TOP_22_006` when unset | Scenario names resolved through `metadata_authority`. |
+| `--allow-partial-channel-groups` | `allow_partial_channel_groups` | bool | `false` | When true, missing scenario channel groups do not fail run construction. |
+| `--skip-sr` | `skip_sr` | bool | `false` | Skip signal-region channels. |
+| `--skip-cr` | `skip_cr` | bool | `false` | Skip control-region channels. |
+| `--do-errors` | `do_errors` | bool | `false` | Save squared-weight coefficients. |
+| `--do-systs` | `do_systs` | bool | `false` | Enable systematic variations. |
+| `--split-lep-flavor` | `split_lep_flavor` | bool | `false` | Split channels by lepton flavor where configured. |
+| `--summary-verbosity` | `summary_verbosity` | enum (`none`, `brief`, `full`) | `brief` | Controls pre-execution histogram summary detail. |
+| `--log-level` | `log_level` | optional enum (`none`, `info`, `warning`, `error`, `debug`) | `None` (effective `INFO`) | Driver-process logging level. |
+| `--log-tasks` | `log_tasks` | bool | `false` | Emit one-line task submission logs (futures path). |
+| `--wc-list` | `wc_list` | list of strings | `[]` | Wilson coefficients to evaluate; duplicates removed preserving order. |
+| `--ecut` | `ecut` | optional float | `None` | Event-level energy cut (GeV). |
+| `--do-np` | `do_np` | bool | `false` | Run nonprompt estimation post-processing. |
+| `--do-renormfact-envelope` | `do_renormfact_envelope` | bool | `false` | Requires `do_np` and `do_systs`. |
+| `--port` | `port` | string | `9123-9130` | TaskVine manager port/range. |
+| `--no-port-negotiation` | `negotiate_manager_port` | bool | negotiation enabled (`true`) | Flag disables fallback port negotiation. |
+| `--manager-name` | `manager_name` | optional string | `None` | Explicit TaskVine manager name. |
+| `--manager-name-template` | `manager_name_template` | optional string | `None` | Template with `{pid}` support. |
+| `--scratch-dir` | `scratch_dir`, `scratch_path`* | optional string | `None` | Shared staging directory for distributed execution. |
+| `--resource-monitor` | `resource_monitor` | optional string | `measure` | TaskVine resource monitor mode. |
+| `--resources-mode` | `resources_mode` | optional string | `auto` | TaskVine resource mode. |
+| `--environment-file` | `environment_file` | optional string | `cached` | Remote environment tarball selection (`cached`, `auto`, `none`, or path). |
+| `--no-environment-file` | `environment_file` | optional string | n/a | Alias for `--environment-file none`. |
+| `--taskvine-print-stdout`, `--no-taskvine-print-stdout` | `taskvine_print_stdout` | bool | `true` | Forward worker stdout to manager logs. |
+| `--futures-status`, `--no-futures-status` | `futures_status` | optional bool | `None` | Toggle futures progress status output. |
+| `--futures-tail-timeout` | `futures_tail_timeout` | optional int | `None` | Timeout for stalled futures tasks. |
+| `--futures-memory` | `futures_memory` | optional int | `None` | Memory hint used by futures path. |
+| `--futures-prefetch` | `futures_prefetch` | optional int | `1` | Number of files prefetched by futures path (`0` disables). |
+| `--futures-retries` | `futures_retries` | int | `0` | Retries per futures task before abort. |
+| `--futures-retry-wait` | `futures_retry_wait` | float | `5.0` | Seconds between futures retries. |
+| `--produce-sidecars`, `--no-produce-sidecars` | `produce_sidecars` | bool | `false` | Include sidecar payloads in processor outputs. |
+| `--ddr-processor-key-delim` | `ddr_processor_key_delim` | string | `-` | Delimiter for DDR-generated key labels. |
+| `--ddr-output-schema` | `ddr_output_schema` | enum (`flat`, `tuple`) | `flat` | `flat` is canonical default for TaskVine DDR serialized output. |
+| `--ddr-preserve-sidecars`, `--no-ddr-preserve-sidecars` | `ddr_preserve_sidecars` | bool | `false` | Preserve sidecars when flattening DDR output. |
+| `--ddr-sidecars-key` | `ddr_sidecars_key` | string | `__sidecars__` | Reserved top-level key for preserved sidecars. |
+| `--ddr-step-size` | `ddr_step_size` | optional int | `None` | Defaults to `chunksize` when unset. |
+| `--ddr-max-task-retries` | `ddr_max_task_retries` | optional int | `None` | Maximum DDR task retries. |
+| `--ddr-results-directory` | `ddr_results_directory` | optional string | `None` | Override DDR results directory path. |
+| `--ddr-verbose`, `--no-ddr-verbose` | `ddr_verbose` | optional bool | `None` | DDR-layer verbose logging toggle. |
+| `--ddr-x509-proxy` | `ddr_x509_proxy` | optional string | `None` | Proxy source path; staged as `proxy.pem` for workers. |
+| `--ddr-preprocessed-data` | `ddr_preprocessed_data` | optional string | `None` | Reuse preprocess artifact and skip preprocess step. |
+| `--ddr-save-preprocess` | `ddr_save_preprocess` | optional string | `None` | Save preprocess artifact after preprocess step. |
+| `--ddr-auto-save-preprocess`, `--no-ddr-auto-save-preprocess` | `ddr_auto_save_preprocess` | bool | `true` | Auto-save preprocess artifact when reuse is not requested. |
+| `--ddr-preprocess-artifact` | `ddr_preprocess_artifact` | optional string | `None` | Override deterministic auto-save preprocess path. |
 
-| Flag | Default | Notes |
-| --- | --- | --- |
-| `jsonFiles` (positional) | empty | JSON/CFG input specs when not using YAML-only profiles. |
-| `--options` | unset | YAML file path or `path.yml:profile`. |
-| `--executor` | `taskvine` | `taskvine`, `futures`, `iterative`. |
-| `--chunksize` | `500000` | Events per chunk. |
-| `--nchunks` | unset | Cap processed chunks. |
-| `--nworkers` | `8` | Worker count. |
-| `--outname` | `plotsTopEFT` | Output file stem. |
-| `--outpath` | `histos` | Output directory. |
-| `--treename` | `Events` | Input tree. |
-| `--scenario` | `TOP_22_006` when omitted | Scenario name; YAML profiles should encode this. |
-| `--metadata` | unset | Metadata path when not using `--options`. |
-| `--summary-verbosity` | `brief` | `none`, `brief`, `full`. |
-| `--produce-sidecars` | `false` | Enables sidecar creation in processor outputs. |
+## YAML-only helper keys
 
-## TaskVine/distributed flags
+These keys control options-file composition and do not correspond to CLI flags.
 
-| Flag | Default | Notes |
-| --- | --- | --- |
-| `--port` | `9123-9130` | Manager port/range. |
-| `--no-port-negotiation` | false | Disable manager port scanning fallback. |
-| `--manager-name` | unset | Explicit manager name. |
-| `--manager-name-template` | unset | Template with `{pid}` support. |
-| `--scratch-dir` | unset | Shared staging path. |
-| `--resource-monitor` | `measure` | TaskVine monitor mode. |
-| `--resources-mode` | `auto` | TaskVine resources mode. |
-| `--environment-file` | `cached` | Remote env tarball selection. |
-| `--taskvine-print-stdout` | true | Forward worker stdout. |
+| YAML key | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `defaults` | mapping | `{}` | Applied first. |
+| `profiles` | mapping of mappings | `{}` | Named overlays selected by `path.yml:profile`. |
+| `default_profile` | optional string | `None` | Used when profile suffix is omitted. |
 
-## Futures/iterative debug flags
-
-| Flag | Default | Notes |
-| --- | --- | --- |
-| `--futures-workers` | executor default | Local process count override. |
-| `--futures-status` | executor default | Progress bar toggle. |
-| `--futures-tail-timeout` | unset | Timeout for stalled task cancellation. |
-| `--futures-memory` | unset | Memory hint for dynamic chunking. |
-| `--futures-prefetch` | `1` | Input prefetch count. |
-| `--futures-retries` | `0` | Retry count. |
-| `--futures-retry-wait` | `5.0` | Seconds between retries. |
-
-## DDR flags
-
-These apply to TaskVine DDR mode.
-
-| Flag | Default | Notes |
-| --- | --- | --- |
-| `--ddr-processor-key-delim` | `-` | Delimiter for processor key schema `<channel><delim><var><delim><application><delim><systematic_label>`. |
-| `--ddr-output-schema {flat,tuple}` | `flat` | `flat` is canonical default; `tuple` preserves tuple-style output schema. |
-| `--ddr-preserve-sidecars` | false | Preserve non-hist sidecars under reserved key during flattening. |
-| `--ddr-sidecars-key` | `__sidecars__` | Reserved key for preserved sidecars. |
-| `--ddr-step-size` | unset | Defaults to `--chunksize` when unset. |
-| `--ddr-max-task-retries` | unset | DDR task retries. |
-| `--ddr-results-directory` | unset | Override DDR results directory. |
-| `--ddr-verbose` | unset | DDR-layer verbose toggle. |
-| `--ddr-x509-proxy` | unset | Proxy source path; staged as `proxy.pem`. |
-| `--ddr-preprocessed-data` | unset | Reuse preprocess mapping from disk and skip preprocess. |
-| `--ddr-save-preprocess` | unset | Save preprocess mapping after preprocess step. |
-| `--ddr-auto-save-preprocess` | true | Auto-save preprocess mapping when reuse is not requested. |
-| `--ddr-preprocess-artifact` | unset | Override deterministic auto-save path target. |
-
-## Output schema note
-
-- TaskVine DDR serialized output defaults to flat canonical tuples:
-  `(sample, channel, var, application, systematic_label)`.
-- Futures/iterative outputs remain tuple-keyed:
-  `(var, channel, application, sample, systematic)`.
-
-See [schemas.md](schemas.md) for full schema contract and fail-fast policies.
+Additional YAML-only advanced runtime keys are accepted by `RunConfigBuilder`
+for DDR internals (for example `ddr_resources_processing`,
+`ddr_environment_variables`, `ddr_preprocess_kwargs`, `ddr_kwargs`) when a
+profile needs settings that are intentionally not exposed as top-level CLI
+switches.

--- a/docs/run_analysis_cli_reference.md
+++ b/docs/run_analysis_cli_reference.md
@@ -1,93 +1,93 @@
 # `run_analysis.py` CLI and YAML reference
 
-This page summarises every command-line flag and YAML key understood by
-[`analysis/topeft_run2/run_analysis.py`](../analysis/topeft_run2/run_analysis.py) via
-`RunConfigBuilder`.  Use it as a quick lookup when preparing reproducible
-profiles or translating ad-hoc commands into a shared configuration file.  The
-[Run analysis configuration flow](run_analysis_configuration.md) guide walks
-through the broader execution pipeline, including how the metadata and executor
-helpers consume these values.
+This page is the authoritative flag reference for
+`analysis/topeft_run2/run_analysis.py`.
 
-## How to read this reference
+## Options exclusivity rule
 
-* **Precedence** – When `--options` is supplied, the selected YAML profile is the
-  single source of truth.  Every CLI flag listed below is ignored so the run
-  stays reproducible, and `--options` cannot be combined with `--metadata`.
-  Drop `--options` when you want to experiment with temporary command-line
-  overrides.  `RunConfigBuilder` performs this check before reading CLI
-  attributes.【F:analysis/topeft_run2/run_analysis_helpers.py†L347-L415】
-* **YAML profiles** – Options files support three top-level sections:
-  * `defaults`: a mapping applied unconditionally.
-  * `profiles`: a mapping of profile names to overrides.  Select one with
-    `path.yml:profile`.  When omitted the builder falls back to
-    `default_profile` or the only profile in the file.
-  * Additional keys outside these sections act as last-minute overrides.
+When `--options <path[:profile]>` is provided, options YAML is the only
+configuration source.
 
-  These sections are merged in the order listed above so that profiles can
-  extend the shared defaults.  See the configuration flow guide for a narrative
-  walkthrough of profile usage and metadata integration.【F:analysis/topeft_run2/run_analysis_helpers.py†L347-L415】【F:docs/run_analysis_configuration.md†L1-L63】
-* **Types** – Values are normalised into the `RunConfig` dataclass.  YAML lists
-  and strings are accepted interchangeably for sequence-like fields such as
-  `scenarios` and `wc_list`.  Integers and booleans are coerced from strings when
-  needed.【F:analysis/topeft_run2/run_analysis_helpers.py†L103-L306】
-* **Metadata defaults** – CLI runs resolve the selected `--scenario` through
-  `analysis/topeft_run2/metadata_authority.py`, which owns scenario lookup and
-  metadata path selection. Options profiles can override the metadata path via
-  the `metadata`/`metadata_path` keys when backward compatibility is needed,
-  but CLI `--metadata` is rejected when `--options` is in use.【F:analysis/topeft_run2/run_analysis.py†L320-L412】【F:analysis/topeft_run2/metadata_authority.py†L1-L200】
+- Allowed alongside `--options`: `--help` (and `--version` only if present).
+- Disallowed alongside `--options`: all other config flags, including
+  `--metadata`, `--executor`, `--chunksize`, `--scenario`, `--pretend`, etc.
 
-## Command-line flags and YAML keys
+## Key defaults
 
-The table below lists each CLI flag, the corresponding YAML key (where
-applicable), the accepted type after coercion, the default value embedded in the
-parser/dataclass, and extra notes.  Keys marked with * are synonyms provided for
-backwards compatibility when writing YAML.
+- `--executor`: `taskvine`
+- `--chunksize`: `500000`
+- `--ddr-output-schema`: `flat`
+- `--produce-sidecars`: disabled
 
-| CLI flag(s) | YAML key(s) | Type after coercion | Default | Notes |
-| --- | --- | --- | --- | --- |
-| `jsonFiles` (positional) | `jsonFiles`, `json_files`* | list of strings | `[]` | Accepts a single path, a comma-separated string, or a list.  Combined with `prefix` during sample discovery.【F:analysis/topeft_run2/run_analysis.py†L32-L207】【F:analysis/topeft_run2/run_analysis_helpers.py†L103-L232】 |
-| `--prefix`, `-r` | `prefix` | string | `""` | Applied to every JSON entry unless the manifest overrides it.  See the configuration flow for redirector usage.【F:analysis/topeft_run2/run_analysis.py†L38-L64】【F:analysis/topeft_run2/run_analysis_helpers.py†L240-L318】【F:docs/run_analysis_configuration.md†L64-L134】 |
-| `--executor`, `-x` | `executor` | string | `"taskvine"` | Selects the backend created by `ExecutorFactory`.  The CLI defaults to the TaskVine executor and expects a cached remote-environment tarball; switch to `futures` for single-node testing, which ignores the missing-cache failure and runs without shipping an archive.  The `iterative` executor remains available for debugging on Coffea builds that expose it.【F:analysis/topeft_run2/run_analysis.py†L32-L222】【F:analysis/topeft_run2/run_analysis_helpers.py†L240-L338】【F:analysis/topeft_run2/workflow.py†L520-L682】【F:docs/run_analysis_configuration.md†L64-L134】【F:topeft/modules/executor_cli.py†L214-L284】 |
-| `--test`, `-t` | `test` | bool | `False` | Enables reduced-event smoke tests.  Distributed backends may reject this combination as described in the troubleshooting checklist.【F:analysis/topeft_run2/run_analysis.py†L38-L85】【F:analysis/topeft_run2/run_analysis_helpers.py†L240-L318】【F:docs/run_analysis_configuration.md†L214-L240】 |
-| `--pretend` | `pretend` | bool | `False` | Parses manifests without executing Coffea tasks.【F:analysis/topeft_run2/run_analysis.py†L38-L85】【F:analysis/topeft_run2/run_analysis_helpers.py†L240-L318】 |
-| `--nworkers`, `-n` | `nworkers` | int | `8` | Worker count for the selected executor.【F:analysis/topeft_run2/run_analysis.py†L38-L109】【F:analysis/topeft_run2/run_analysis_helpers.py†L240-L318】 |
-| `--chunksize`, `-s` | `chunksize` | int | `100000` | Events per task chunk.【F:analysis/topeft_run2/run_analysis.py†L38-L109】【F:analysis/topeft_run2/run_analysis_helpers.py†L240-L318】 |
-| `--nchunks`, `-c` | `nchunks` | optional int | `None` | Limits the number of chunks processed when set.【F:analysis/topeft_run2/run_analysis.py†L38-L109】【F:analysis/topeft_run2/run_analysis_helpers.py†L240-L318】 |
-| `--outname`, `-o` | `outname` | string | `"plotsTopEFT"` | Histogram filename stem.【F:analysis/topeft_run2/run_analysis.py†L38-L132】【F:analysis/topeft_run2/run_analysis_helpers.py†L240-L318】 |
-| `--outpath`, `-p` | `outpath` | string | `"histos"` | Output directory for results.【F:analysis/topeft_run2/run_analysis.py†L38-L132】【F:analysis/topeft_run2/run_analysis_helpers.py†L240-L318】 |
-| `--treename` | `treename` | string | `"Events"` | Input TTree name.【F:analysis/topeft_run2/run_analysis.py†L38-L132】【F:analysis/topeft_run2/run_analysis_helpers.py†L240-L318】 |
-| `--do-errors` | `do_errors` | bool | `False` | Persists quadratic weights (`w**2`) for uncertainty propagation.【F:analysis/topeft_run2/run_analysis.py†L64-L163】【F:analysis/topeft_run2/run_analysis_helpers.py†L240-L318】 |
-| `--do-systs` | `do_systs` | bool | `False` | Enables systematic planning based on metadata definitions.【F:analysis/topeft_run2/run_analysis.py†L64-L163】【F:analysis/topeft_run2/run_analysis_helpers.py†L240-L318】【F:docs/run_analysis_configuration.md†L136-L211】 |
-| `--split-lep-flavor` | `split_lep_flavor` | bool | `False` | Splits histogram categories by lepton flavour.  Mentioned in the summary verbosity description for awareness.【F:analysis/topeft_run2/run_analysis.py†L64-L163】【F:analysis/topeft_run2/run_analysis_helpers.py†L240-L318】 |
-| `--summary-verbosity` | `summary_verbosity` | string (`"none"`, `"brief"`, `"full"`) | `"brief"` | Controls the textual run summary printed before execution.【F:analysis/topeft_run2/run_analysis.py†L132-L173】【F:analysis/topeft_run2/run_analysis_helpers.py†L188-L238】【F:analysis/topeft_run2/workflow.py†L972-L1002】 |
-| `--log-tasks` | `log_tasks` | bool | `False` | Emits a one-line log for each submitted histogram task.【F:analysis/topeft_run2/run_analysis.py†L173-L206】【F:analysis/topeft_run2/run_analysis_helpers.py†L240-L318】 |
-| `--scenario` (repeatable) | `scenarios` | list of strings | `[]` (resolved to `['TOP_22_006']` when empty) | Scenarios map to channel groups via `metadata_authority`; invalid names trigger a friendly error that lists the supported values.【F:analysis/topeft_run2/run_analysis.py†L173-L420】【F:analysis/topeft_run2/run_analysis_helpers.py†L240-L338】【F:analysis/topeft_run2/metadata_authority.py†L1-L240】【F:analysis/topeft_run2/workflow.py†L934-L1016】 |
-| `--skip-sr` | `skip_sr` | bool | `False` | Drops all signal-region categories during planning.【F:analysis/topeft_run2/run_analysis.py†L173-L206】【F:analysis/topeft_run2/run_analysis_helpers.py†L240-L318】 |
-| `--skip-cr` | `skip_cr` | bool | `False` | Drops all control-region categories during planning.【F:analysis/topeft_run2/run_analysis.py†L173-L206】【F:analysis/topeft_run2/run_analysis_helpers.py†L240-L318】 |
-| `--do-np` | `do_np` | bool | `False` | Requests nonprompt estimation after histogram production.【F:analysis/topeft_run2/run_analysis.py†L173-L206】【F:analysis/topeft_run2/run_analysis_helpers.py†L240-L318】【F:analysis/topeft_run2/workflow.py†L906-L976】 |
-| `--do-renormfact-envelope` | `do_renormfact_envelope` | bool | `False` | Requires `do_np` and `do_systs` and applies the renormalisation/factorisation envelope post-processing.【F:analysis/topeft_run2/run_analysis.py†L173-L206】【F:analysis/topeft_run2/run_analysis_helpers.py†L240-L318】【F:analysis/topeft_run2/workflow.py†L918-L965】 |
-| `--wc-list` | `wc_list` | list of strings | `[]` | Wilson coefficients to evaluate; duplicates are removed while preserving order.【F:analysis/topeft_run2/run_analysis.py†L173-L206】【F:analysis/topeft_run2/run_analysis_helpers.py†L240-L336】 |
-| `--ecut` | `ecut` | optional float | `None` | Event-level energy cut in GeV.【F:analysis/topeft_run2/run_analysis.py†L173-L206】【F:analysis/topeft_run2/run_analysis_helpers.py†L240-L318】 |
-| `--port` | `port` | string | `"9123-9130"` | TaskVine manager port or range.  Strings are passed through verbatim while sequences are normalised to `min-max`.【F:analysis/topeft_run2/run_analysis.py†L173-L232】【F:analysis/topeft_run2/run_analysis_helpers.py†L140-L338】 |
-| `--no-port-negotiation` | `negotiate_manager_port` | bool | `False` (negation of the default `True`) | Disable automatic TaskVine port negotiation and use the first value from `--port` directly.  Failures to bind now abort instead of retrying other ports.【F:analysis/topeft_run2/run_analysis.py†L173-L236】【F:analysis/topeft_run2/run_analysis_helpers.py†L240-L338】【F:analysis/topeft_run2/workflow.py†L632-L682】 |
-| `--manager-name` | `manager_name` | optional string | `None` | Override the distributed executor manager identifier.  Defaults to `<user>-<executor>-coffea` when omitted.【F:analysis/topeft_run2/run_analysis.py†L236-L261】【F:analysis/topeft_run2/run_analysis_helpers.py†L240-L338】【F:analysis/topeft_run2/workflow.py†L604-L682】 |
-| `--manager-name-template` | `manager_name_template` | optional string | `None` | Template for TaskVine manager names when multiple processes run concurrently.  The default expands to `<manager-name>-{pid}` on compatible Coffea versions.【F:analysis/topeft_run2/run_analysis.py†L236-L261】【F:analysis/topeft_run2/run_analysis_helpers.py†L240-L338】【F:analysis/topeft_run2/workflow.py†L604-L682】 |
-| `--resource-monitor` | `resource_monitor` | optional string | `None` | TaskVine resource monitor setting (for example `measure`).  Use `none`/`null` to defer to the executor default.【F:analysis/topeft_run2/run_analysis.py†L236-L261】【F:analysis/topeft_run2/run_analysis_helpers.py†L103-L210】【F:analysis/topeft_run2/run_analysis_helpers.py†L240-L338】【F:analysis/topeft_run2/workflow.py†L604-L682】 |
-| `--resources-mode` | `resources_mode` | optional string | `None` | TaskVine resources-mode override passed directly to the executor when set.【F:analysis/topeft_run2/run_analysis.py†L236-L261】【F:analysis/topeft_run2/run_analysis_helpers.py†L240-L338】【F:analysis/topeft_run2/workflow.py†L604-L682】 |
-| `--environment-file` | `environment_file` | optional string | `"cached"` | Environment tarball shipped with distributed executors.  The default resolves the newest cached archive without rebuilding.  Use `auto` to trigger `remote_environment` packaging, provide a path explicitly, or disable shipping with keywords such as `none`/`false`.【F:analysis/topeft_run2/run_analysis.py†L188-L223】【F:analysis/topeft_run2/run_analysis_helpers.py†L124-L175】【F:analysis/topeft_run2/run_analysis_helpers.py†L240-L338】【F:analysis/topeft_run2/workflow.py†L586-L682】 |
-| `--options` | *(YAML only)* | string | `None` | Selects the YAML options file and optional profile.  When set, CLI flags are ignored; combining `--options` with config flags such as `--scenario` or `--metadata` raises an error to keep runs reproducible.【F:analysis/topeft_run2/run_analysis.py†L198-L420】【F:analysis/topeft_run2/run_analysis_helpers.py†L319-L415】 |
+## Core flags
 
-### YAML-only helper keys
+| Flag | Default | Notes |
+| --- | --- | --- |
+| `jsonFiles` (positional) | empty | JSON/CFG input specs when not using YAML-only profiles. |
+| `--options` | unset | YAML file path or `path.yml:profile`. |
+| `--executor` | `taskvine` | `taskvine`, `futures`, `iterative`. |
+| `--chunksize` | `500000` | Events per chunk. |
+| `--nchunks` | unset | Cap processed chunks. |
+| `--nworkers` | `8` | Worker count. |
+| `--outname` | `plotsTopEFT` | Output file stem. |
+| `--outpath` | `histos` | Output directory. |
+| `--treename` | `Events` | Input tree. |
+| `--scenario` | `TOP_22_006` when omitted | Scenario name; YAML profiles should encode this. |
+| `--metadata` | unset | Metadata path when not using `--options`. |
+| `--summary-verbosity` | `brief` | `none`, `brief`, `full`. |
+| `--produce-sidecars` | `false` | Enables sidecar creation in processor outputs. |
 
-These keys shape how the YAML profile is applied but do not map to explicit CLI
-flags.
+## TaskVine/distributed flags
 
-| YAML key | Type | Default | Notes |
-| --- | --- | --- | --- |
-| `defaults` | mapping | `{}` | Baseline values merged before profiles and ad-hoc overrides.【F:analysis/topeft_run2/run_analysis_helpers.py†L347-L392】 |
-| `profiles` | mapping of mappings | `{}` | Named overlays.  Combine with `default_profile` or `path.yml:profile` to choose one.【F:analysis/topeft_run2/run_analysis_helpers.py†L347-L392】 |
-| `default_profile` | string | `None` | Automatically selected when present and `path.yml:profile` is not supplied.【F:analysis/topeft_run2/run_analysis_helpers.py†L360-L383】 |
+| Flag | Default | Notes |
+| --- | --- | --- |
+| `--port` | `9123-9130` | Manager port/range. |
+| `--no-port-negotiation` | false | Disable manager port scanning fallback. |
+| `--manager-name` | unset | Explicit manager name. |
+| `--manager-name-template` | unset | Template with `{pid}` support. |
+| `--scratch-dir` | unset | Shared staging path. |
+| `--resource-monitor` | `measure` | TaskVine monitor mode. |
+| `--resources-mode` | `auto` | TaskVine resources mode. |
+| `--environment-file` | `cached` | Remote env tarball selection. |
+| `--taskvine-print-stdout` | true | Forward worker stdout. |
 
-For executor-specific tuning, extend the builder with additional keys as
-outlined in the [Run analysis configuration flow](run_analysis_configuration.md#key-helpers-and-extension-points)
-reference section.【F:docs/run_analysis_configuration.md†L200-L276】
+## Futures/iterative debug flags
+
+| Flag | Default | Notes |
+| --- | --- | --- |
+| `--futures-workers` | executor default | Local process count override. |
+| `--futures-status` | executor default | Progress bar toggle. |
+| `--futures-tail-timeout` | unset | Timeout for stalled task cancellation. |
+| `--futures-memory` | unset | Memory hint for dynamic chunking. |
+| `--futures-prefetch` | `1` | Input prefetch count. |
+| `--futures-retries` | `0` | Retry count. |
+| `--futures-retry-wait` | `5.0` | Seconds between retries. |
+
+## DDR flags
+
+These apply to TaskVine DDR mode.
+
+| Flag | Default | Notes |
+| --- | --- | --- |
+| `--ddr-processor-key-delim` | `-` | Delimiter for processor key schema `<channel><delim><var><delim><application><delim><systematic_label>`. |
+| `--ddr-output-schema {flat,tuple}` | `flat` | `flat` is canonical default; `tuple` preserves tuple-style output schema. |
+| `--ddr-preserve-sidecars` | false | Preserve non-hist sidecars under reserved key during flattening. |
+| `--ddr-sidecars-key` | `__sidecars__` | Reserved key for preserved sidecars. |
+| `--ddr-step-size` | unset | Defaults to `--chunksize` when unset. |
+| `--ddr-max-task-retries` | unset | DDR task retries. |
+| `--ddr-results-directory` | unset | Override DDR results directory. |
+| `--ddr-verbose` | unset | DDR-layer verbose toggle. |
+| `--ddr-x509-proxy` | unset | Proxy source path; staged as `proxy.pem`. |
+| `--ddr-preprocessed-data` | unset | Reuse preprocess mapping from disk and skip preprocess. |
+| `--ddr-save-preprocess` | unset | Save preprocess mapping after preprocess step. |
+| `--ddr-auto-save-preprocess` | true | Auto-save preprocess mapping when reuse is not requested. |
+| `--ddr-preprocess-artifact` | unset | Override deterministic auto-save path target. |
+
+## Output schema note
+
+- TaskVine DDR serialized output defaults to flat canonical tuples:
+  `(sample, channel, var, application, systematic_label)`.
+- Futures/iterative outputs remain tuple-keyed:
+  `(var, channel, application, sample, systematic)`.
+
+See [schemas.md](schemas.md) for full schema contract and fail-fast policies.

--- a/docs/run_analysis_cli_reference.md
+++ b/docs/run_analysis_cli_reference.md
@@ -32,7 +32,6 @@ Keys marked with `*` are accepted aliases for backward compatibility in YAML.
 | `--test`, `-t` | `test` | bool | `false` | Fast smoke mode; only local executors support this path. |
 | `--pretend` | `pretend` | bool | `false` | Validates configuration and histogram plan, then exits before execution/output write. |
 | `--nworkers`, `-n` | `nworkers` | int | `8` | Worker count used by workflow execution paths. |
-| `--futures-workers` | n/a | int | `8` | Parsed by shared executor helper but currently not consumed by `run_analysis.py`; use `nworkers`. |
 | `--chunksize`, `-s` | `chunksize` | int | `500000` | Events per chunk. |
 | `--nchunks`, `-c` | `nchunks` | optional int | `None` | Maximum number of chunks to process. |
 | `--outname`, `-o` | `outname` | string | `plotsTopEFT` | Output filename stem. |

--- a/docs/run_analysis_cli_reference.md
+++ b/docs/run_analysis_cli_reference.md
@@ -31,7 +31,7 @@ Keys marked with `*` are accepted aliases for backward compatibility in YAML.
 | `--executor`, `-x` | `executor` | string | `taskvine` | Supported: `taskvine`, `futures`, `iterative`. |
 | `--test`, `-t` | `test` | bool | `false` | Fast smoke mode; only local executors support this path. |
 | `--pretend` | `pretend` | bool | `false` | Validates configuration and histogram plan, then exits before execution/output write. |
-| `--nworkers`, `-n` | `nworkers` | int | `8` | Worker count used by workflow execution paths. |
+| `--nworkers`, `-n` | `nworkers` | int | `8` | Worker count used by workflow execution paths (registered by shared `ExecutorCLIHelper`). |
 | `--chunksize`, `-s` | `chunksize` | int | `500000` | Events per chunk. |
 | `--nchunks`, `-c` | `nchunks` | optional int | `None` | Maximum number of chunks to process. |
 | `--outname`, `-o` | `outname` | string | `plotsTopEFT` | Output filename stem. |

--- a/docs/run_analysis_configuration.md
+++ b/docs/run_analysis_configuration.md
@@ -135,14 +135,13 @@ the parser rejects them to preserve reproducibility.
   `analysis/topeft_run2/configs/fullR2_run.yml:sr`. `RunConfigBuilder` merges
   `defaults`, the selected profile, then any top‑level overrides. When
   `--options` is provided, other CLI flags are rejected, so set workload controls
-  like `executor`, `chunksize`, and `nchunks` directly in the YAML. `full_run.sh`
-  automatically selects the Run‑2 SR/CR profiles when you request Run‑2 eras
-  without `--scenario/--options`; for Run‑3 runs you typically pass a dedicated
-  Run‑3 YAML.
+  like `executor`, `chunksize`, and `nchunks` directly in the YAML. The
+  `full_run.sh` wrapper is options-only, so wrapper launches always pass an
+  explicit `--options` spec and do not inject additional config flags.
 * **Executor choice** – `--executor taskvine|futures|iterative` selects the
   backend. TaskVine is recommended for distributed campaigns, `futures` for
-  local multi‑core runs, and `iterative` for tiny smoke tests. The wrapper
-  (`full_run.sh`) defaults to TaskVine but exposes the same flag.
+  local multi‑core runs, and `iterative` for tiny smoke tests. For wrapper
+  launches, set `executor` in YAML.
 * **Workload controls** – `--chunksize` (number of events per chunk),
   `--nchunks` (maximum chunks processed), and `--nworkers` (threads/processes)
   are the primary levers when tuning runtimes. Futures runs also accept
@@ -200,14 +199,13 @@ python analysis/topeft_run2/run_analysis.py \
 ```
 
 The first and third examples rely purely on CLI flags for quick debugging; the
-second mirrors a typical `full_run.sh` launch where the YAML preset controls
-scenarios, metadata, and SR/CR toggles without extra CLI overrides.
+second mirrors a typical options-driven wrapper launch where the YAML preset
+controls scenarios, metadata, and execution toggles.
 
 ### Common pitfalls
 
-* `--scenario` and `--options` are mutually exclusive on the CLI. When the
-  wrapper (`full_run.sh`) detects `--options` in the passthrough arguments it
-  aborts early so that the guard remains enforced.
+* `--scenario` and `--options` are mutually exclusive on the CLI. Wrapper runs
+  are options-only and must encode scenario selection in YAML.
 * If a YAML profile sets `executor: taskvine` but you want to run locally,
   edit the YAML (or run without `--options`) and set `executor: futures`.
 * `--chunksize` and `--nchunks` must be specified in the YAML when `--options`

--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -1,0 +1,103 @@
+# Output and key schemas
+
+This page is the single source of truth for histogram key and DDR output
+schemas.
+
+## 1) Internal histogram tuple schema
+
+Inside planning and processor filling, histogram keys are 5-tuples:
+
+- `(var, channel, application, sample, systematic)`
+
+This is the canonical internal tuple contract.
+
+## 2) TaskVine DDR processor-key schema
+
+TaskVine DDR processors are keyed by:
+
+- `<channel><delim><var><delim><application><delim><systematic_label>`
+
+Default delimiter is `-` (`ddr_processor_key_delim`).
+
+Delimiter safety rule:
+
+- If any component contains the delimiter, key construction fails fast.
+
+## 3) DDR raw nested shape (before flattening)
+
+Dynamic data reduction returns nested mappings:
+
+- `{processor_key: {dataset_name: leaf_payload}}`
+
+`leaf_payload` contains histogram tuple keys (and optionally sidecars when
+produced/preserved).
+
+## 4) TaskVine DDR flattened canonical schema (default)
+
+By default, serialized TaskVine DDR output is flattened to:
+
+- `(sample, channel, var, application, systematic_label)`
+
+`systematic_label` normalization:
+
+- tuples/lists are converted to colon-joined labels
+- scalars are converted with `str(...)`
+
+## 5) Optional DDR tuple-schema serialization
+
+TaskVine DDR can serialize using tuple-style schema with:
+
+- `ddr_output_schema: tuple`
+
+Tuple output schema in this mode is:
+
+- `(var, channel, application, sample, systematic_label)`
+
+## 6) Strict flatten validation rules
+
+Flattening enforces all of the following:
+
+1. Processor key must parse into exactly 4 fields using configured delimiter.
+2. Leaf histogram keys must be 5-tuples.
+3. For each histogram tuple key, `(channel, var, application, systematic_label)`
+   must exactly match parsed processor-key fields.
+4. Mismatches fail fast with processor key and offending tuple diagnostics.
+
+## 7) Flatten collision policy
+
+Flattening is fail-fast for duplicate target keys.
+
+- If two origins map to the same flattened key, processing raises with both
+  origins (processor/dataset/histogram-key) in diagnostics.
+- No implicit `iadd` merge is performed in default flattening path.
+
+## 8) Sidecar behavior
+
+Two independent controls:
+
+- `produce_sidecars` (processor-side creation; default `false`)
+- `ddr_preserve_sidecars` (flatten-time preservation; default `false`)
+
+Defaults:
+
+- sidecars are not produced and therefore not serialized.
+
+If preserved:
+
+- non-hist sidecars are stored under `ddr_sidecars_key` (default
+  `__sidecars__`) in flattened DDR output.
+
+## 9) What is written to pickle by executor path
+
+- TaskVine DDR default: flattened canonical keys
+  `(sample, channel, var, application, systematic_label)`
+- TaskVine DDR with `ddr_output_schema: tuple`: tuple-style keys
+  `(var, channel, application, sample, systematic_label)`
+- Futures/iterative: internal tuple keys
+  `(var, channel, application, sample, systematic)`
+
+## 10) Related docs
+
+- [How to run workflow](how_to_run_analysis_workflow.md)
+- [DDR preprocess/proxy policy](ddr_preprocess_proxy_policy.md)
+- [Analysis processor data flow](analysis_processor_data_flow.md)

--- a/docs/workflow_and_yaml_hub.md
+++ b/docs/workflow_and_yaml_hub.md
@@ -1,131 +1,81 @@
-# Workflow and YAML overview
+# Workflow and YAML hub
 
-> **Start here:** this hub is the recommended entry point for new contributors.
-> It links the shared environment, YAML presets, executor choices, and quickstart
-> workflows so you can go from “fresh checkout” to “first Run‑2 launch” without
-> jumping across multiple README files. For a fuller documentation map, see
-> [docs/index.md](index.md).
+> Start here for Run-2 execution. This page documents the options-first wrapper
+> flow, TaskVine DDR defaults, and where to find detailed schema/reference docs.
 
-This hub pulls together the essentials for launching Run 2 analyses, choosing between the local futures and distributed TaskVine executors, and understanding how the YAML options files drive the workflow. It is meant as a single place to start, with pointers back to the detailed references once you are comfortable with the flow.
+## Recommended execution model
 
-## Before you begin
+`analysis/topeft_run2/full_run.sh` is now a strict options-only wrapper:
 
-1. Create or update the shared `coffea2025` Conda environment and install both
-   `topeft` and the sibling [`topcoffea`](https://github.com/TopEFT/topcoffea)
-   checkout in editable mode. The commands are summarised in the repository
-   `README.md` and expanded in the [environment packaging guide](environment_packaging.md).
-2. Keep `topcoffea` on a coordinated ref (matching release tags or aligned
-   feature refs) so the cache-free jet/MET corrections match what the Run‑2
-   workflow expects. Compatibility policy is documented in
-   `topcoffea/docs/topeft_integration.md`.
-3. If you plan to run distributed jobs, build the TaskVine environment tarball
-   via `python -m topcoffea.modules.remote_environment` before launching any runs.
-4. When you are ready for an end-to-end smoke test, follow the links at the end
-   of this page to the Run‑2 quickstart and plotting sections.
+- Accepted flags: `--options <path[:profile]>` and `--help`.
+- All run configuration (executor, samples, scenario, chunksize, DDR knobs,
+  sidecars, proxy/preprocess settings) must live in YAML.
+- TaskVine + DDR is the recommended production profile.
 
-## Quick workflow walkthrough
-
-1. **Pick or clone an options file.** The shared presets live in `analysis/topeft_run2/configs/` (for example `fullR2_run.yml`). Each file exposes a `defaults` block and optional `profiles` so you can switch between control and signal regions or tailor the executor. See [YAML structure and merging](#yaml-structure-and-merging) for the merge order.
-2. **Prepare inputs.** Point the run at one or more sample manifests such as `input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json`. Relative paths are resolved from the repository root.
-3. **Run with the local futures executor** for single-node smoke tests:
-
-   ```bash
-   cd analysis/topeft_run2
-   ./full_run.sh --sr -y UL17 \
-       --executor futures \
-       --samples ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \
-       --outdir histos/local_futures \
-       --tag quickstart --dry-run
-   ```
-
-   Drop `--dry-run` to execute. For Run-2 years, `full_run.sh` auto-selects
-   `configs/fullR2_run.yml` (SR/CR profile chosen by `--sr/--cr`) unless you
-   pass explicit `--options` or `--scenario`.
-4. **Run with the TaskVine executor** when you are ready to distribute work. Package the environment once per checkout (`python -m topcoffea.modules.remote_environment`), ensure workers point at the advertised manager name, and let the wrapper select the Run-3 defaults:
-
-   ```bash
-   cd analysis/topeft_run2
-   ./full_run.sh --cr -y run3 \
-       --executor taskvine \
-       --outdir histos/run3_fwd_validation \
-       --tag dev_validation
-   ```
-
-   Launch a worker pool in another terminal and pass the same tarball through
-   `--python-env` when using TaskVine submission helpers (for example
-   `vine_submit_workers ... --python-env "$(python -m topcoffea.modules.remote_environment)" -M ${USER}-taskvine-coffea 10`).
-   See [TaskVine workflow quickstart](taskvine_workflow.md) for a deeper dive.
-5. **Turn the histogram pickle into plots** using the existing helper once the run finishes:
-
-   ```bash
-   cd analysis/topeft_run2
-   python make_cr_and_sr_plots.py \
-       -f histos/taskvine/plotsTopEFT.pkl.gz \
-       -o plots/taskvine \
-       -n plots \
-       -y 2017 \
-       --skip-syst
-   ```
-
-Both executors emit tuple-keyed histogram pickles in the `(variable, channel, application, sample, systematic)` format that the plotting utilities expect. [analysis_processing.md](analysis_processing.md) describes the tuple schema in more detail. The Run 2 processor also recomputes b-tag multiplicities as integer arrays right before histogramming so Awkward arithmetic has well-defined inputs when building category masks.
-
-## Common wrapper recipes
-
-These compact `full_run.sh` launches cover common Run-2/Run-3 checks and avoid
-repeating the same command fragments in legacy notes:
+Example launches:
 
 ```bash
-# UL18 iterative dry-run smoke test (prints resolved command only)
 cd analysis/topeft_run2
-./full_run.sh --sr -y UL18 \
-    --executor iterative \
-    --outdir histos/debug_iter_UL18 \
-    --chunksize 10 --nchunks 1 --dry-run
+./full_run.sh --options configs/fullR2_run.yml:sr
+./full_run.sh --options configs/fullR2_run.yml
 ```
 
-```bash
-# Run-2 SR production-style launch using canonical defaults
-cd analysis/topeft_run2
-./full_run.sh --sr -y run2 \
-    --executor futures \
-    --outdir histos/run2_TOP22_006
-```
+When no profile suffix is provided, `RunConfigBuilder` resolves the profile from
+YAML (`default_profile` or single-profile fallback).
 
-```bash
-# Run-3 TaskVine CR launch (defaults to fwd_analysis scenario)
-cd analysis/topeft_run2
-./full_run.sh --cr -y run3 \
-    --executor taskvine \
-    --outdir histos/run3_fwd_validation \
-    --tag dev_validation
-```
+## Single authority for scenarios and metadata
 
-For `run_analysis.py`-level debugging patterns (for example compact futures
-runs with retry/prefetch knobs), use the canonical recipes in
-[Run analysis configuration flow](run_analysis_configuration.md#example-commands).
+Run-2 scenario resolution is centralized in
+`analysis/topeft_run2/metadata_authority.py`.
 
-## YAML structure and merging
+- Canonical scenario map:
+  `analysis/metadata/run2_scenarios.yaml`
+- Canonical metadata bundle entrypoint:
+  `metadata_authority.load_metadata_bundle(...)`
 
-Options files allow you to keep executor choices, region toggles, and metadata overrides in one place. The workflow consumes them in a predictable order:
+Use YAML `scenarios:` entries for wrapper runs. Do not depend on wrapper-side
+scenario logic.
 
-- `defaults` – applied first and always active. Good for repository-wide settings such as `summary_verbosity: full`, `do_systs: true`, or a custom `metadata` file cloned from `analysis/metadata/metadata.yml`.
-- `profiles` – named overlays that activate with a `:profile` suffix (for example `configs/fullR2_run.yml:cr`). If only one profile exists, it is applied automatically. Profiles commonly toggle `scenarios`, `regions`, or `executor` values.
-- Top-level keys – any values placed alongside `defaults` or `profiles` are merged last. Use them sparingly for ad-hoc tweaks you do not want to codify in a profile.
+## YAML guidance
 
-When `--options` is provided, the YAML becomes the single source of truth: CLI flags (including `--metadata`) are rejected to keep the run reproducible. Remove `--options` if you need ad-hoc CLI overrides. The [`run_analysis.py` CLI and YAML reference](run_analysis_cli_reference.md) lists every supported key, while the [Run analysis configuration flow](run_analysis_configuration.md) explains how the builder resolves types and validates inputs.
+`--options` is the single configuration source when supplied.
 
-### Common sections to edit
+- `defaults`: baseline values.
+- `profiles`: named overlays selected with `path.yml:profile`.
+- top-level keys: final overrides.
 
-- **Executor selection and resources** – set `executor: futures` for local runs or `executor: taskvine` to distribute work. TaskVine-specific keys such as `environment_file`, `manager_name_template`, and `resources_mode` can live under `defaults` or individual profiles so they travel with the preset.
-- **Metadata bundle** – point `metadata` at a cloned YAML (for example `configs/metadata_custom.yml`) when testing new regions, variables, or systematics. The [Run configuration dataclasses and metadata overview](dataclasses_and_metadata.md) and [sample metadata reference](sample_metadata_reference.md) document the available fields.
-- **Samples and scenarios** – use `samples` to list JSON manifests or `.cfg` bundles, and set `scenarios` to restrict which channel groups are active. Profiles can also toggle `skip_sr`, `skip_cr`, or `years` to match the intended slice of the analysis.
-- **Output naming** – adjust `outname` and `outpath` to keep control- and signal-region runs separate. Because histogram pickles encode the tuple keys, you can point plotting helpers at any of these outputs without reconfiguring channel metadata.
+Recommended production defaults in YAML:
 
-### Suggested editing workflow
+- `executor: taskvine`
+- `chunksize: 500000`
+- `ddr_output_schema: flat`
+- `produce_sidecars: false`
 
-1. Copy the nearest preset (for example `cp analysis/topeft_run2/configs/fullR2_run.yml analysis/topeft_run2/configs/fullR2_run_taskvine.yml`).
-2. Update `defaults.executor` to `taskvine` and add TaskVine resource hints if you want a dedicated distributed profile; keep a separate profile for local futures runs if needed.
-3. Clone `analysis/metadata/metadata.yml` to a tracked location and reference it via the `metadata` key when testing new variables or systematics.
-4. Check the merged configuration with `python run_analysis.py ... --options <file>:<profile> --dry-run` to confirm the chosen samples and channels before launching a long run. If you need a verbose summary, set `summary_verbosity: full` inside the YAML profile or run without `--options`.
+For debug profiles, set `executor: futures` or `executor: iterative` in YAML.
 
-Keeping these edits in YAML ensures collaborators can reproduce the exact configuration without hunting through older notebooks or shell history.
+## DDR defaults and policies
+
+TaskVine DDR defaults in the current workflow:
+
+- Flat canonical output schema for serialized DDR results.
+- Strict flatten validation: processor-key fields must match histogram tuple
+  fields; mismatches fail fast.
+- Duplicate flattened keys fail fast with origin diagnostics.
+- Delimiter-safe DDR processor keys with collision checks.
+- Deterministic preprocess artifact default:
+  `taskvine-results/ddr_preprocessed_data.json`.
+- Proxy staging policy: copy configured proxy to `proxy.pem` and set
+  `X509_USER_PROXY=proxy.pem` for worker jobs.
+
+See:
+
+- [Schema reference](schemas.md)
+- [DDR preprocess/proxy policy](ddr_preprocess_proxy_policy.md)
+- [CLI reference](run_analysis_cli_reference.md)
+
+## Where to go next
+
+- [How to run an analysis workflow](how_to_run_analysis_workflow.md)
+- [Run 2 quickstart pipeline](quickstart_run2.md)
+- [TaskVine workflow quickstart](taskvine_workflow.md)
+- [Analysis processor data flow](analysis_processor_data_flow.md)

--- a/tests/test_cli_flag_token_hygiene.py
+++ b/tests/test_cli_flag_token_hygiene.py
@@ -1,0 +1,29 @@
+"""Token-level hygiene checks for legacy worker-flag spellings."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def test_no_legacy_worker_flag_tokens_in_tracked_files() -> None:
+    head = "futures"
+    tail = "workers"
+    dash = "-"
+    under = "_"
+    pattern = f"{head}{dash}{tail}|{head}{under}{tail}|--{head}{dash}{tail}"
+
+    completed = subprocess.run(
+        ["git", "grep", "-n", "-E", pattern],
+        cwd=_repo_root(),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    # git grep returns 1 when there are no matches.
+    assert completed.returncode == 1, completed.stdout + completed.stderr

--- a/tests/test_executor_cli.py
+++ b/tests/test_executor_cli.py
@@ -50,6 +50,7 @@ def test_executor_cli_taskvine_configuration(tmp_path):
 
     parser = argparse.ArgumentParser()
     helper.configure_parser(parser)
+    parser.add_argument("--nworkers", type=int, default=8)
 
     scratch_dir = tmp_path / "staging"
     args = parser.parse_args(
@@ -69,7 +70,7 @@ def test_executor_cli_taskvine_configuration(tmp_path):
             "--resources-mode",
             "manual",
             "--no-taskvine-print-stdout",
-            "--futures-workers",
+            "--nworkers",
             "4",
             "--futures-status",
             "--futures-tail-timeout",

--- a/tests/test_executor_cli.py
+++ b/tests/test_executor_cli.py
@@ -50,7 +50,6 @@ def test_executor_cli_taskvine_configuration(tmp_path):
 
     parser = argparse.ArgumentParser()
     helper.configure_parser(parser)
-    parser.add_argument("--nworkers", type=int, default=8)
 
     scratch_dir = tmp_path / "staging"
     args = parser.parse_args(
@@ -212,3 +211,32 @@ def test_executor_cli_futures_allows_missing_cached(tmp_path):
     assert config.executor == "futures"
     assert config.environment_file is None
     assert config.taskvine.environment_file is None
+
+
+def test_executor_cli_futures_uses_central_nworkers(tmp_path):
+    helper = ExecutorCLIHelper(
+        remote_environment=SimpleNamespace(env_dir_cache=tmp_path / "envs"),
+        futures_spec=FuturesArgumentSpec(
+            workers_default=3,
+            include_status=False,
+            include_tail_timeout=False,
+        ),
+        taskvine_spec=TaskVineArgumentSpec(
+            include_manager_name=False,
+            include_manager_template=False,
+            include_scratch_dir=False,
+            include_resource_monitor=False,
+            include_resources_mode=False,
+        ),
+        default_environment="cached",
+        default_executor="taskvine",
+    )
+
+    parser = argparse.ArgumentParser()
+    helper.configure_parser(parser)
+
+    parsed = parser.parse_args(["--executor", "futures", "--nworkers", "6"])
+    config = helper.parse_args(parsed)
+
+    assert config.executor == "futures"
+    assert config.futures.workers == 6

--- a/tests/test_full_run_wrapper.py
+++ b/tests/test_full_run_wrapper.py
@@ -1,4 +1,4 @@
-"""Smoke-test the unified run wrapper in dry-run mode."""
+"""Tests for the strict options-only full_run.sh wrapper."""
 
 from __future__ import annotations
 
@@ -6,87 +6,78 @@ import subprocess
 from pathlib import Path
 
 
-def test_full_run_sh_dry_run(tmp_path):
+def _wrapper_path() -> tuple[Path, Path]:
     repo_root = Path(__file__).resolve().parent.parent
     analysis_dir = repo_root / "analysis" / "topeft_run2"
-    script_path = analysis_dir / "full_run.sh"
-    outdir = tmp_path / "histos"
-    outdir.mkdir(parents=True, exist_ok=True)
+    return repo_root, analysis_dir / "full_run.sh"
 
-    sample_path = "../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json"
 
-    cmd = [
-        str(script_path),
-        "--sr",
-        "-y",
-        "UL17",
-        "--tag",
-        "drytest",
-        "--outdir",
-        str(outdir),
-        "--executor",
-        "futures",
-        "--samples",
-        sample_path,
-        "--dry-run",
-    ]
-
+def test_full_run_sh_help() -> None:
+    _, script_path = _wrapper_path()
     completed = subprocess.run(
-        cmd,
+        [str(script_path), "--help"],
         check=True,
         capture_output=True,
         text=True,
-        cwd=analysis_dir,
+    )
+    assert "Usage:" in completed.stdout
+    assert "--options <path[:profile]>" in completed.stdout
+
+
+def test_full_run_sh_requires_options() -> None:
+    _, script_path = _wrapper_path()
+    completed = subprocess.run(
+        [str(script_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    assert "--options is required" in completed.stderr
+
+
+def test_full_run_sh_rejects_unknown_flags() -> None:
+    _, script_path = _wrapper_path()
+    completed = subprocess.run(
+        [str(script_path), "--executor", "futures"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    assert "unsupported argument" in completed.stderr
+
+
+def test_full_run_sh_runs_with_options_only(tmp_path: Path) -> None:
+    repo_root, script_path = _wrapper_path()
+    options_file = tmp_path / "wrapper_options.yml"
+    options_file.write_text(
+        "\n".join(
+            [
+                "defaults:",
+                "  executor: futures",
+                "  pretend: true",
+                "  summary_verbosity: none",
+                "  jsonFiles:",
+                "    - ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json",
+                "profiles:",
+                "  sr:",
+                "    scenarios:",
+                "      - TOP_22_006",
+                "    skip_cr: true",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
     )
 
-    stdout = completed.stdout
-    assert "Resolved years: UL17" in stdout
-    assert "Executor: futures" in stdout
-    assert "UL17_SRs_drytest" in stdout
-    assert str(outdir) in stdout
-    assert "--skip-cr --do-systs" in stdout
-
-
-def test_full_run_sh_dry_run_without_conda(monkeypatch, tmp_path):
-    repo_root = Path(__file__).resolve().parent.parent
-    analysis_dir = repo_root / "analysis" / "topeft_run2"
-    script_path = analysis_dir / "full_run.sh"
-    outdir = tmp_path / "histos"
-    outdir.mkdir(parents=True, exist_ok=True)
-
-    sample_path = "../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json"
-
-    env = {
-        "PATH": "/usr/bin",
-        "PYTHONPATH": "",
-    }
-
-    cmd = [
-        str(script_path),
-        "--sr",
-        "-y",
-        "UL17",
-        "--tag",
-        "drytest",
-        "--outdir",
-        str(outdir),
-        "--executor",
-        "futures",
-        "--samples",
-        sample_path,
-        "--dry-run",
-    ]
-
     completed = subprocess.run(
-        cmd,
+        [str(script_path), "--options", f"{options_file}:sr"],
         check=True,
         capture_output=True,
         text=True,
-        cwd=analysis_dir,
-        env=env,
+        cwd=repo_root / "analysis" / "topeft_run2",
     )
 
-    assert "Note: no active conda environment detected" in completed.stderr
-    assert "Resolved years: UL17" in completed.stdout
-    assert "Executor: futures" in completed.stdout
-    assert "UL17_SRs_drytest" in completed.stdout
+    combined_output = completed.stdout + completed.stderr
+    assert "Pretend mode active" in combined_output

--- a/tests/test_full_run_wrapper.py
+++ b/tests/test_full_run_wrapper.py
@@ -50,6 +50,8 @@ def test_full_run_sh_rejects_unknown_flags() -> None:
 
 def test_full_run_sh_runs_with_options_only(tmp_path: Path) -> None:
     repo_root, script_path = _wrapper_path()
+    output_dir = tmp_path / "pretend_output"
+    outname = "test_wrapper_pretend"
     options_file = tmp_path / "wrapper_options.yml"
     options_file.write_text(
         "\n".join(
@@ -58,6 +60,8 @@ def test_full_run_sh_runs_with_options_only(tmp_path: Path) -> None:
                 "  executor: futures",
                 "  pretend: true",
                 "  summary_verbosity: none",
+                f"  outpath: {output_dir.as_posix()}",
+                f"  outname: {outname}",
                 "  jsonFiles:",
                 "    - ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json",
                 "profiles:",
@@ -73,11 +77,26 @@ def test_full_run_sh_runs_with_options_only(tmp_path: Path) -> None:
 
     completed = subprocess.run(
         [str(script_path), "--options", f"{options_file}:sr"],
-        check=True,
+        check=False,
         capture_output=True,
         text=True,
         cwd=repo_root / "analysis" / "topeft_run2",
     )
 
-    combined_output = completed.stdout + completed.stderr
-    assert "Pretend mode active" in combined_output
+    assert completed.returncode == 0
+    output_file = output_dir / f"{outname}.pkl.gz"
+    assert not output_file.exists()
+    if output_dir.exists():
+        assert list(output_dir.iterdir()) == []
+
+    combined_output = (completed.stdout + completed.stderr).lower()
+    forbidden_markers = (
+        "submitting histogram task",
+        "starting histogram task",
+        "completed histogram task",
+        "launching coffeadynamicdatareduction",
+        "saving output in",
+        "finished writing",
+    )
+    for marker in forbidden_markers:
+        assert marker not in combined_output

--- a/tests/test_run_analysis_cli_surface.py
+++ b/tests/test_run_analysis_cli_surface.py
@@ -1,0 +1,23 @@
+"""CLI surface checks for run_analysis.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run_analysis_path() -> Path:
+    repo_root = Path(__file__).resolve().parent.parent
+    return repo_root / "analysis" / "topeft_run2" / "run_analysis.py"
+
+
+def test_run_analysis_help_omits_futures_workers() -> None:
+    script_path = _run_analysis_path()
+    completed = subprocess.run(
+        [sys.executable, str(script_path), "--help"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "--futures-workers" not in completed.stdout

--- a/tests/test_run_analysis_cli_surface.py
+++ b/tests/test_run_analysis_cli_surface.py
@@ -12,6 +12,11 @@ def _run_analysis_path() -> Path:
     return repo_root / "analysis" / "topeft_run2" / "run_analysis.py"
 
 
+def _run_sow_path() -> Path:
+    repo_root = Path(__file__).resolve().parent.parent
+    return repo_root / "analysis" / "topeft_run2" / "run_sow.py"
+
+
 def test_run_analysis_help_omits_legacy_worker_flag() -> None:
     script_path = _run_analysis_path()
     completed = subprocess.run(
@@ -22,3 +27,14 @@ def test_run_analysis_help_omits_legacy_worker_flag() -> None:
     )
     forbidden = "--" + "futures" + "-" + "workers"
     assert forbidden not in completed.stdout
+
+
+def test_run_sow_help_includes_central_nworkers_flag() -> None:
+    script_path = _run_sow_path()
+    completed = subprocess.run(
+        [sys.executable, str(script_path), "--help"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "--nworkers" in completed.stdout

--- a/tests/test_run_analysis_cli_surface.py
+++ b/tests/test_run_analysis_cli_surface.py
@@ -12,7 +12,7 @@ def _run_analysis_path() -> Path:
     return repo_root / "analysis" / "topeft_run2" / "run_analysis.py"
 
 
-def test_run_analysis_help_omits_futures_workers() -> None:
+def test_run_analysis_help_omits_legacy_worker_flag() -> None:
     script_path = _run_analysis_path()
     completed = subprocess.run(
         [sys.executable, str(script_path), "--help"],
@@ -20,4 +20,5 @@ def test_run_analysis_help_omits_futures_workers() -> None:
         capture_output=True,
         text=True,
     )
-    assert "--futures-workers" not in completed.stdout
+    forbidden = "--" + "futures" + "-" + "workers"
+    assert forbidden not in completed.stdout

--- a/tests/test_run_analysis_options_conflicts.py
+++ b/tests/test_run_analysis_options_conflicts.py
@@ -58,3 +58,14 @@ def test_options_with_help_is_allowed() -> None:
     argv = ["--options", "opts.yml", "--help"]
     conflicts = find_options_conflicts(argv, parser, allowlist)
     assert conflicts == []
+
+
+def test_options_allowlist_help_only_without_version_flag() -> None:
+    parser = _build_parser()
+    assert options_allowlist(parser) == {"--help"}
+
+
+def test_options_allowlist_includes_version_when_present() -> None:
+    parser = _build_parser()
+    parser.add_argument("--version", action="store_true")
+    assert options_allowlist(parser) == {"--help", "--version"}

--- a/topeft/modules/executor_cli.py
+++ b/topeft/modules/executor_cli.py
@@ -182,6 +182,16 @@ class ExecutorCLIHelper:
     def configure_parser(self, parser: argparse.ArgumentParser) -> None:
         """Add executor-related options to ``parser``."""
 
+        option_actions = parser._option_string_actions
+        if "--nworkers" not in option_actions and "-n" not in option_actions:
+            parser.add_argument(
+                "--nworkers",
+                "-n",
+                type=int,
+                default=self._futures_spec.workers_default,
+                help="Number of workers",
+            )
+
         parser.add_argument(
             "--executor",
             "-x",

--- a/topeft/modules/executor_cli.py
+++ b/topeft/modules/executor_cli.py
@@ -24,6 +24,7 @@ class FuturesArgumentSpec:
     """Configuration describing which futures options to expose on the CLI."""
 
     workers_default: int = 8
+    include_workers: bool = True
     include_status: bool = True
     include_tail_timeout: bool = True
     include_memory: bool = False
@@ -251,12 +252,13 @@ class ExecutorCLIHelper:
                 help="Forward TaskVine worker stdout to the manager logs.",
             )
 
-        parser.add_argument(
-            "--futures-workers",
-            type=int,
-            default=self._futures_spec.workers_default,
-            help="Maximum number of local processes for the futures executor.",
-        )
+        if self._futures_spec.include_workers:
+            parser.add_argument(
+                "--futures-workers",
+                type=int,
+                default=self._futures_spec.workers_default,
+                help="Maximum number of local processes for the futures executor.",
+            )
 
         if self._futures_spec.include_status:
             parser.add_argument(
@@ -341,7 +343,13 @@ class ExecutorCLIHelper:
         )
 
     def _parse_futures(self, args: argparse.Namespace) -> FuturesConfig:
-        workers = max(int(getattr(args, "futures_workers", self._futures_spec.workers_default) or 1), 1)
+        if self._futures_spec.include_workers:
+            workers_value = getattr(args, "futures_workers", None)
+        else:
+            workers_value = getattr(args, "nworkers", None)
+        if workers_value is None:
+            workers_value = self._futures_spec.workers_default
+        workers = max(int(workers_value or 1), 1)
         status = getattr(args, "futures_status", None) if self._futures_spec.include_status else None
 
         tailtimeout: Optional[int]

--- a/topeft/modules/executor_cli.py
+++ b/topeft/modules/executor_cli.py
@@ -156,7 +156,13 @@ class ExecutorConfig:
 
 
 class ExecutorCLIHelper:
-    """Compose executor CLI options and translate them into runtime settings."""
+    """Compose executor CLI options and translate them into runtime settings.
+
+    Maintainer policy: ``--nworkers/-n`` is the single shared worker-count
+    knob across executors. Executor-specific worker-count flags are
+    intentionally not supported; futures workers are derived from
+    ``args.nworkers``.
+    """
 
     def __init__(
         self,

--- a/topeft/modules/executor_cli.py
+++ b/topeft/modules/executor_cli.py
@@ -24,7 +24,6 @@ class FuturesArgumentSpec:
     """Configuration describing which futures options to expose on the CLI."""
 
     workers_default: int = 8
-    include_workers: bool = True
     include_status: bool = True
     include_tail_timeout: bool = True
     include_memory: bool = False
@@ -252,14 +251,6 @@ class ExecutorCLIHelper:
                 help="Forward TaskVine worker stdout to the manager logs.",
             )
 
-        if self._futures_spec.include_workers:
-            parser.add_argument(
-                "--futures-workers",
-                type=int,
-                default=self._futures_spec.workers_default,
-                help="Maximum number of local processes for the futures executor.",
-            )
-
         if self._futures_spec.include_status:
             parser.add_argument(
                 "--futures-status",
@@ -343,10 +334,7 @@ class ExecutorCLIHelper:
         )
 
     def _parse_futures(self, args: argparse.Namespace) -> FuturesConfig:
-        if self._futures_spec.include_workers:
-            workers_value = getattr(args, "futures_workers", None)
-        else:
-            workers_value = getattr(args, "nworkers", None)
+        workers_value = getattr(args, "nworkers", None)
         if workers_value is None:
             workers_value = self._futures_spec.workers_default
         workers = max(int(workers_value or 1), 1)


### PR DESCRIPTION
## Motivation

This branch finalizes CLI/doc hygiene for Run-2 workflow execution so users have one canonical launch path and one canonical worker-count knob.

## Key behavior changes

- `analysis/topeft_run2/full_run.sh` is strict options-only:
  - execution requires `--options <path[:profile]>`
  - `--help` remains available
  - no passthrough of arbitrary runtime flags
- `analysis/topeft_run2/run_analysis.py` keeps options single-source semantics when `--options` is used.
- `--futures-workers` is removed; `--nworkers/-n` is the sole worker-count control.
- `--nworkers/-n` registration is centralized in `ExecutorCLIHelper` to avoid per-entrypoint drift.

## Docs added/updated

- Added:
  - `docs/how_to_run_analysis_workflow.md`
  - `docs/schemas.md`
  - `docs/ddr_preprocess_proxy_policy.md`
  - `docs/analysis_processor_data_flow.md`
- Updated:
  - `README.md`, `docs/index.md`, `docs/analysis_processing.md`,
    `docs/run_analysis_cli_reference.md`, `docs/workflow_and_yaml_hub.md`,
    `docs/quickstart_run2.md`, and related links.

## Testing performed

- `python -m compileall topeft/modules analysis tests`
- `python -m pytest -q` (230 passed, 6 skipped)
- Contract checks:
  - `full_run.sh --help`
  - `full_run.sh` without args exits non-zero (exit=1)
  - `run_analysis.py --help` contains `--nworkers` and no `--futures-workers`
  - token hygiene grep for `futures-workers|futures_workers`

## Options profile selection

- `./analysis/topeft_run2/full_run.sh --options analysis/topeft_run2/configs/fullR2_run.yml`
  uses `default_profile` from the YAML (or single-profile fallback).
- `./analysis/topeft_run2/full_run.sh --options analysis/topeft_run2/configs/fullR2_run.yml:sr`
  forces an explicit profile override.

## Migration notes

- Run via:
  - `./analysis/topeft_run2/full_run.sh --options analysis/topeft_run2/configs/fullR2_run.yml[:profile]`
- Put behavior knobs in YAML/profiles (`pretend`, `chunksize`, `executor`, DDR settings), not wrapper passthrough flags.
- Treat logged “equivalent CLI” output as informational (best-effort).

## Reviewer callouts

- `docs/schemas.md` is the schema source of truth.
- `docs/ddr_preprocess_proxy_policy.md` documents TaskVine preprocess/proxy behavior.
- `docs/analysis_processor_data_flow.md` contains processor-runtime depth; `docs/analysis_processing.md` is orchestration-level.

## Risks / notes

- Keep the defensive duplicate-flag guard in `ExecutorCLIHelper` for `--nworkers` (prevents argparse conflicts during transitions).
- Existing direct-script help caveats remain:
  - `analysis/flip_measurement/run_flip.py --help` import-path failure
  - `analysis/extreme_events_study/run_extreme_events.py --help` import-path failure

## How to reproduce the YAML-profile wrapper test

```bash
cd /users/apiccine/work/ChUpdate/topeft
/users/apiccine/work/ChUpdate/codex-run.sh /bin/bash --noprofile --norc -c \
  '/users/apiccine/work/miniconda3/envs/coffea2025/bin/python -m pytest -q tests/test_full_run_wrapper.py::test_full_run_sh_runs_with_options_only'
```