### PR TITLE
Docs: clean GitHub-hostile markup in user-facing docs

### DIFF
--- a/docs/dataclasses_and_metadata.md
+++ b/docs/dataclasses_and_metadata.md
@@ -13,19 +13,19 @@ The workflow persists configuration in the `RunConfig` dataclass introduced by
 default settings into immutable attributes (per [PEP 557](https://peps.python.org/pep-0557/))
 so downstream helpers can rely on consistent types and defaults.  Key fields
 capture input discovery, metadata switches, executor choices, and futures-tuning
-knobs that mirror the CLI flags. 【F:analysis/topeft_run2/run_analysis_helpers.py†L330-L371】
+knobs that mirror the CLI flags (source: `analysis/topeft_run2/run_analysis_helpers.py`).
 
 `RunConfigBuilder` is responsible for merging CLI namespaces, YAML option files,
 and default values.  The builder maps user-facing keys such as `--scenarios` or
 `metadata:` entries to the corresponding dataclass attributes, applying
 normalisation helpers (`coerce_bool`, `normalize_sequence`, etc.) before storing
-them. 【F:analysis/topeft_run2/run_analysis_helpers.py†L374-L467】  When the
+them (source: `analysis/topeft_run2/run_analysis_helpers.py`).  When the
 `--options` argument references a YAML document, the builder evaluates the
 `defaults`, `profiles`, and pass-through keys in order, making profile overlays
-behave predictably. 【F:analysis/topeft_run2/run_analysis_helpers.py†L491-L539】
+behave predictably (source: `analysis/topeft_run2/run_analysis_helpers.py`).
 If no YAML is provided, the builder falls back to CLI overrides, deduplicating
 scenario and Wilson-coefficient selections before returning the final
-configuration. 【F:analysis/topeft_run2/run_analysis_helpers.py†L541-L599】
+configuration (source: `analysis/topeft_run2/run_analysis_helpers.py`).
 
 Because `RunConfig` is a dataclass, existing code can call `dataclasses.asdict`
 for auditing or serialization, and new optional attributes can be added without
@@ -40,15 +40,15 @@ Histogram orchestration relies on a trio of frozen dataclasses declared in
 
 - `HistogramTask` captures the per-job inputs (sample name, clean channel,
   application, metadata and systematic availability) that will be fed into the
-  Coffea processor. 【F:analysis/topeft_run2/workflow.py†L293-L307】
+  Coffea processor (source: `analysis/topeft_run2/workflow.py`).
 - `HistogramCombination` records the `(sample, channel, variable, application,
-  systematic)` tuple for human-readable summaries. 【F:analysis/topeft_run2/workflow.py†L309-L317】
+  systematic)` tuple for human-readable summaries (source: `analysis/topeft_run2/workflow.py`).
 - `HistogramPlan` packages the final task list, the histogram names that were
-  activated, and the flattened summary for logging. 【F:analysis/topeft_run2/workflow.py†L320-L326】
+  activated, and the flattened summary for logging (source: `analysis/topeft_run2/workflow.py`).
 
 `HistogramPlanner` assembles these structures by crossing the selected metadata
 channels with variable definitions, available systematics, and sample-specific
-variations. 【F:analysis/topeft_run2/workflow.py†L329-L494】  During planning the
+variations (source: `analysis/topeft_run2/workflow.py`).  During planning the
 class honours channel-specific whitelists/blacklists, handles optional flavour
 splitting, and ensures that each combination is represented once in the summary.
 The resulting `HistogramPlan` is consumed by the executor factory, which keeps
@@ -60,14 +60,14 @@ Per-sample manifests are loaded via the `SampleLoader` helper.  During
 `load(...)` the helper enforces the required keys (`xsec`, `nEvents`,
 `nGenEvents`, `nSumOfWeights`, `files`, `histAxisName`, `treeName`, `year`, and
 `isData`) and coerces each value into the expected Python type before attaching a
-redirector prefix. 【F:analysis/topeft_run2/run_analysis_helpers.py†L202-L248】
+redirector prefix (source: `analysis/topeft_run2/run_analysis_helpers.py`).
 Any metadata-driven weight variations listed in the manifest are also coerced to
 floats so downstream code can perform numeric comparisons without additional
-parsing. 【F:analysis/topeft_run2/run_analysis_helpers.py†L243-L247】
+parsing (source: `analysis/topeft_run2/run_analysis_helpers.py`).
 
 The optional variation keys themselves are derived from the metadata YAML via
 `weight_variations_from_metadata`, which scans the `systematics` section for
-`sum_of_weights` entries. 【F:analysis/topeft_run2/run_analysis_helpers.py†L294-L327】
+`sum_of_weights` entries (source: `analysis/topeft_run2/run_analysis_helpers.py`).
 Supplying `--options` profiles that disable systematics or editing the metadata
 file therefore changes both the JSON validation rules and the systematic
 combinations enumerated later by `HistogramPlanner`.
@@ -81,10 +81,10 @@ The canonical metadata bundle (`analysis/metadata/metadata.yml`) contains severa
 sections that drive channel discovery and systematic planning:
 
 - `golden_jsons` maps each year to the luminosity mask used when running on
-  collision data. 【F:analysis/metadata/metadata.yml†L1-L7】
+  collision data (source: `analysis/metadata/metadata.yml`).
 - `channels.groups` defines scenario-specific region lists, including jet-bin
   expansions, histogram include/exclude lists, and separate application tags for
-  data vs. MC. 【F:analysis/metadata/metadata.yml†L9-L111】
+  data vs. MC (source: `analysis/metadata/metadata.yml`).
 - `variables` (further down in the file) describes histogram axes, binning, and
   callable expressions that populate the planner’s `variable_info` payloads.
 - Run‑2 scenario definitions live in `analysis/metadata/run2_scenarios.yaml` and
@@ -95,7 +95,7 @@ sections that drive channel discovery and systematic planning:
 
 `ChannelPlanner` resolves the requested scenarios into concrete region and
 feature selections, preserving metadata that the processor needs later.
-【F:analysis/topeft_run2/workflow.py†L76-L275】  The planner records per-channel
+(source: `analysis/topeft_run2/workflow.py`).  The planner records per-channel
 whitelists, blacklists, application tags, and flavour metadata, which are then
 consumed by `HistogramPlanner` when building each `HistogramTask`.
 

--- a/docs/environment_packaging.md
+++ b/docs/environment_packaging.md
@@ -3,7 +3,7 @@
 Changes to `environment.yml` affect both local development setups and the
 archived environment shipped to remote workers. After editing the specification
 make sure the companion [`topcoffea`](https://github.com/TopEFT/topcoffea)
-package remains importable::
+package remains importable:
 
        python -c "import topcoffea"
 
@@ -64,14 +64,14 @@ Then run:
 These keep the wrapper's environment cleanup intact while still allowing
 one-line invocations for CI and local debugging.
 
-1. Recreate the local Conda environment so the lock file matches the new pins::
+1. Recreate the local Conda environment so the lock file matches the new pins:
 
        conda env update -f environment.yml --prune
 
    This command updates the existing `coffea2025` environment in-place and
    removes packages that are no longer required.
 
-2. Regenerate the packaged tarball that workflows submit to remote resources::
+2. Regenerate the packaged tarball that workflows submit to remote resources:
 
        python -m topcoffea.modules.remote_environment
 

--- a/docs/run_analysis_configuration.md
+++ b/docs/run_analysis_configuration.md
@@ -59,11 +59,11 @@ load a different file.
 
 | Metadata key | Controls | Processor impact |
 | --- | --- | --- |
-| ``channels.groups[].regions`` | Channel labels, subchannels, jet bins, tags, and application assignments. | Guides :class:`ChannelPlanner` when enumerating signal/control regions and annotating each Coffea task. |
-| ``channels.groups[].histogram_variables`` | Per-region include/exclude rules for histogram names. | Filters the :class:`HistogramPlanner` combinations so only approved variables are scheduled. |
-| ``variables`` | Histogram axis definitions, binning, and callable expressions. | Becomes the histogram catalogue consumed by :class:`AnalysisProcessor`. |
+| ``channels.groups[].regions`` | Channel labels, subchannels, jet bins, tags, and application assignments. | Guides `ChannelPlanner` when enumerating signal/control regions and annotating each Coffea task. |
+| ``channels.groups[].histogram_variables`` | Per-region include/exclude rules for histogram names. | Filters the `HistogramPlanner` combinations so only approved variables are scheduled. |
+| ``variables`` | Histogram axis definitions, binning, and callable expressions. | Becomes the histogram catalogue consumed by `AnalysisProcessor`. |
 | ``scenarios`` | Friendly scenario names mapped to channel groups. | Powers the ``--scenario`` CLI flag and YAML ``scenarios`` lists. |
-| ``systematics`` | Weight, object, and theory variations (with optional year or feature guards). | Supplies :func:`weight_variations_from_metadata` and the systematic helper with the variations to evaluate when ``do_systs`` is enabled. |
+| ``systematics`` | Weight, object, and theory variations (with optional year or feature guards). | Supplies `weight_variations_from_metadata(...)` and the systematic helper with the variations to evaluate when ``do_systs`` is enabled. |
 | ``golden_jsons`` | Year-indexed data-quality JSON files. | Enables automated golden JSON lookups when running over data samples. |
 
 When customising an analysis, clone the file rather than editing the baseline in
@@ -83,18 +83,18 @@ tweaking the Run 2 configuration knows where each dial is sourced.
 ## Overview of the configuration pipeline
 
 ``run_analysis.py`` executes the steps below when launched from the repository
-root::
+root:
 
     python analysis/topeft_run2/run_analysis.py \
         input_samples/sample_jsons/test_samples/UL17_private_ttH_for_CI.json \
         --options analysis/topeft_run2/configs/fullR2_run.yml:sr
 
-1. **Argument parsing** – :func:`analysis.topeft_run2.run_analysis.build_parser`
+1. **Argument parsing** – `analysis.topeft_run2.run_analysis.build_parser(...)`
    defines the CLI options that downstream helpers understand.  The parser keeps
    backwards compatibility with the historical ``jsonFiles`` positional argument
    while advertising the YAML-driven ``--options`` knob, which accepts either
    ``path.yml`` or ``path.yml:profile`` when you need a specific preset.
-2. **YAML overrides** – :class:`analysis.topeft_run2.run_analysis_helpers.RunConfigBuilder`
+2. **YAML overrides** – `analysis.topeft_run2.run_analysis_helpers.RunConfigBuilder`
    reads the options file (if provided) before evaluating CLI values.  The YAML
    supports three blocks:
 
@@ -120,24 +120,24 @@ root::
        the Run‑2 presets on your behalf.
 
 3. **Configuration normalization** – the builder converts all inputs into a
-   :class:`analysis.topeft_run2.run_analysis_helpers.RunConfig` dataclass.  The
+   `analysis.topeft_run2.run_analysis_helpers.RunConfig` dataclass.  The
    dataclass mirrors the traditional CLI options but guarantees consistent types
    (lists instead of comma separated strings, ``None`` for unset values, etc.).
-4. **Sample discovery** – :class:`analysis.topeft_run2.run_analysis_helpers.SampleLoader`
+4. **Sample discovery** – `analysis.topeft_run2.run_analysis_helpers.SampleLoader`
    expands positional inputs into concrete JSON files, parsing ``.cfg`` bundles
    and directories when necessary.  The loader attaches redirectors, validates
    files, and normalizes numeric metadata.  See the
    [sample metadata reference](sample_metadata_reference.md) for a manifest
    checklist and troubleshooting advice tailored to this stage.
-5. **Metadata planning** – :class:`analysis.topeft_run2.workflow.ChannelPlanner`
-   and :class:`analysis.topeft_run2.workflow.HistogramPlanner` translate the
+5. **Metadata planning** – `analysis.topeft_run2.workflow.ChannelPlanner`
+   and `analysis.topeft_run2.workflow.HistogramPlanner` translate the
    selected metadata scenarios and variable definitions into the list of
    histogram tasks.  This is where ``--scenario``, ``--skip-sr`` and similar
    knobs take effect.
-6. **Execution** – :class:`analysis.topeft_run2.workflow.ExecutorFactory`
+6. **Execution** – `analysis.topeft_run2.workflow.ExecutorFactory`
    instantiates the selected backend (``futures``, ``iterative`` or
    ``taskvine``).  Each histogram task yields an
-   :class:`analysis.topeft_run2.analysis_processor.AnalysisProcessor` instance
+   `analysis.topeft_run2.analysis_processor.AnalysisProcessor` instance
    configured for the corresponding sample and channel.  Progress is summarized
    according to ``summary_verbosity``—``"brief"`` prints bullet lists of the
    unique samples, channel/application pairs, variables, and systematics that
@@ -146,9 +146,9 @@ root::
    ``split_lep_flavor`` is active).  These details are optionally mirrored in
    the single-line ``log_tasks`` messages.
 
-The helpers are designed so that the resulting :class:`RunConfig` can be stored
+The helpers are designed so that the resulting `RunConfig` can be stored
 or passed around.  For example, the quickstart workflow returns the configuration
-it used so that you can plug the same object into :func:`run_workflow` later.
+it used so that you can plug the same object into `run_workflow(...)` later.
 
 ## CLI highlights
 
@@ -250,22 +250,22 @@ Systematic switches are managed collaboratively by the helpers:
 
 * ``RunConfig.do_systs`` enables systematic planning.  The builder honours YAML
   booleans (``true``/``false``) and CLI flags.
-* :func:`analysis.topeft_run2.run_analysis_helpers.weight_variations_from_metadata`
+* `analysis.topeft_run2.run_analysis_helpers.weight_variations_from_metadata(...)`
   inspects ``analysis/metadata/metadata.yml`` to identify all available sum-of-weight
   variations.  Supplying a YAML options file with a ``systematics`` block lets
   you add or restrict variations on a per-profile basis.
-* :class:`SampleLoader` makes the variations available on each sample entry so
-  that :class:`analysis.topeft_run2.workflow.RunWorkflow` can validate the
+* `SampleLoader` makes the variations available on each sample entry so
+  that `analysis.topeft_run2.workflow.RunWorkflow` can validate the
   metadata before any Coffea tasks are submitted.
-* :class:`analysis.topeft_run2.workflow.SystematicsHelper` (instantiated inside
+* `analysis.topeft_run2.workflow.SystematicsHelper` (instantiated inside
   the workflow) cross-references the metadata with the scenario-provided feature
   flags and the requested year, building the final structure that
-  :class:`AnalysisProcessor` consumes.
+  `AnalysisProcessor` consumes.
 
 When ``--do-renormfact-envelope`` is enabled, the workflow enforces the presence
 of ``--do-systs`` and ``--do-np`` because the renormalization/factorization
 envelope is only meaningful after the non-prompt application integrals are
-available.  These checks happen in :meth:`RunWorkflow._validate_config` so that
+available.  These checks happen in `RunWorkflow._validate_config(...)` so that
 misconfigurations fail fast.
 
 ## Key helpers and extension points
@@ -274,24 +274,24 @@ The table below summarises the most common extension hooks:
 
 | Helper | Responsibility | How to extend |
 | ------ | -------------- | ------------- |
-| :class:`RunConfigBuilder` | Merge CLI, defaults, and YAML into a :class:`RunConfig`. | Subclass the builder and override :meth:`build` to recognise additional YAML keys (for example, executor-specific settings).  The CLI parser can expose the same flag so that existing scripts keep working. |
-| :class:`SampleLoader` | Resolve JSON/CFG inputs and normalize metadata. | Provide a custom ``SampleLoader`` to support other manifest formats (for example, CSV).  The replacement object must offer ``collect`` and ``load`` methods returning the same structures. |
-| :class:`analysis.topeft_run2.workflow.ChannelPlanner` | Activate channels according to metadata scenarios. | Extend :class:`topeft.modules.channel_metadata.ChannelMetadataHelper` or wrap the planner to insert additional filters (for example, dropping jet categories). |
-| :class:`analysis.topeft_run2.workflow.HistogramPlanner` | Enumerate histogram combinations for execution. | Pass a custom planner that rewrites the histogram list (for example, sampling only a subset of variables) before the workflow starts the executor. |
-| :class:`analysis.topeft_run2.workflow.ExecutorFactory` | Configure the execution backend. | Supply a factory that sets up distributed resources (for example, a site-specific TaskVine profile).  The factory only needs to return an object with a ``create_runner`` method. |
-| :func:`analysis.topeft_run2.workflow.run_workflow` | Convenience wrapper mirroring the CLI. | Import the function and feed it the :class:`RunConfig` returned by the quickstart helpers when you want to programmatically drive the workflow from notebooks or scripts. |
+| `RunConfigBuilder` | Merge CLI, defaults, and YAML into a `RunConfig`. | Subclass the builder and override `build(...)` to recognise additional YAML keys (for example, executor-specific settings).  The CLI parser can expose the same flag so that existing scripts keep working. |
+| `SampleLoader` | Resolve JSON/CFG inputs and normalize metadata. | Provide a custom ``SampleLoader`` to support other manifest formats (for example, CSV).  The replacement object must offer ``collect`` and ``load`` methods returning the same structures. |
+| `analysis.topeft_run2.workflow.ChannelPlanner` | Activate channels according to metadata scenarios. | Extend `topeft.modules.channel_metadata.ChannelMetadataHelper` or wrap the planner to insert additional filters (for example, dropping jet categories). |
+| `analysis.topeft_run2.workflow.HistogramPlanner` | Enumerate histogram combinations for execution. | Pass a custom planner that rewrites the histogram list (for example, sampling only a subset of variables) before the workflow starts the executor. |
+| `analysis.topeft_run2.workflow.ExecutorFactory` | Configure the execution backend. | Supply a factory that sets up distributed resources (for example, a site-specific TaskVine profile).  The factory only needs to return an object with a ``create_runner`` method. |
+| `analysis.topeft_run2.workflow.run_workflow(...)` | Convenience wrapper mirroring the CLI. | Import the function and feed it the `RunConfig` returned by the quickstart helpers when you want to programmatically drive the workflow from notebooks or scripts. |
 
 ### Adding new configuration values
 
 1. Extend the CLI parser in ``run_analysis.py`` with the new flag.
-2. Update the ``field_specs`` mapping in :class:`RunConfigBuilder` so that the
-   value is recorded inside :class:`RunConfig`.  Reuse the existing coercion
+2. Update the ``field_specs`` mapping in `RunConfigBuilder` so that the
+   value is recorded inside `RunConfig`.  Reuse the existing coercion
    helpers when possible (``coerce_bool``, ``coerce_int`` or
    ``normalize_sequence``).
 3. Add documentation for the new key to the YAML options file used in your team
    and mention the knob in the quickstart walkthrough if it helps new users.
-4. Use the value in either :class:`RunWorkflow` or
-   :class:`AnalysisProcessor`.  Because :class:`RunConfig` is a dataclass, adding
+4. Use the value in either `RunWorkflow` or
+   `AnalysisProcessor`.  Because `RunConfig` is a dataclass, adding
    optional attributes is backwards compatible and automatically reflected in the
    quickstart return value.
 
@@ -314,7 +314,7 @@ switching executors once the run is ready to scale beyond the local machine.
   an error because only the local ``futures`` backend is configured for fast
   validation runs.  Drop the flag or switch executors when performing smoke tests
   on remote resources.
-* ``FileNotFoundError`` from :class:`SampleLoader` usually means that relative
+* ``FileNotFoundError`` from `SampleLoader` usually means that relative
   paths were provided.  Always invoke ``run_analysis.py`` from the repository
   root or supply absolute paths.
 * If histogram handling fails with an ``ImportError`` noting that

--- a/docs/sample_metadata_reference.md
+++ b/docs/sample_metadata_reference.md
@@ -11,9 +11,9 @@ dataclasses used by the workflow, see the
 ## Required keys
 
 Every JSON manifest must provide the fields listed below.  The
-:class:`analysis.topeft_run2.run_analysis_helpers.SampleLoader` enforces types and
-fills defaults where appropriate during :func:`collect` and
-:func:`load`. 【F:analysis/topeft_run2/run_analysis_helpers.py†L183-L242】
+`analysis.topeft_run2.run_analysis_helpers.SampleLoader` enforces types and
+fills defaults where appropriate during `collect(...)` and
+`load(...)` (source: `analysis/topeft_run2/run_analysis_helpers.py`).
 
 | Key | Type | Purpose | Notes |
 | --- | ---- | ------- | ----- |
@@ -36,9 +36,9 @@ helpers or downstream plotting tools.
 When ``isData`` is ``false`` the loader will look for extra ``nSumOfWeights_*``
 entries that correspond to metadata-driven systematic variations.  The keys must
 match the variations extracted from ``analysis/metadata/metadata.yml`` via
-:func:`analysis.topeft_run2.run_analysis_helpers.weight_variations_from_metadata`.
+`analysis.topeft_run2.run_analysis_helpers.weight_variations_from_metadata(...)`.
 Any variation found in the JSON is converted to ``float`` before being attached
-to the sample record. 【F:analysis/topeft_run2/run_analysis_helpers.py†L232-L241】
+to the sample record (source: `analysis/topeft_run2/run_analysis_helpers.py`).
 The resulting payload is carried directly into the histogram planning
 dataclasses described in the
 [Run configuration dataclasses and metadata overview](dataclasses_and_metadata.md).
@@ -82,7 +82,7 @@ the variation from the metadata scenario or record the corresponding
 ``run_analysis.py`` and the quickstart helper accept ``--prefix`` (aliased as
 ``--redirector``) to prepend a URI before each file.  The loader stores the value
 under ``redirector`` and concatenates it with each entry in ``files`` when
-building the job list. 【F:analysis/topeft_run2/run_analysis_helpers.py†L198-L224】
+building the job list (source: `analysis/topeft_run2/run_analysis_helpers.py`).
 Use this mechanism whenever the JSON lists EOS or site-local paths that require
 XRootD access.
 
@@ -101,7 +101,7 @@ signal_samples.json
 
 Set ``isData`` to ``true`` for collision data.  In this mode the loader skips the
 optional systematic sums of weights and relies on the nominal ``nSumOfWeights``
-to be identical to ``nEvents``. 【F:analysis/topeft_run2/run_analysis_helpers.py†L232-L235】【F:input_samples/sample_jsons/data_samples/2018/MuonEG_A-UL2018_NDSkim.json†L1-L19】
+to be identical to ``nEvents`` (sources: `analysis/topeft_run2/run_analysis_helpers.py`, `input_samples/sample_jsons/data_samples/2018/MuonEG_A-UL2018_NDSkim.json`).
 A representative data manifest looks like:
 
 ```json
@@ -130,7 +130,7 @@ below outlines frequent failures and the quickest way to recover.
 
 | Error message | Root cause | Fix |
 | ------------- | ---------- | --- |
-| ``FileNotFoundError: Input file /path/to/sample.json not found!`` | The manifest path is relative to a different working directory or contains a typo. | Run the command from the repository root or switch to an absolute path.  When using ``.cfg`` bundles, prefer paths relative to the bundle itself. 【F:analysis/topeft_run2/run_analysis_helpers.py†L209-L228】 |
+| ``FileNotFoundError: Input file /path/to/sample.json not found!`` | The manifest path is relative to a different working directory or contains a typo. | Run the command from the repository root or switch to an absolute path.  When using ``.cfg`` bundles, prefer paths relative to the bundle itself (source: `analysis/topeft_run2/run_analysis_helpers.py`). |
 | ``Missing weight variation: nSumOfWeights_ISRUp`` | The metadata scenario requests ISR variations but the JSON omits the matching sum of weights. | Add the ``nSumOfWeights_ISRUp`` (and corresponding ``Down``) entries to the manifest or drop the variation from ``systematics`` in the metadata file. |
 | ``ValueError: Unsupported input type`` | A ``.cfg`` file references a non-JSON asset (for example, a TXT list). | Convert the list into JSON manifests or expand the ``.cfg`` to point directly at the ``.json`` files. |
 

--- a/docs/tuple_key_audit.md
+++ b/docs/tuple_key_audit.md
@@ -3,20 +3,20 @@
 This audit records where histogram tuple keys are created and consumed across the repository. The target convention is `(variable, channel, application, sample, systematic)`; tuple consumers now reject legacy 4-tuples to avoid silent reshaping.
 
 ## Run 2 workflow
-- `analysis/topeft_run2/analysis_processor.py` validates that `hist_keys` entries are 5-element tuples and builds keys as `(variable, channel, application, sample, systematic)`.【F:analysis/topeft_run2/analysis_processor.py†L322-L552】
+- `analysis/topeft_run2/analysis_processor.py` validates that `hist_keys` entries are 5-element tuples and builds keys as `(variable, channel, application, sample, systematic)` (source: `analysis/topeft_run2/analysis_processor.py`).
 - Downstream `HistogramCombination` usage in the Run 2 workflow therefore aligns with the 5-tuple standard.
 
 ## Training tutorial workflow
-- The training processor now emits 5-tuples `(variable, channel, application, sample, systematic)` with an explicit default application tag.【F:analysis/training/simple_processor.py†L308-L379】
-- Tests enforce the 5-tuple shape and require no categorical axes in the stored histograms.【F:tests/test_training_tuple_output.py†L94-L117】
-- The training runner already serialises 5-tuple histogram keys for downstream consumption.【F:analysis/training/simple_run.py†L1-L117】
+- The training processor now emits 5-tuples `(variable, channel, application, sample, systematic)` with an explicit default application tag (source: `analysis/training/simple_processor.py`).
+- Tests enforce the 5-tuple shape and require no categorical axes in the stored histograms (source: `tests/test_training_tuple_output.py`).
+- The training runner already serialises 5-tuple histogram keys for downstream consumption (source: `analysis/training/simple_run.py`).
 
 ## Shared runner output helpers
-- `topeft/modules/runner_output.py` rejects non-5-tuple histogram keys and raises on categorical histogram axes to avoid fallback reconstruction.【F:topeft/modules/runner_output.py†L1-L154】
+- `topeft/modules/runner_output.py` rejects non-5-tuple histogram keys and raises on categorical histogram axes to avoid fallback reconstruction (source: `topeft/modules/runner_output.py`).
 
 ## Flip-rate (charge flip) measurement
-- The flip runner enforces 5-tuples before materialising histogram summaries, matching the tuple-key standard.【F:analysis/flip_measurement/run_flip.py†L126-L151】
+- The flip runner enforces 5-tuples before materialising histogram summaries, matching the tuple-key standard (source: `analysis/flip_measurement/run_flip.py`).
 
 ## MC validation
-- The generator-level validation processor builds 5-element histogram tuples and labels aggregated outputs with optional application tags.【F:analysis/mc_validation/mc_validation_gen_processor.py†L299-L361】
-- Plotting helpers normalise tuple keys to the 5-field standard and rely on stored application/channel/systematic values.【F:analysis/mc_validation/plot_utils.py†L19-L115】
+- The generator-level validation processor builds 5-element histogram tuples and labels aggregated outputs with optional application tags (source: `analysis/mc_validation/mc_validation_gen_processor.py`).
+- Plotting helpers normalise tuple keys to the 5-field standard and rely on stored application/channel/systematic values (source: `analysis/mc_validation/plot_utils.py`).


### PR DESCRIPTION
### Summary

- Replace GitHub-hostile prose markup in `docs/` with plain Markdown/code formatting.
- Convert leftover Sphinx-style inline roles into backticked symbols/callables.
- Replace `【F:...】` source artifacts with readable source notes.
- Normalize a few prose-level `::` / `root::` intros so they render naturally in GitHub.
- Keep the change strictly docs-only: no code, runtime, or analysis-semantics changes.

### Motivation

Some user-facing `topeft` docs still contained markup that renders poorly in the GitHub web UI, including Sphinx/reST inline roles and `【F:...】` source artifacts. That made otherwise useful documentation harder to read and less approachable for people browsing the repo directly on GitHub.

This PR cleans those remaining cases without changing the underlying technical meaning of the docs.

### Implementation details

#### A. Replace GitHub-hostile inline role markup

Updated the remaining docs pages that still used Sphinx-style inline roles so GitHub shows readable symbol names instead of raw role syntax.

Files changed:
- `docs/run_analysis_configuration.md`
- `docs/sample_metadata_reference.md`

Examples of the conversion style:
- `:class:\`RunConfigBuilder\`` → ``RunConfigBuilder``
- `:func:\`weight_variations_from_metadata\`` → ``weight_variations_from_metadata(...)``
- dotted paths/functions now appear as backticked code references rather than raw Sphinx roles

This keeps the references precise while making them readable in plain Markdown contexts.

#### B. Replace `【F:...】` source artifacts with readable prose notes

Several pages still contained source-artifact markers of the form `【F:...】`, which do not read naturally on GitHub.

Those were replaced with plain source notes such as:
- `(source: \`analysis/topeft_run2/run_analysis_helpers.py\`)`
- `(sources: \`...\`, \`...\`)`

Files changed:
- `docs/dataclasses_and_metadata.md`
- `docs/sample_metadata_reference.md`
- `docs/tuple_key_audit.md`

This preserves provenance/context while removing UI-hostile markup.

#### C. Normalize prose-level literal-block intros

A few prose lines still used reST-style `::` / `root::` wording that is awkward in GitHub Markdown rendering.

These were normalized to plain prose such as:
- `package remains importable:` instead of `package remains importable::`
- `root:` instead of `root::`

Files changed:
- `docs/environment_packaging.md`
- `docs/run_analysis_configuration.md`

#### D. Scope / semantics

This PR is intentionally narrow:
- no code files changed
- no command semantics changed
- no workflow behavior changed
- no analysis or physics logic changed

The edits are presentation/readability cleanups only.

### Testing

Docs-only verification was used.

Commands/checks performed:
```bash
rg -n "【[^】]+】" README.md docs -S || true
rg -n "】|【" README.md docs -S || true
rg -n "\[[A-Z]:[^\]]+\]" README.md docs -S || true
rg -n ":[A-Za-z0-9_:.+-]+:\`" README.md docs -S || true
rg -n "::($|[^:])|root::" README.md docs -S || true
git diff -- README.md docs/*.md docs/**/*.md || true
git status -sb
```

What this covers:
- confirms removal of remaining GitHub-hostile markup patterns in `README.md` and `docs/`
- confirms the final diff is docs-only
- confirms no tracked modifications were left uncommitted

Not run:
```bash
compileall
pytest
```

Reason: this PR does not modify code or runtime behavior.

### Review notes

Please review this as a docs-rendering/readability PR, not as a semantic docs rewrite.

Key points to check:
- converted symbol/function references still read precisely
- source-note replacements preserve meaning/context
- no wording accidentally changes workflow behavior or requirements
- no user-facing command examples were altered in substance