### PR TITLE
Docs: make README a landing page and clarify workflow hub/quickstart/operator/config roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,33 +23,33 @@ newcomer, follow this path:
 
 1. [Workflow and YAML hub](docs/workflow_and_yaml_hub.md)
 2. [Run 2 quickstart pipeline](docs/quickstart_run2.md)
-3. [TaskVine workflow quickstart](docs/taskvine_workflow.md)
-4. [Run analysis configuration flow](docs/run_analysis_configuration.md)
+3. [TaskVine workflow quickstart](docs/taskvine_workflow.md) for distributed
+   execution, or [How to run an analysis workflow](docs/how_to_run_analysis_workflow.md)
+   for the wrapper entrypoint
+4. [Run analysis configuration flow](docs/run_analysis_configuration.md) when
+   you need to tune YAML or CLI behavior
 5. [`run_analysis.py` CLI and YAML reference](docs/run_analysis_cli_reference.md)
 
-If you prefer the options-first wrapper entrypoint, continue with
-[How to run an analysis workflow](docs/how_to_run_analysis_workflow.md).
-
-## Read next by intent
+## Choose your next guide
 
 - First run / newcomer: [Workflow and YAML hub](docs/workflow_and_yaml_hub.md)
   and [Run 2 quickstart pipeline](docs/quickstart_run2.md)
 - Distributed execution / TaskVine: [TaskVine workflow quickstart](docs/taskvine_workflow.md)
   and [Environment packaging](docs/environment_packaging.md)
-- Workflow guide / configuration reference: [Run analysis configuration flow](docs/run_analysis_configuration.md)
+- Wrapper-driven execution: [How to run an analysis workflow](docs/how_to_run_analysis_workflow.md)
+- Configuration and workflow knobs: [Run analysis configuration flow](docs/run_analysis_configuration.md)
   and [`run_analysis.py` CLI and YAML reference](docs/run_analysis_cli_reference.md)
-- Metadata, scenarios, and sample manifests: [Run 2 metadata scenarios guide](docs/run2_scenarios.md)
-  and [Sample metadata reference](docs/sample_metadata_reference.md)
-- Output schema / DDR payloads: [Schema reference](docs/schemas.md) and
+- Troubleshooting outputs, metadata, or schemas:
+  [Run analysis configuration flow](docs/run_analysis_configuration.md#troubleshooting-checklist),
+  [Sample metadata reference](docs/sample_metadata_reference.md), and
   [DDR outputs and pickle structure](docs/ddr_outputs_and_pkl.md)
 - Architecture / maintainer context: [Workflow and processor reference](docs/analysis_processing.md)
   and [Workflow module chain](docs/workflow_module_chain.md)
-- Contributor / developer docs: [Testing guide](docs/developer/testing.md),
-  [Module notes](docs/developer/modules.md), and
-  [Parameters and calibration assets](docs/developer/parameters.md)
+- Developer verification: [Testing guide](docs/developer/testing.md)
 - Legacy / archival context: [Run 2 legacy notes](docs/run2_legacy_notes.md),
   [TOP-22-006 script walkthrough](docs/quickstart_top22_006.md), and
-  [Run and plot quickstart](docs/run_and_plot_quickstart.md)
+  [Run and plot quickstart](docs/run_and_plot_quickstart.md). These are not
+  part of the primary newcomer path.
 
 ## Documentation map
 

--- a/README.md
+++ b/README.md
@@ -4,216 +4,62 @@
 [![codecov](https://codecov.io/gh/TopEFT/topcoffea/branch/master/graph/badge.svg?token=U2DMI1C22F)](https://codecov.io/gh/TopEFT/topcoffea)
 
 # topeft
-Top quark EFT analyses using the Coffea framework
+
+`topeft` is the analysis and workflow repository for TopEFT Coffea-based runs.
+If you are a newcomer, analyst, or day-to-day operator, this is the repository
+to start with.
+
+`topeft` builds on the shared `topcoffea` library for corrections, executors,
+and common utilities. If you need shared-library internals, corrections logic,
+or cross-repository compatibility guidance, use the
+[`topcoffea` docs hub](https://github.com/TopEFT/topcoffea/blob/main/docs/index.md)
+and
+[`topcoffea/docs/topeft_integration.md`](https://github.com/TopEFT/topcoffea/blob/main/docs/topeft_integration.md).
 
 ## Start here
 
-New to the project? Start with the [workflow and YAML hub](docs/workflow_and_yaml_hub.md).  
-For day-to-day execution, use [How to run an analysis workflow](docs/how_to_run_analysis_workflow.md), which documents the options-only `full_run.sh` entrypoint and TaskVine DDR-first defaults. Consult [docs/index.md](docs/index.md) for the full documentation map.
+`docs/index.md` is the canonical documentation hub for this repository. For a
+newcomer, follow this path:
 
-## Repository contents
+1. [Workflow and YAML hub](docs/workflow_and_yaml_hub.md)
+2. [Run 2 quickstart pipeline](docs/quickstart_run2.md)
+3. [TaskVine workflow quickstart](docs/taskvine_workflow.md)
+4. [Run analysis configuration flow](docs/run_analysis_configuration.md)
+5. [`run_analysis.py` CLI and YAML reference](docs/run_analysis_cli_reference.md)
 
-The `topeft/topeft` directory is installable as a Python package:
+If you prefer the options-first wrapper entrypoint, continue with
+[How to run an analysis workflow](docs/how_to_run_analysis_workflow.md).
 
-- `topeft/topeft`: Core modules shipped with the package.
-- `pyproject.toml`: PEP 517 metadata describing dependencies and bundled data.
-- `topeft/setup.py`: Minimal shim for invoking the package build.
-- `topeft/analysis`: Analysis- and workflow-specific scripts (e.g. `analysis/topeft_run2`).
-- `topeft/tests`: Pytest suites (see [docs/developer/testing.md](docs/developer/testing.md) for details).
-- `topeft/input_samples`: Sample manifests and CFG bundles used by the workflows.
+## Read next by intent
 
-## Environment & dependencies
+- First run / newcomer: [Workflow and YAML hub](docs/workflow_and_yaml_hub.md)
+  and [Run 2 quickstart pipeline](docs/quickstart_run2.md)
+- Distributed execution / TaskVine: [TaskVine workflow quickstart](docs/taskvine_workflow.md)
+  and [Environment packaging](docs/environment_packaging.md)
+- Workflow guide / configuration reference: [Run analysis configuration flow](docs/run_analysis_configuration.md)
+  and [`run_analysis.py` CLI and YAML reference](docs/run_analysis_cli_reference.md)
+- Metadata, scenarios, and sample manifests: [Run 2 metadata scenarios guide](docs/run2_scenarios.md)
+  and [Sample metadata reference](docs/sample_metadata_reference.md)
+- Output schema / DDR payloads: [Schema reference](docs/schemas.md) and
+  [DDR outputs and pickle structure](docs/ddr_outputs_and_pkl.md)
+- Architecture / maintainer context: [Workflow and processor reference](docs/analysis_processing.md)
+  and [Workflow module chain](docs/workflow_module_chain.md)
+- Contributor / developer docs: [Testing guide](docs/developer/testing.md),
+  [Module notes](docs/developer/modules.md), and
+  [Parameters and calibration assets](docs/developer/parameters.md)
+- Legacy / archival context: [Run 2 legacy notes](docs/run2_legacy_notes.md),
+  [TOP-22-006 script walkthrough](docs/quickstart_top22_006.md), and
+  [Run and plot quickstart](docs/run_and_plot_quickstart.md)
 
-The analysis relies on the shared `coffea2025` Conda environment and a sibling
-[`topcoffea`](https://github.com/TopEFT/topcoffea) checkout. The start-here hub
-summarises the setup steps and links to the TaskVine environment packaging guide.
-All CLI entry points validate that the installed `topcoffea` ref matches the
-coordinated ref expected for your run; for policy details, see
-`docs/topeft_integration.md` in the `topcoffea` repository.
+## Documentation map
 
-### HistEFT support
+Use [docs/index.md](docs/index.md) as the authoritative docs map. The README is
+intentionally a landing page; detailed workflow, metadata, configuration,
+Troubleshooting, and archival material lives in the docs pages linked above.
 
-The repository now expects the `topcoffea` package to be installed in the active
-environment instead of shipping a partial vendor copy. The upstream project still
-exposes `HistEFT` via `topcoffea.modules.histEFT`, so existing
-imports keep working once the dependency is installed. CI includes a smoke test
-that asserts `import topcoffea` resolves outside the `topeft` checkout—remove any
-stray `topcoffea/` directories under this repository and reinstall the sibling
-package (for example via `pip install -e /path/to/topcoffea`) if that guard
-triggers.
-
-## Related docs
-
-Explore the rest of the documentation via:
-
-- [Workflow & YAML hub](docs/workflow_and_yaml_hub.md) – start here.
-- [How to run an analysis workflow](docs/how_to_run_analysis_workflow.md) – options-first `full_run.sh` usage.
-- [Documentation index](docs/index.md) – curated doc tracks.
-- [Schema reference](docs/schemas.md) – canonical tuple/flat contracts and DDR flattening rules.
-- [TaskVine workflow quickstart](docs/taskvine_workflow.md) – distributed execution focus.
-- [Datacard fitting workflow](docs/fitting.md) – canonical datacard/fit handoff.
-- [Run 2 metadata scenarios](docs/run2_scenarios.md) – scenario definitions and validators.
-toggles, output names, and executor settings in a single place.
-
-#### Supported metadata scenarios
-
-The default metadata bundle matches the TOP-22-006 reinterpretation categories,
-but the YAML and CLI entry points can target additional scenarios defined in
-`analysis/metadata/metadata.yml`:
-
-- `TOP_22_006` – Baseline Run 2 reinterpretation with the shared control suite.
-- `tau_analysis` – Adds the tau-enriched signal/control regions needed for the
-  dedicated tau study.
-- `fwd_analysis` – Enables the forward-jet categories while reusing the common
-  control regions.
-
-Channel activation is controlled entirely by these scenario selections.  Scenarios
-can be combined by copying the relevant blocks in your YAML profile or—when
-running without `--options`—by passing `--scenario` multiple times on the CLI.
-Detailed instructions for running each bundle
-individually and mixing them in YAML are provided in the
-[Run 2 metadata scenarios guide](docs/run2_scenarios.md).  For a guided
-walkthrough of the Run 2 workflow—including environment setup, metadata
-bundles, and extended examples—see the [TOP-22-006 quickstart
-guide](docs/quickstart_top22_006.md) and the [Run 2 quickstart
-overview](docs/quickstart_run2.md).
-
-Additional reference material for the module structure and configuration helpers
-is available in the [analysis processing primer](docs/analysis_processing.md),
-the [YAML configuration guide](docs/run_analysis_configuration.md), and the
-[`run_analysis.py` CLI/YAML reference](docs/run_analysis_cli_reference.md).
-
-### Metadata configuration
-
-The Run 2 helpers, quickstarts, and processors all read from
-`analysis/metadata/metadata.yml`.  This YAML file is the single source of truth for
-which regions run, which histogram variables are kept, and which systematic
-variations are evaluated.  Key sections include:
-
-| Metadata key | Controls | Processor impact |
-| --- | --- | --- |
-| `channels.groups[].regions` | Channel definitions, lepton/jet binning, and application tags. | Drives channel activation inside `ChannelPlanner` and the per-task metadata passed to the Coffea processor. |
-| `channels.groups[].histogram_variables` | Include/exclude lists for variables per region. | Filters the histogram catalogue built by `HistogramPlanner` so the processor only schedules the variables you request. |
-| `variables` | Bin edges, labels, and callable definitions for histograms. | Supplies the axis configuration for every histogram task. |
-| `scenarios` | Scenario bundles that map friendly names to channel groups. | Enables CLI/YAML `--scenario` toggles and the quickstart presets. |
-| `systematics` | Weight and object variations (with optional year/scenario guards). | Determines which sum-of-weights keys and shape variations the processor evaluates when `--do-systs` is set. |
-| `golden_jsons` | Year-tagged certified-luminosity files. | Guides data-quality filtering when running over data JSONs. |
-
-When you need a custom configuration, copy the metadata file to a new name (for
-example `analysis/topeft_run2/configs/metadata_myteam.yml`) so your edits stay
-isolated.  Quickstart helpers can still consume the clone directly via their own
-`--metadata` flag, but `run_analysis.py` now resolves metadata solely through
-the scenario registry or YAML options files.  Add a `metadata:` entry to the
-profile you launch with `--options` so the override lives alongside the rest of
-your configuration knobs.  A minimal example profile looks like:
-
-```yaml
-# analysis/topeft_run2/configs/fullR2_run_myteam.yml
-metadata: configs/metadata_myteam.yml
-jsonFiles:
-  - ../../input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json
-scenarios:
-  - TOP_22_006
-```
-
-Run the custom configuration with:
-
-```bash
-python run_analysis.py --options analysis/topeft_run2/configs/fullR2_run_myteam.yml
-```
-
-The [metadata configuration guide](docs/run_analysis_configuration.md#metadata-configuration)
-expands on the available keys and shows how the planners consume them.
-
-### Migration note: scenario-only channel activation
-
-As of this release, the ``--channel-feature`` flag has been retired.  Channel
-activation is now driven entirely by the metadata scenarios documented in
-``analysis/metadata/metadata.yml``.  Use ``--scenario`` (either repeated on the
-command line or listed in a YAML profile) to enable the tau, forward, or other
-specialised selections.  The [Run 2 metadata scenarios guide](docs/run2_scenarios.md)
-collects end-to-end examples of the recommended combinations.
-
-If you prefer a minimal smoke test before running the full configuration,
-consider the quickstart helper:
-
-```bash
-python -m topeft.quickstart input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \
-    --prefix root://cmsxrootd.fnal.gov/ \
-    --output quickstart-output
-```
-
-The helper resolves your samples, validates the requested scenario, and launches
-a short futures-based run.  Detailed explanations of each switch are covered in
-[docs/quickstart_run2.md](docs/quickstart_run2.md).  When you are ready to scale
-out, switch to the TaskVine executor described above so the packaged environment
-can be reused across distributed resources. See
-[docs/taskvine_workflow.md](docs/taskvine_workflow.md) for distributed-execution
-details.
-
-For local futures runs the CLI now exposes dedicated knobs for staging and
-recovery: ``--futures-prefetch`` limits the number of ROOT files staged per
-sample, ``--futures-retries``/``--futures-retry-wait`` control automatic
-resubmission, and ``--futures-status`` or ``--futures-tail-timeout`` let you
-adjust progress logging.  YAML profiles accept the same keys with underscores.
-See [docs/run_analysis_cli_reference.md](docs/run_analysis_cli_reference.md) and
-[docs/run_analysis_configuration.md](docs/run_analysis_configuration.md) for
-the canonical options reference and workflow recipes before handing jobs off to
-TaskVine.
-
-
-## How to contribute
-
-If you would like to push changes to the repo, please make a branch and open a PR and ensure that the CI passes. Note that if you are developing on a fork, the CodeCov CI will fail.
-
-Note, if your branch gets out of date as other PRs are merged into the master branch, you may need to merge those changes into your brnach and fix any conflicts prior to your PR being merged. 
-
-If your branch changes anything that is expected to causes the yields to change, please run the following to updated the reference yields:
-```bash
-cd analysis/topEFT/
-sh remake_ci_ref_yields.sh
-sh remake_ci_ref_datacard.sh
-```
-The first script remakes the reference `json` file for the yields, and the second remakes the reference `txt` file for the datacar maker. If you are sure these change are expected, commit and push them to the PR.
-
-## Testing
+## Testing and contributing
 
 Testing instructions are centralized in
-[docs/developer/testing.md](docs/developer/testing.md), which is the canonical
-source of truth for wrapper usage, pytest invocation, TaskVine-related test
-notes, and optional coverage flags.
-
-The file [tests/README.md](tests/README.md) is a stub that points to the same
-canonical page.
-
-
-
-## To reproduce the TOP-22-006 histograms and datacards
-
-The [v0.5 tag](https://github.com/TopEFT/topcoffea/releases/tag/v0.5) was used to produce the results in the TOP-22-006 paper.
-
-1. Run the processor to obtain the histograms (from the skimmed naod files).
-   The preserved presets live in ``analysis/topeft_run2/configs/fullR2_run.yml``;
-   launch them through the unified wrapper:
-
-    ```bash
-    cd analysis/topeft_run2
-    ./full_run.sh --options configs/fullR2_run.yml:cr
-    ```
-
-2. Run the datacard maker to obtain the cards and templates from SM (from the pickled histogram file produced in Step 1, be sure to use the version with the nonprompt estimation, i.e. the one with `_np` appended to the configured output stem). This step would also produce scalings-preselect.json file which the later version is necessary for IM workspace making. Note that command option `--wc-scalings` is not mandatory but to enforce the ordering of wcs in scalings. Add command `-A` to include all EFT templates in datacards for previous AAC model. Add option `-C` to run on condor.
-    ```
-    time python make_cards.py /path/to/your/examplename_np.pkl.gz --do-nuisance --var-lst lj0pt ptz -d /scratch365/you/somedir --unblind --do-mc-stat --wc-scalings cQQ1 cQei cQl3i cQlMi cQq11 cQq13 cQq81 cQq83 cQt1 cQt8 cbW cpQ3 cpQM cpt cptb ctG ctW ctZ ctei ctlSi ctlTi ctli ctp ctq1 ctq8 ctt1
-    ```
-
-3. Run the post-processing checks on the cards to look for any unexpected errors, to grab the right set of ptz and lj0pt templates/cards used in TOP-22-006, and to get final version of scalings.json file. The script will copy the relevant cards/templates/ and create the json file to a directory called `ptz-lj0pt_withSys` that it makes inside of the directory you pass that points to the cards and templates made in Step 2. This `ptz-lj0pt_withSys` is the directory that can be copied to wherever you plan to run the `combine` steps (e.g. PSI). Can also run this on condor with `-c`.
-    ```
-    time python datacards_post_processing.py /scratch365/you/somedir -s
-    ```
-
-4. Check the yields with `get_datacard_yields.py` script. This scrip will read the datacards in the directory produced in Step 3 and will dump the SM yields (summed over jet bins) to the screen (the text is formatted as a latex table). Use the `--unblind` option if you want to also see the data numbers.
-    ```
-    python get_datacard_yields.py /scratch365/you/somedir/ptz-lj0pt_withSys/ --unblind
-    ```
-
-5. Proceed to the [Steps for reproducing the "official" TOP-22-006 workspace](https://github.com/TopEFT/EFTFit#steps-for-reproducing-the-official-top-22-006-workspace) steps listed in the EFTFit Readme. Remember that in addition to the files cards and templates, you will also need the `selectedWCs.txt` file. 
+[docs/developer/testing.md](docs/developer/testing.md). For code changes, keep
+the `topeft` and `topcoffea` refs aligned, run the documented verification
+steps, and open a PR against the coordinated branch you are working on.

--- a/docs/analysis_processing.md
+++ b/docs/analysis_processing.md
@@ -62,5 +62,6 @@ policies.
 ## Detailed references
 
 - [Analysis processor data flow](analysis_processor_data_flow.md)
+- [Workflow module chain](workflow_module_chain.md)
 - [CLI and YAML reference](run_analysis_cli_reference.md)
 - [DDR preprocess and proxy policy](ddr_preprocess_proxy_policy.md)

--- a/docs/how_to_run_analysis_workflow.md
+++ b/docs/how_to_run_analysis_workflow.md
@@ -68,6 +68,8 @@ config resolution. This is informational only and helps auditing resolved values
 
 ## Related references
 
+- [Run analysis configuration flow](run_analysis_configuration.md) – Detailed
+  YAML, CLI, and troubleshooting guide once the wrapper contract is clear.
 - [Schema reference](schemas.md)
 - [DDR preprocess/proxy policy](ddr_preprocess_proxy_policy.md)
 - [Analysis processor data flow](analysis_processor_data_flow.md)

--- a/docs/how_to_run_analysis_workflow.md
+++ b/docs/how_to_run_analysis_workflow.md
@@ -1,6 +1,13 @@
 # How to run an analysis workflow
 
-This is the operator-facing guide for current Run-2 execution.
+Use this page when you already know you want the
+`analysis/topeft_run2/full_run.sh` wrapper entrypoint. This is the
+wrapper/operator recipe for current Run-2 execution, not the primary newcomer
+quickstart and not the detailed configuration manual.
+
+If you are still orienting yourself, start with
+[workflow_and_yaml_hub.md](workflow_and_yaml_hub.md) or
+[quickstart_run2.md](quickstart_run2.md) first.
 
 ## Wrapper contract
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,56 +1,87 @@
 # TopEFT documentation map
 
-Use this map to navigate the documentation tracks introduced during the docs
-reorganisation. Each section highlights the current source of truth for that
-topic so newcomers can follow a single path instead of bouncing between
-overlapping quickstarts.
+Use this page as the canonical hub for `topeft` documentation. The repository
+`README.md` is the landing page; this index is the organized map for newcomers,
+operators, and maintainers.
 
-## Landing & quickstart
+## Start here
 
-- [Workflow and YAML hub](workflow_and_yaml_hub.md) – **Start here** for
-  prerequisites, YAML merging, and executor choices.
+Follow this sequence if you are new to `topeft` or need the shortest path from
+setup to a first successful run:
+
+1. [Workflow and YAML hub](workflow_and_yaml_hub.md) – **Start here** for
+   prerequisites, YAML merging, and executor choices.
+2. [Run 2 quickstart pipeline](quickstart_run2.md) – Primary end-to-end Run-2
+   walkthrough from environment setup to first plots.
+3. [TaskVine workflow quickstart](taskvine_workflow.md) – Distributed execution
+   path for analyst and operator workflows.
+4. [Run analysis configuration flow](run_analysis_configuration.md) – Narrative
+   workflow guide for CLI and YAML configuration.
+5. [`run_analysis.py` CLI and YAML reference](run_analysis_cli_reference.md) –
+   Flag-by-flag configuration reference.
+
+If you are using the wrapper entrypoint directly, continue with
+[How to run an analysis workflow](how_to_run_analysis_workflow.md).
+
+## Workflow guides and reference
+
 - [How to run an analysis workflow](how_to_run_analysis_workflow.md) –
-  options-first operator guide for `full_run.sh`.
-- [Run 2 quickstart pipeline](quickstart_run2.md) – Primary end-to-end Run‑2
-  walkthrough (environment → run → plot).
-- [Run and plot quickstart](run_and_plot_quickstart.md) – Legacy plotting
-  appendix with extra tips beyond the main quickstart.
-- [TOP-22-006 script walkthrough](quickstart_top22_006.md) – Scenario-specific
-  quickstart extending the Run‑2 presets.
-
-## Running analyses
-
-- [Run analysis configuration flow](run_analysis_configuration.md) – Narrative
-  walkthrough of CLI/YAML merging and workflow helpers.
+  Options-first operator guide for `full_run.sh`.
+- [Run analysis configuration flow](run_analysis_configuration.md) – Workflow
+  guide to CLI/YAML merging and helper resolution.
 - [`run_analysis.py` CLI and YAML reference](run_analysis_cli_reference.md) –
-  Flag-by-flag lookup table.
-- [Schema reference](schemas.md) – Canonical internal/output schema contracts
-  and DDR flattening fail-fast rules.
-- [TaskVine/DDR knob reference](taskvine_ddr_knobs.md) – Canonical CLI+YAML
-  knobs for manager/debug/proxy/probe/log/exit-marker behavior.
-- [DDR preprocess + proxy policy](ddr_preprocess_proxy_policy.md) – TaskVine
-  operational defaults for proxy staging and preprocess artifacts.
+  Configuration reference for all main workflow flags.
+- [TaskVine workflow quickstart](taskvine_workflow.md) – Distributed execution
+  guide, including environment-packaging handoff.
+- [Environment packaging](environment_packaging.md) – Maintainer and operator
+  guide for the shared TaskVine tarball.
+- [TaskVine/DDR knob reference](taskvine_ddr_knobs.md) – Canonical CLI and YAML
+  knob list for manager, debug, proxy, probe, and exit-marker behavior.
+- [DDR preprocess + proxy policy](ddr_preprocess_proxy_policy.md) – Current
+  TaskVine defaults for proxy staging and preprocess artifacts.
+- [Schema reference](schemas.md) – Canonical internal and output schema
+  contracts.
 - [DDR outputs and pickle structure](ddr_outputs_and_pkl.md) – Raw DDR payload,
   flattened schema, and final `.pkl.gz` layout.
-- [TaskVine workflow quickstart](taskvine_workflow.md) – Distributed executor
-  focus, including environment packaging pointers.
 - [Datacard fitting workflow](fitting.md) – Canonical handoff from histogram
   production to datacard generation and Combine setup.
-- [Environment packaging](environment_packaging.md) – Maintaining the shared
-  TaskVine tarball.
 
-## Metadata & scenarios
+## Metadata and scenario reference
 
 - [Run configuration dataclasses and metadata overview](dataclasses_and_metadata.md)
-  – How metadata is stored in dataclasses.
+  – How metadata and workflow options are stored in dataclasses.
 - [Metadata channels and application structure](metadata_channels.md) – Channel
-  group/application conventions and feature-flag mapping.
+  group, application, and feature-flag conventions.
 - [Channel group summary reference](channel_group_summary.md) – Expanded
   channel-group listings extracted from `analysis/metadata/metadata.yml`.
-- [Run 2 metadata scenarios guide](run2_scenarios.md) – Scenario/feature
-  definitions and validator pointers.
+- [Run 2 metadata scenarios guide](run2_scenarios.md) – Scenario definitions,
+  feature bundles, and validator pointers.
 - [Sample metadata reference](sample_metadata_reference.md) – JSON manifest
-  schema and troubleshooting tips.
+  schema plus common troubleshooting pointers.
+
+## Troubleshooting and validation
+
+- [Sample metadata reference](sample_metadata_reference.md) – First stop for
+  malformed manifests, missing metadata keys, and sample-bookkeeping issues.
+- [Schema reference](schemas.md) – Check tuple ordering and schema expectations
+  when serialized outputs do not match downstream consumers.
+- [DDR outputs and pickle structure](ddr_outputs_and_pkl.md) – Inspect raw DDR
+  sidecars and final pickle layout when output reconstruction looks wrong.
+- [Environment packaging](environment_packaging.md) – Rebuild policy and tarball
+  expectations for worker-environment drift.
+- [Testing guide](developer/testing.md) – Canonical smoke-test and pytest entry
+  points.
+
+## Architecture
+
+- [Workflow and processor reference](analysis_processing.md) – Medium-depth
+  processor and workflow architecture overview.
+- [Workflow module chain](workflow_module_chain.md) – Concrete call chain from
+  `run_analysis.py` to TaskVine DDR helpers.
+- [Analysis processor data flow](analysis_processor_data_flow.md) – Detailed
+  `AnalysisProcessor` runtime flow from dataset context to accumulator output.
+- [Tuple key audit](tuple_key_audit.md) – Five-tuple histogram-key conventions
+  across the repository.
 
 ## Developer references
 
@@ -61,22 +92,13 @@ overlapping quickstarts.
 - [Testing guide](developer/testing.md) – Canonical pytest usage and TaskVine
   test notes.
 
-## Architecture & internals
-
-- [Workflow and processor reference](analysis_processing.md) – Processor ↔
-  workflow architecture and execution flow.
-- [Workflow module chain](workflow_module_chain.md) – Concrete call chain from
-  `run_analysis.py` to TaskVine DDR helpers.
-- [Analysis processor data flow](analysis_processor_data_flow.md) – Detailed
-  `AnalysisProcessor` runtime flow from dataset context to accumulator output.
-- [Tuple key audit](tuple_key_audit.md) – 5‑tuple conventions for histogram
-  keys across the repository.
-- [Run 2 legacy notes](run2_legacy_notes.md) – Maintainer-focused legacy
-  context for `analysis/topeft_run2/`.
-
 ## Legacy / archival
 
-- [Run 2 legacy notes](run2_legacy_notes.md) – Curated legacy/internal notes
-  consolidated from historical `analysis/topeft_run2` docs.
+- [Run 2 legacy notes](run2_legacy_notes.md) – Curated historical and maintainer
+  context for `analysis/topeft_run2/`.
+- [TOP-22-006 script walkthrough](quickstart_top22_006.md) – Scenario-specific
+  quickstart retained for historical reproduction context.
+- [Run and plot quickstart](run_and_plot_quickstart.md) – Legacy plotting
+  appendix with extra tips beyond the primary quickstart path.
 - [Extreme events study notes](extreme_events_study.md) – Consolidated legacy
   notes for `analysis/extreme_events_study/`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,9 @@ setup to a first successful run:
 If you are using the wrapper entrypoint directly, continue with
 [How to run an analysis workflow](how_to_run_analysis_workflow.md).
 
+Do not start with the legacy pages at the bottom of this map unless you are
+reproducing an older workflow or need historical context.
+
 ## Workflow guides and reference
 
 - [How to run an analysis workflow](how_to_run_analysis_workflow.md) –
@@ -46,6 +49,15 @@ If you are using the wrapper entrypoint directly, continue with
 - [Datacard fitting workflow](fitting.md) – Canonical handoff from histogram
   production to datacard generation and Combine setup.
 
+If you only need one next stop after the primary path above:
+
+- choose [TaskVine workflow quickstart](taskvine_workflow.md) for distributed
+  execution
+- choose [How to run an analysis workflow](how_to_run_analysis_workflow.md) for
+  wrapper-first execution
+- choose [Run analysis configuration flow](run_analysis_configuration.md) for
+  YAML, CLI, and troubleshooting detail
+
 ## Metadata and scenario reference
 
 - [Run configuration dataclasses and metadata overview](dataclasses_and_metadata.md)
@@ -61,6 +73,8 @@ If you are using the wrapper entrypoint directly, continue with
 
 ## Troubleshooting and validation
 
+- [Run analysis configuration flow](run_analysis_configuration.md#troubleshooting-checklist)
+  – General troubleshooting checklist for workflow/configuration issues.
 - [Sample metadata reference](sample_metadata_reference.md) – First stop for
   malformed manifests, missing metadata keys, and sample-bookkeeping issues.
 - [Schema reference](schemas.md) – Check tuple ordering and schema expectations
@@ -102,3 +116,5 @@ If you are using the wrapper entrypoint directly, continue with
   appendix with extra tips beyond the primary quickstart path.
 - [Extreme events study notes](extreme_events_study.md) – Consolidated legacy
   notes for `analysis/extreme_events_study/`.
+
+These pages are archival and should not be used as the default onboarding path.

--- a/docs/quickstart_run2.md
+++ b/docs/quickstart_run2.md
@@ -55,7 +55,9 @@ Output schema depends on executor path:
 - Futures/iterative outputs are tuple-keyed:
   `(var, channel, application, sample, systematic)`
 
-See [schemas.md](schemas.md) for complete details.
+See [schemas.md](schemas.md) for the canonical tuple-key contracts and
+[ddr_outputs_and_pkl.md](ddr_outputs_and_pkl.md) for the TaskVine DDR sidecars,
+flattened output schema, and final `.pkl.gz` layout.
 
 ## Step 4: plot
 

--- a/docs/quickstart_run2.md
+++ b/docs/quickstart_run2.md
@@ -2,6 +2,8 @@
 
 This quickstart is the shortest path from sample JSON to a first output pickle.
 It uses the options-first wrapper and mirrors current TaskVine DDR defaults.
+Read [workflow_and_yaml_hub.md](workflow_and_yaml_hub.md) first if you need the
+high-level map of where this page fits in the overall workflow.
 
 ## Prerequisites
 
@@ -79,3 +81,11 @@ Run-2 scenario resolution is controlled by:
 - `analysis/topeft_run2/metadata_authority.py`
 
 For wrapper-driven runs, place `scenarios:` in YAML options.
+
+## Next steps
+
+- Ready to scale out: continue with [taskvine_workflow.md](taskvine_workflow.md)
+- Need to adjust YAML or CLI behavior: continue with
+  [run_analysis_configuration.md](run_analysis_configuration.md)
+- Need the wrapper entrypoint details:
+  [how_to_run_analysis_workflow.md](how_to_run_analysis_workflow.md)

--- a/docs/quickstart_run2.md
+++ b/docs/quickstart_run2.md
@@ -1,8 +1,10 @@
 # Run 2 quickstart pipeline
 
-This quickstart is the shortest path from sample JSON to a first output pickle.
-It uses the options-first wrapper and mirrors current TaskVine DDR defaults.
-Read [workflow_and_yaml_hub.md](workflow_and_yaml_hub.md) first if you need the
+This quickstart is the first-successful-run guide for current Run-2 workflows.
+It uses the options-first wrapper and mirrors current TaskVine DDR defaults,
+but it is not the full wrapper/operator reference or the detailed
+configuration manual. Read
+[workflow_and_yaml_hub.md](workflow_and_yaml_hub.md) first if you need the
 high-level map of where this page fits in the overall workflow.
 
 ## Prerequisites
@@ -84,8 +86,9 @@ For wrapper-driven runs, place `scenarios:` in YAML options.
 
 ## Next steps
 
-- Ready to scale out: continue with [taskvine_workflow.md](taskvine_workflow.md)
-- Need to adjust YAML or CLI behavior: continue with
+- Ready to scale out with distributed execution: continue with
+  [taskvine_workflow.md](taskvine_workflow.md)
+- Need the detailed YAML, CLI, or troubleshooting guide: continue with
   [run_analysis_configuration.md](run_analysis_configuration.md)
-- Need the wrapper entrypoint details:
+- Need the wrapper entrypoint contract and operator recipe:
   [how_to_run_analysis_workflow.md](how_to_run_analysis_workflow.md)

--- a/docs/run_analysis_configuration.md
+++ b/docs/run_analysis_configuration.md
@@ -10,6 +10,10 @@ with the [Run configuration dataclasses and metadata overview](dataclasses_and_m
 
 If you only need a quick lookup of supported CLI flags and YAML keys, jump to
 the dedicated [`run_analysis.py` CLI and YAML reference](run_analysis_cli_reference.md).
+If this is your first pass through the workflow, start instead with
+[workflow_and_yaml_hub.md](workflow_and_yaml_hub.md) and
+[quickstart_run2.md](quickstart_run2.md), then return here when you need to
+tune behavior or debug configuration issues.
 
 ## Invocation quick reference
 

--- a/docs/run_analysis_configuration.md
+++ b/docs/run_analysis_configuration.md
@@ -1,10 +1,11 @@
 # Run analysis configuration flow
 
-The ``analysis/topeft_run2/run_analysis.py`` entry point stitches together the
-command line, metadata bundles, and Coffea execution helpers that drive the Run 2
-analysis.  This page documents how the configuration is normalized, how the
+This is the detailed configuration and troubleshooting guide for
+``analysis/topeft_run2/run_analysis.py``. The entry point stitches together the
+command line, metadata bundles, and Coffea execution helpers that drive the Run
+2 analysis. This page documents how the configuration is normalized, how the
 helpers cooperate, and which extension points are available when adapting the
-workflow to new samples or channels.  Readers looking for a catalog of the
+workflow to new samples or channels. Readers looking for a catalog of the
 dataclasses and metadata payloads that emerge from this process should start
 with the [Run configuration dataclasses and metadata overview](dataclasses_and_metadata.md).
 
@@ -13,7 +14,9 @@ the dedicated [`run_analysis.py` CLI and YAML reference](run_analysis_cli_refere
 If this is your first pass through the workflow, start instead with
 [workflow_and_yaml_hub.md](workflow_and_yaml_hub.md) and
 [quickstart_run2.md](quickstart_run2.md), then return here when you need to
-tune behavior or debug configuration issues.
+tune behavior or debug configuration issues. If you specifically need the
+wrapper/operator recipe, use
+[how_to_run_analysis_workflow.md](how_to_run_analysis_workflow.md).
 
 ## Invocation quick reference
 

--- a/docs/taskvine_workflow.md
+++ b/docs/taskvine_workflow.md
@@ -69,6 +69,9 @@ update the dependencies so other analysts can reuse the same package.  For
 path.  You can still set `environment_file` explicitly (`path`, `cached`, or
 `auto`) for reproducibility and policy control.
 
+For the detailed rebuild policy, cache naming rules, and maintainer-focused
+packaging notes, see [Environment packaging](environment_packaging.md).
+
 `environment_file=none` (including `--no-environment-file`) is not supported
 for TaskVine in `run_analysis.py`; the run fails fast with exit code `2`
 because workers require a Python environment tarball.

--- a/docs/taskvine_workflow.md
+++ b/docs/taskvine_workflow.md
@@ -1,7 +1,7 @@
 # TaskVine workflow quickstart
 
-TaskVine is the default distributed executor for `topeft`.  This guide threads
-together the full workflow so new analysts can bootstrap the Coffea 2025.7
+TaskVine is the default distributed executor for `topeft`. This guide covers
+the distributed-execution setup so analysts can bootstrap the Coffea 2025.7
 environment, package the tarball consumed by remote workers, and submit a
 matching worker pool.
 

--- a/docs/taskvine_workflow.md
+++ b/docs/taskvine_workflow.md
@@ -5,6 +5,10 @@ together the full workflow so new analysts can bootstrap the Coffea 2025.7
 environment, package the tarball consumed by remote workers, and submit a
 matching worker pool.
 
+This page is the distributed-execution branch of the primary newcomer path. If
+you are starting from scratch, read [workflow_and_yaml_hub.md](workflow_and_yaml_hub.md)
+and [quickstart_run2.md](quickstart_run2.md) first.
+
 ## 1. Prepare the Coffea 2025.7 environment
 
 All examples assume a clean checkout of both `topeft` and `topcoffea`.  Install
@@ -160,6 +164,10 @@ end-to-end examples:
 Both guides call out where to adjust metadata, toggle scenarios, and select the
 TaskVine executor so analysts can move seamlessly from setup to distributed
 submissions.
+
+If you need to tune YAML, CLI, metadata, or troubleshooting behavior after the
+TaskVine setup is clear, continue with
+[run_analysis_configuration.md](run_analysis_configuration.md).
 
 ## Legacy naming note
 

--- a/docs/workflow_and_yaml_hub.md
+++ b/docs/workflow_and_yaml_hub.md
@@ -1,15 +1,19 @@
 # Workflow and YAML hub
 
-> Start here for Run-2 execution. This page documents the options-first wrapper
-> flow, TaskVine DDR defaults, and where to find detailed schema/reference docs.
+> Orientation and decision hub for current Run-2 execution.
+> Start here to understand the wrapper/YAML model, then branch to the
+> first-run, TaskVine, wrapper-operator, or detailed configuration guide.
 
 Use this hub to orient yourself, then pick exactly one next guide:
 
-- [Run 2 quickstart pipeline](quickstart_run2.md) for a first local or smoke-test run
+- [Run 2 quickstart pipeline](quickstart_run2.md) for a first successful local
+  or smoke-test run
 - [TaskVine workflow quickstart](taskvine_workflow.md) once you are ready for
-  distributed execution
+  distributed execution after the quickstart path is clear
+- [How to run an analysis workflow](how_to_run_analysis_workflow.md) if you
+  already know you want the `full_run.sh` wrapper entrypoint
 - [Run analysis configuration flow](run_analysis_configuration.md) when you need
-  to tune YAML, CLI, or troubleshooting behavior
+  the detailed YAML, CLI, or troubleshooting guide
 
 Do not start with the legacy quickstarts unless you are reproducing an older
 analysis flow.

--- a/docs/workflow_and_yaml_hub.md
+++ b/docs/workflow_and_yaml_hub.md
@@ -3,6 +3,17 @@
 > Start here for Run-2 execution. This page documents the options-first wrapper
 > flow, TaskVine DDR defaults, and where to find detailed schema/reference docs.
 
+Use this hub to orient yourself, then pick exactly one next guide:
+
+- [Run 2 quickstart pipeline](quickstart_run2.md) for a first local or smoke-test run
+- [TaskVine workflow quickstart](taskvine_workflow.md) once you are ready for
+  distributed execution
+- [Run analysis configuration flow](run_analysis_configuration.md) when you need
+  to tune YAML, CLI, or troubleshooting behavior
+
+Do not start with the legacy quickstarts unless you are reproducing an older
+analysis flow.
+
 ## Recommended execution model
 
 `analysis/topeft_run2/full_run.sh` is now a strict options-only wrapper:
@@ -75,7 +86,12 @@ See:
 
 ## Where to go next
 
-- [How to run an analysis workflow](how_to_run_analysis_workflow.md)
-- [Run 2 quickstart pipeline](quickstart_run2.md)
-- [TaskVine workflow quickstart](taskvine_workflow.md)
-- [Analysis processor data flow](analysis_processor_data_flow.md)
+- [Run 2 quickstart pipeline](quickstart_run2.md) – Primary newcomer path
+- [TaskVine workflow quickstart](taskvine_workflow.md) – Distributed execution
+  branch of the same path
+- [How to run an analysis workflow](how_to_run_analysis_workflow.md) – Wrapper
+  entrypoint details
+- [Run analysis configuration flow](run_analysis_configuration.md) – YAML, CLI,
+  and troubleshooting detail
+- [Analysis processor data flow](analysis_processor_data_flow.md) – Runtime
+  internals after the workflow path is clear


### PR DESCRIPTION
## Summary

- Rewrite `README.md` into a true landing page and move detailed workflow/reference material behind the docs hub.
- Promote `docs/index.md` to the canonical docs map with clearer newcomer, workflow, troubleshooting, architecture, developer, and archival sections.
- Surface previously under-linked but important docs such as `environment_packaging.md`, `ddr_outputs_and_pkl.md`, and `workflow_module_chain.md`.
- Clarify and preserve the split roles of the workflow/config cluster instead of merging pages:
  - `workflow_and_yaml_hub.md`
  - `quickstart_run2.md`
  - `how_to_run_analysis_workflow.md`
  - `run_analysis_configuration.md`
- Demote legacy/historical material more explicitly so it no longer competes with the primary onboarding path.

## Motivation

Before this PR, `topeft` had a strong documentation set, but the top-level navigation still created unnecessary friction:

- `README.md` competed with the docs hub by duplicating scenario/configuration/reference material.
- There were too many plausible “start here” pages, which made the newcomer path ambiguous.
- Some useful operational or architecture pages were under-linked and easy to miss.
- Legacy and archival material was still prominent enough to blur the active workflow path.
- The workflow/config pages overlapped in purpose unless the reader already knew which one they wanted.

This PR addresses those issues by making the routing clearer without changing workflow semantics and without collapsing pages that still serve distinct roles.

## Implementation details

### A. Turn `README.md` into a landing page

The README was heavily reduced so it now behaves as a landing page rather than a second workflow manual.

Main changes:
- keep repo identity and relation to `topcoffea`
- define a primary newcomer sequence
- add a “choose your next guide” section by intent
- point readers to `docs/index.md` as the authoritative docs map
- replace long in-README scenario/config/reference/historical material with links

Large duplicated sections were removed, including:
- metadata/scenario explanation that is better owned by dedicated docs
- detailed configuration guidance
- large historical reproduction content in the primary landing flow

This reduces drift risk and makes the docs authority clearer.

### B. Strengthen `docs/index.md` as the canonical hub

`docs/index.md` was restructured into a stronger canonical map.

Key changes:
- clearer `Start here` sequence
- stronger `Workflow guides and reference` section
- dedicated `Troubleshooting and validation` section
- dedicated `Architecture` section
- cleaner `Legacy / archival` section
- explicit note that legacy pages are archival and not the default onboarding path
- removal of duplicated placement of `run2_legacy_notes.md`

This page now answers:
- where a newcomer should start
- which page is authoritative for a given topic
- which pages are current vs archival
- which pages are operator-facing vs maintainer-facing

### C. Surface under-linked docs

Three lightly linked but important pages were surfaced more clearly:

- `docs/environment_packaging.md`
  - linked directly from `docs/taskvine_workflow.md`
  - also surfaced from `README.md` / `docs/index.md`

- `docs/ddr_outputs_and_pkl.md`
  - linked from `docs/quickstart_run2.md`
  - surfaced in troubleshooting/validation routing

- `docs/workflow_module_chain.md`
  - linked from `docs/analysis_processing.md`
  - surfaced in architecture/maintainer routing

This improves discoverability without changing page ownership.

### D. Keep the workflow/config cluster split, but clarify page roles

A deliberate choice in this PR is to **not** merge the main workflow/config docs cluster.

Instead, their openings and “next step” language were tightened so each page has a clearer canonical role:

#### `docs/workflow_and_yaml_hub.md`
Role:
- orientation and decision hub

What changed:
- makes clear that readers should start here to understand the model
- explicitly routes readers to exactly one next guide
- warns against starting with legacy quickstarts

#### `docs/quickstart_run2.md`
Role:
- first successful run guide

What changed:
- opening clarifies this is the first-run path, not the full operator/config manual
- “Next steps” section now points clearly to TaskVine, wrapper, or config pages
- output-schema note now links to `ddr_outputs_and_pkl.md`

#### `docs/how_to_run_analysis_workflow.md`
Role:
- wrapper/operator recipe

What changed:
- opening explicitly says this is for readers who already know they want the wrapper entrypoint
- clarifies it is not the primary newcomer page and not the detailed config manual
- adds direct handoff to `run_analysis_configuration.md`

#### `docs/run_analysis_configuration.md`
Role:
- detailed configuration and troubleshooting guide

What changed:
- opening explicitly positions it as the deep config/troubleshooting page
- routes first-time readers back to the hub/quickstart
- routes wrapper-specific readers to `how_to_run_analysis_workflow.md`

This keeps the current structure but makes the separation intelligible to a new reader.

### E. Clarify `taskvine_workflow.md` and keep it as a branch, not a rival entrypoint

`docs/taskvine_workflow.md` was adjusted so it no longer reads like a competing full-workflow manual.

Changes:
- opening explicitly says it is the distributed-execution branch of the main onboarding path
- routes readers back to hub/quickstart if they are starting from scratch
- adds a handoff to `run_analysis_configuration.md` for deeper tuning/troubleshooting
- links to `environment_packaging.md` for detailed packaging policy

This preserves TaskVine-specific detail while reducing entrypoint competition.

### F. Demote archival material more explicitly

The docs now more clearly separate active workflow guidance from historical material.

Examples:
- legacy pages were grouped more clearly in `docs/index.md`
- archival wording was strengthened
- README no longer carries long historical reproduction material in the default newcomer path

Importantly, legacy pages were **not deleted**. They were retained but demoted.

### G. Semantics intentionally unchanged

This PR is docs-only.

It does **not** change:
- analysis behavior
- metadata/scenario logic
- TaskVine policy
- workflow execution semantics
- plotting/data-card production logic
- developer/test behavior

The change is about navigation, page roles, and documentation authority only.

## Testing

This PR was verified as a docs-only change.

What was run:
- mandatory preflight:
  - `git status -sb`
  - `git diff --name-status`
  - `git clean -nd`
- targeted `rg` sanity checks for routing terms, page-role language, and expected links
- `git diff` inspection before commit
- `git show --stat`
- `git show --name-only`
- full `git show`
- final `git status -sb`

Limitations:
- no `compileall`
- no `pytest`

That was intentional because the PR only changes documentation text and navigation structure.

## Review notes

- The most important review point is the **intended role split** of the workflow/config cluster. This PR intentionally keeps those pages separate:
  - hub = orientation / decision page
  - quickstart = first successful run
  - wrapper page = operator recipe
  - config page = detailed tuning and troubleshooting
- Reviewers should check that `README.md` now behaves like a landing page and does not drift back into a second manual.
- Reviewers should also check that legacy pages are still available for provenance/history, but no longer compete with the main onboarding path.
- No workflow or analysis semantics are intended to change.