### PR TITLE
Add Run 3 PuppiMET handling and forward-eta correction policies

### DIFF
--- a/analysis/btagMCeff/btagMCeff.py
+++ b/analysis/btagMCeff/btagMCeff.py
@@ -16,7 +16,7 @@ from topeft.modules.paths import topeft_path
 from topcoffea.modules.get_param_from_jsons import GetParam
 get_te_param = GetParam(topeft_path("params/params.json"))
 
-from topeft.modules.corrections import ApplyJetCorrections, ApplyJetSystematics, get_selected_met
+from topeft.modules.corrections import ApplyJetCorrections, ApplyJetSystematics, get_selected_met, resolve_forward_eta_stochastic_jer_suppression
 
 #coffea.deprecations_as_errors = True
 
@@ -72,6 +72,10 @@ class AnalysisProcessor(processor.ProcessorABC):
         if year.startswith("202"):
             is_run3 = True
         is_run2 = not is_run3
+        effective_suppress_forward_eta_stochastic_jer = resolve_forward_eta_stochastic_jer_suppression(
+            is_run3,
+            self.suppress_forward_eta_stochastic_jer,
+        )
 
         run_era = None
         if isData:
@@ -162,7 +166,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             isData=isData,
             era=run_era,
             run=run,
-            suppress_forward_eta_stochastic_jer=self.suppress_forward_eta_stochastic_jer,
+            suppress_forward_eta_stochastic_jer=effective_suppress_forward_eta_stochastic_jer,
         ).build(j, lazy_cache=events_cache)  #Run3 ready
         j = ApplyJetSystematics(year,j,syst_var)
         met = ApplyJetCorrections(year, corr_type='met', isData=isData, era=run_era, run=run).build(met_raw, j, lazy_cache=events_cache)

--- a/analysis/btagMCeff/btagMCeff.py
+++ b/analysis/btagMCeff/btagMCeff.py
@@ -16,7 +16,7 @@ from topeft.modules.paths import topeft_path
 from topcoffea.modules.get_param_from_jsons import GetParam
 get_te_param = GetParam(topeft_path("params/params.json"))
 
-from topeft.modules.corrections import ApplyJetCorrections, ApplyJetSystematics
+from topeft.modules.corrections import ApplyJetCorrections, ApplyJetSystematics, get_selected_met
 
 #coffea.deprecations_as_errors = True
 
@@ -81,7 +81,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                 run_era = self._samples[dataset]["path"].split("/")[2].split("-")[0][-1]
 
         # Initialize objects
-        met = events.MET
+        met = get_selected_met(events, year)
         e   = events.Electron
         mu  = events.Muon
         j   = events.Jet

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -22,7 +22,7 @@ import topcoffea.modules.corrections as tc_cor
 from topeft.modules.axes import info as axes_info
 from topeft.modules.axes import info_2d as axes_info_2d
 from topeft.modules.paths import topeft_path
-from topeft.modules.corrections import ApplyJetCorrections, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, ApplyRochesterCorrections, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_supported_jet_systematics
+from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, ApplyRochesterCorrections, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_supported_jet_systematics, get_supported_met_systematics, is_met_unclustered_systematic
 import topeft.modules.event_selection as te_es
 import topeft.modules.object_selection as te_os
 from topcoffea.modules.get_param_from_jsons import GetParam
@@ -514,7 +514,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         # Initialize objects
 
-        met  = events.MET
+        met  = get_selected_met(events, year)
         ele  = events.Electron
         mu   = events.Muon
         tau  = events.Tau
@@ -542,7 +542,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         # An array of lenght events that is just 1 for each event
         # Probably there's a better way to do this, but we use this method elsewhere so I guess why not..
-        events.nom = ak.ones_like(events.MET.pt)
+        events.nom = ak.ones_like(met.pt)
 
         ele["idEmu"] = te_os.ttH_idEmu_cuts_E3(ele.hoe, ele.eta, ele.deltaEtaSC, ele.eInvMinusPInv, ele.sieie)
         ele["conept"] = leptonSelection.coneptElec(ele)
@@ -758,6 +758,9 @@ class AnalysisProcessor(processor.ProcessorABC):
         obj_correction_syst_lst = get_supported_jet_systematics(
             year, isData=isData, era=run_era
         )
+        obj_correction_syst_lst.extend(
+            get_supported_met_systematics(year, isData=isData, era=run_era)
+        )
         if self.enable_tau_blocks:
             obj_correction_syst_lst.append("TESUp")
             obj_correction_syst_lst.append("TESDown")
@@ -882,6 +885,8 @@ class AnalysisProcessor(processor.ProcessorABC):
             ).build(cleanedJets, lazy_cache=events_cache)  #Run3 ready
             cleanedJets = ApplyJetSystematics(year,cleanedJets,syst_var)
             met = ApplyJetCorrections(year, corr_type='met', isData=isData, era=run_era, run=run).build(met_raw, cleanedJets, lazy_cache=events_cache)
+            if is_met_unclustered_systematic(syst_var):
+                met = ApplyMETSystematics(met, syst_var)
 
             if is_run3:
                 jet_id_mask = tc_os.run3_nanoV12_ak4puppi_jet_id(cleanedJets, year, working_point="tight")

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -155,7 +155,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         return bool(fill_sumw2_hist) and wgt_fluct == "nominal"
 
-    def __init__(self, samples, wc_names_lst=[], hist_lst=None, ecut_threshold=None, fill_sumw2_hist=True, do_systematics=False, split_by_lepton_flavor=False, skip_signal_regions=False, skip_control_regions=False, muonSyst='nominal', dtype=np.float32, rebin=False, offZ_split=False, tau_h_analysis=False, fwd_analysis=False, all_analysis=False, useRun3MVA=True, tau_run_mode="standard", sr_category_dict=None, cr_category_dict=None, suppress_forward_eta_stochastic_jer=False):
+    def __init__(self, samples, wc_names_lst=[], hist_lst=None, ecut_threshold=None, fill_sumw2_hist=True, do_systematics=False, split_by_lepton_flavor=False, skip_signal_regions=False, skip_control_regions=False, muonSyst='nominal', dtype=np.float32, rebin=False, offZ_split=False, tau_h_analysis=False, fwd_analysis=False, all_analysis=False, useRun3MVA=True, tau_run_mode="standard", sr_category_dict=None, cr_category_dict=None, suppress_forward_eta_stochastic_jer=False, fwd_eta_band_pt_apply="auto"):
 
         self._samples = samples
         self._wc_names_lst = wc_names_lst
@@ -206,6 +206,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         self.useRun3MVA = useRun3MVA #can be switched to False use the alternative cuts
         self.tau_run_mode = tau_run_mode
         self.suppress_forward_eta_stochastic_jer = suppress_forward_eta_stochastic_jer
+        self.fwd_eta_band_pt_apply = fwd_eta_band_pt_apply
         # self._tau_wp_checked = False
 
         self._fill_sumw2_hist = bool(fill_sumw2_hist)  # Whether to fill the w**2 companion histograms
@@ -891,10 +892,20 @@ class AnalysisProcessor(processor.ProcessorABC):
             if is_run3:
                 jet_id_mask = tc_os.run3_nanoV12_ak4puppi_jet_id(cleanedJets, year, working_point="tight")
                 cleanedJets["isGood"] = ((getattr(cleanedJets, jetptname) > 30.) & (abs(cleanedJets.eta) < get_te_param("eta_j_cut")) & jet_id_mask)
-                cleanedJets["isFwd"] = ((getattr(cleanedJets, jetptname) > 50.) & (abs(cleanedJets.eta) > get_te_param("eta_j_cut")) & jet_id_mask)
             else:
+                jet_id_mask = True
                 cleanedJets["isGood"] = tc_os.is_tight_jet(getattr(cleanedJets, jetptname), cleanedJets.eta, cleanedJets.jetId, pt_cut=30., eta_cut=get_te_param("eta_j_cut"), id_cut=get_te_param("jet_id_cut"))
-                cleanedJets["isFwd"] = ((getattr(cleanedJets, jetptname) > 50.) & (abs(cleanedJets.eta) > get_te_param("eta_j_cut"))) #te_os.isFwdJet(getattr(cleanedJets, jetptname), cleanedJets.eta, cleanedJets.jetId, jetPtCut=50.)
+            cleanedJets["isFwd"] = te_os.is_forward_jet_eta_banded(
+                getattr(cleanedJets, jetptname),
+                cleanedJets.eta,
+                eta_cut=get_te_param("eta_j_cut"),
+                baseline_pt_cut=get_te_param("fwd_jet_pt_cut"),
+                apply_eta_band_pt=te_os.resolve_fwd_eta_band_pt_apply(year, self.fwd_eta_band_pt_apply),
+                eta_band_min=get_te_param("fwd_jet_eta_band_min"),
+                eta_band_max=get_te_param("fwd_jet_eta_band_max"),
+                eta_band_pt_cut=get_te_param("fwd_jet_eta_band_pt_cut"),
+                quality_mask=jet_id_mask,
+            )
             goodJets = cleanedJets[cleanedJets.isGood]
             fwdJets  = cleanedJets[cleanedJets.isFwd]
 

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -22,7 +22,7 @@ import topcoffea.modules.corrections as tc_cor
 from topeft.modules.axes import info as axes_info
 from topeft.modules.axes import info_2d as axes_info_2d
 from topeft.modules.paths import topeft_path
-from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, ApplyRochesterCorrections, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_supported_jet_systematics, get_supported_met_systematics, is_met_unclustered_systematic
+from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, ApplyRochesterCorrections, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_supported_jet_systematics, get_supported_met_systematics, is_met_unclustered_systematic, resolve_forward_eta_stochastic_jer_suppression
 import topeft.modules.event_selection as te_es
 import topeft.modules.object_selection as te_os
 from topcoffea.modules.get_param_from_jsons import GetParam
@@ -432,6 +432,10 @@ class AnalysisProcessor(processor.ProcessorABC):
         if year.startswith("202"):
             is_run3 = True
         is_run2 = not is_run3
+        effective_suppress_forward_eta_stochastic_jer = resolve_forward_eta_stochastic_jer_suppression(
+            is_run3,
+            self.suppress_forward_eta_stochastic_jer,
+        )
 
         def _log_tau_flag_counts(label, flag_arrays):
             if len(events) == 0:
@@ -882,7 +886,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                 isData=isData,
                 era=run_era,
                 run=run,
-                suppress_forward_eta_stochastic_jer=self.suppress_forward_eta_stochastic_jer,
+                suppress_forward_eta_stochastic_jer=effective_suppress_forward_eta_stochastic_jer,
             ).build(cleanedJets, lazy_cache=events_cache)  #Run3 ready
             cleanedJets = ApplyJetSystematics(year,cleanedJets,syst_var)
             met = ApplyJetCorrections(year, corr_type='met', isData=isData, era=run_era, run=run).build(met_raw, cleanedJets, lazy_cache=events_cache)
@@ -900,7 +904,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                 cleanedJets.eta,
                 eta_cut=get_te_param("eta_j_cut"),
                 baseline_pt_cut=get_te_param("fwd_jet_pt_cut"),
-                apply_eta_band_pt=te_os.resolve_fwd_eta_band_pt_apply(year, self.fwd_eta_band_pt_apply),
+                apply_eta_band_pt=te_os.resolve_fwd_eta_band_pt_apply(is_run3, self.fwd_eta_band_pt_apply),
                 eta_band_min=get_te_param("fwd_jet_eta_band_min"),
                 eta_band_max=get_te_param("fwd_jet_eta_band_max"),
                 eta_band_pt_cut=get_te_param("fwd_jet_eta_band_pt_cut"),

--- a/analysis/topeft_run2/analysis_processor_diboson.py
+++ b/analysis/topeft_run2/analysis_processor_diboson.py
@@ -57,7 +57,7 @@ def construct_cat_name(chan_str,njet_str=None,flav_str=None):
 
 class AnalysisProcessor(processor.ProcessorABC):
 
-    def __init__(self, samples, wc_names_lst=[], hist_lst=None, ecut_threshold=None, do_errors=False, do_systematics=False, split_by_lepton_flavor=False, skip_signal_regions=False, skip_control_regions=False, muonSyst='nominal', dtype=np.float32, rebin=False, offZ_split=False, tau_h_analysis=False, fwd_analysis=False, useRun3MVA=True, suppress_forward_eta_stochastic_jer=False):
+    def __init__(self, samples, wc_names_lst=[], hist_lst=None, ecut_threshold=None, do_errors=False, do_systematics=False, split_by_lepton_flavor=False, skip_signal_regions=False, skip_control_regions=False, muonSyst='nominal', dtype=np.float32, rebin=False, offZ_split=False, tau_h_analysis=False, fwd_analysis=False, useRun3MVA=True, suppress_forward_eta_stochastic_jer=False, fwd_eta_band_pt_apply="auto"):
 
         self._samples = samples
         self._wc_names_lst = wc_names_lst
@@ -67,6 +67,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         self.fwd_analysis = fwd_analysis
         self.useRun3MVA = useRun3MVA #can be switched to False use the alternative cuts
         self.suppress_forward_eta_stochastic_jer = suppress_forward_eta_stochastic_jer
+        self.fwd_eta_band_pt_apply = fwd_eta_band_pt_apply
 
         proc_axis = hist.axis.StrCategory([], name="process", growth=True)
         chan_axis = hist.axis.StrCategory([], name="channel", growth=True)
@@ -537,10 +538,20 @@ class AnalysisProcessor(processor.ProcessorABC):
             if is_run3:
                 jet_id_mask = tc_os.run3_nanoV12_ak4puppi_jet_id(cleanedJets, year, working_point="tight")
                 cleanedJets["isGood"] = ((getattr(cleanedJets, jetptname) > 30.) & (abs(cleanedJets.eta) < get_te_param("eta_j_cut")) & jet_id_mask)
-                cleanedJets["isFwd"] = ((getattr(cleanedJets, jetptname) > 50.) & (abs(cleanedJets.eta) > get_te_param("eta_j_cut")) & jet_id_mask)
             else:
+                jet_id_mask = True
                 cleanedJets["isGood"] = tc_os.is_tight_jet(getattr(cleanedJets, jetptname), cleanedJets.eta, cleanedJets.jetId, pt_cut=30., eta_cut=get_te_param("eta_j_cut"), id_cut=get_te_param("jet_id_cut"))
-                cleanedJets["isFwd"] = te_os.isFwdJet(getattr(cleanedJets, jetptname), cleanedJets.eta, cleanedJets.jetId, jetPtCut=50.)
+            cleanedJets["isFwd"] = te_os.is_forward_jet_eta_banded(
+                getattr(cleanedJets, jetptname),
+                cleanedJets.eta,
+                eta_cut=get_te_param("eta_j_cut"),
+                baseline_pt_cut=get_te_param("fwd_jet_pt_cut"),
+                apply_eta_band_pt=te_os.resolve_fwd_eta_band_pt_apply(year, self.fwd_eta_band_pt_apply),
+                eta_band_min=get_te_param("fwd_jet_eta_band_min"),
+                eta_band_max=get_te_param("fwd_jet_eta_band_max"),
+                eta_band_pt_cut=get_te_param("fwd_jet_eta_band_pt_cut"),
+                quality_mask=jet_id_mask,
+            )
             goodJets = cleanedJets[cleanedJets.isGood]
             fwdJets  = cleanedJets[cleanedJets.isFwd]
 

--- a/analysis/topeft_run2/analysis_processor_diboson.py
+++ b/analysis/topeft_run2/analysis_processor_diboson.py
@@ -20,7 +20,7 @@ import topcoffea.modules.corrections as tc_cor
 
 from topeft.modules.axes import info as axes_info
 from topeft.modules.paths import topeft_path
-from topeft.modules.corrections import ApplyJetCorrections, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, ApplyRochesterCorrections, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps
+from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, ApplyRochesterCorrections, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_supported_met_systematics, is_met_unclustered_systematic
 import topeft.modules.event_selection as te_es
 import topeft.modules.object_selection as te_os
 from topcoffea.modules.get_param_from_jsons import GetParam
@@ -224,7 +224,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             sampleType = "prompt_and_conversions"
 
         # Initialize objects
-        met  = events.MET
+        met  = get_selected_met(events, year)
         ele  = events.Electron
         mu   = events.Muon
         tau  = events.Tau
@@ -252,7 +252,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         # An array of lenght events that is just 1 for each event
         # Probably there's a better way to do this, but we use this method elsewhere so I guess why not..
-        events.nom = ak.ones_like(events.MET.pt)
+        events.nom = ak.ones_like(met.pt)
 
         ele["idEmu"] = te_os.ttH_idEmu_cuts_E3(ele.hoe, ele.eta, ele.deltaEtaSC, ele.eInvMinusPInv, ele.sieie)
         ele["conept"] = leptonSelection.coneptElec(ele)
@@ -414,6 +414,9 @@ class AnalysisProcessor(processor.ProcessorABC):
         obj_correction_syst_lst = [
             f'JER_{year}Up', f'JER_{year}Down'
         ] + obj_jes_entries
+        obj_correction_syst_lst.extend(
+            get_supported_met_systematics(year, isData=isData, era=run_era)
+        )
         if self.tau_h_analysis:
             obj_correction_syst_lst.append("TESUp")
             obj_correction_syst_lst.append("TESDown")
@@ -528,6 +531,8 @@ class AnalysisProcessor(processor.ProcessorABC):
             ).build(cleanedJets, lazy_cache=events_cache)  #Run3 ready
             cleanedJets = ApplyJetSystematics(year,cleanedJets,syst_var)
             met = ApplyJetCorrections(year, corr_type='met', isData=isData, era=run_era, run=run).build(met_raw, cleanedJets, lazy_cache=events_cache)
+            if is_met_unclustered_systematic(syst_var):
+                met = ApplyMETSystematics(met, syst_var)
 
             if is_run3:
                 jet_id_mask = tc_os.run3_nanoV12_ak4puppi_jet_id(cleanedJets, year, working_point="tight")

--- a/analysis/topeft_run2/analysis_processor_diboson.py
+++ b/analysis/topeft_run2/analysis_processor_diboson.py
@@ -20,7 +20,7 @@ import topcoffea.modules.corrections as tc_cor
 
 from topeft.modules.axes import info as axes_info
 from topeft.modules.paths import topeft_path
-from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, ApplyRochesterCorrections, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_supported_met_systematics, is_met_unclustered_systematic
+from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, ApplyRochesterCorrections, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_supported_met_systematics, is_met_unclustered_systematic, resolve_forward_eta_stochastic_jer_suppression
 import topeft.modules.event_selection as te_es
 import topeft.modules.object_selection as te_os
 from topcoffea.modules.get_param_from_jsons import GetParam
@@ -158,6 +158,10 @@ class AnalysisProcessor(processor.ProcessorABC):
         if year.startswith("202"):
             is_run3 = True
         is_run2 = not is_run3
+        effective_suppress_forward_eta_stochastic_jer = resolve_forward_eta_stochastic_jer_suppression(
+            is_run3,
+            self.suppress_forward_eta_stochastic_jer,
+        )
 
         run_era = None
         if isData:
@@ -528,7 +532,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                 isData=isData,
                 era=run_era,
                 run=run,
-                suppress_forward_eta_stochastic_jer=self.suppress_forward_eta_stochastic_jer,
+                suppress_forward_eta_stochastic_jer=effective_suppress_forward_eta_stochastic_jer,
             ).build(cleanedJets, lazy_cache=events_cache)  #Run3 ready
             cleanedJets = ApplyJetSystematics(year,cleanedJets,syst_var)
             met = ApplyJetCorrections(year, corr_type='met', isData=isData, era=run_era, run=run).build(met_raw, cleanedJets, lazy_cache=events_cache)
@@ -546,7 +550,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                 cleanedJets.eta,
                 eta_cut=get_te_param("eta_j_cut"),
                 baseline_pt_cut=get_te_param("fwd_jet_pt_cut"),
-                apply_eta_band_pt=te_os.resolve_fwd_eta_band_pt_apply(year, self.fwd_eta_band_pt_apply),
+                apply_eta_band_pt=te_os.resolve_fwd_eta_band_pt_apply(is_run3, self.fwd_eta_band_pt_apply),
                 eta_band_min=get_te_param("fwd_jet_eta_band_min"),
                 eta_band_max=get_te_param("fwd_jet_eta_band_max"),
                 eta_band_pt_cut=get_te_param("fwd_jet_eta_band_pt_cut"),

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -271,7 +271,7 @@ def _resolve_environment_file(env_override, use_remote_env, extra_pip_local=None
 
 
 def _prepare_work_queue_staging_directory(filepath_override=None):
-    requested_path = filepath_override or f"/scratch365/{os.environ.get('USER', 'user')}/workers"
+    requested_path = filepath_override or f"/groups/klannon/{os.environ.get('USER', 'user')}/workers"
     path_preexisted = os.path.exists(requested_path)
 
     try:

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -682,7 +682,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--chunksize",
         "-s",
-        default=20000,
+        default=100000,
         help="Number of events per chunk",
     )
     parser.add_argument(

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -735,6 +735,15 @@ if __name__ == "__main__":
         ),
     )
     parser.add_argument(
+        "--fwd-eta-band-pt-apply",
+        choices=("auto", "on", "off"),
+        default="auto",
+        help=(
+            "Control the forward-jet eta-band pT tightening. auto applies it for "
+            "Run 3 only, on applies it for all years, and off disables it for all years."
+        ),
+    )
+    parser.add_argument(
         "--split-lep-flavor",
         action="store_true",
         help="Split up categories by lepton flavor",
@@ -917,6 +926,7 @@ if __name__ == "__main__":
     fill_sumw2 = not args.no_sumw2
     do_systs = args.do_systs
     suppress_forward_eta_stochastic_jer = args.suppress_forward_eta_stochastic_jer
+    fwd_eta_band_pt_apply = args.fwd_eta_band_pt_apply
     split_lep_flavor = args.split_lep_flavor
     offZ_split = args.offZ_3l_split
     tau_h_analysis = args.tau_h_analysis
@@ -966,6 +976,7 @@ if __name__ == "__main__":
             "suppress_forward_eta_stochastic_jer",
             suppress_forward_eta_stochastic_jer,
         )
+        fwd_eta_band_pt_apply = ops.pop("fwd_eta_band_pt_apply", fwd_eta_band_pt_apply)
         split_lep_flavor = ops.pop("split_lep_flavor", split_lep_flavor)
         offZ_split = ops.pop("offZ_split", offZ_split)
         tau_h_analysis = ops.pop("tau_h_analysis", tau_h_analysis)
@@ -1487,6 +1498,7 @@ if __name__ == "__main__":
                 "skip_sr": skip_sr,
                 "skip_cr": skip_cr,
                 "do_systs": do_systs,
+                "fwd_eta_band_pt_apply": fwd_eta_band_pt_apply,
                 "fill_sumw2": fill_sumw2,
                 "useRun3MVA": useRun3MVA,
             },
@@ -1576,6 +1588,7 @@ if __name__ == "__main__":
         sr_category_dict=category_group_selection["sr_category_dict"],
         cr_category_dict=category_group_selection["cr_category_dict"],
         suppress_forward_eta_stochastic_jer=suppress_forward_eta_stochastic_jer,
+        fwd_eta_band_pt_apply=fwd_eta_band_pt_apply,
     )
 
     if executor_name in ["work_queue", "taskvine"]:

--- a/analysis/topeft_run2/run_analysis_diboson.py
+++ b/analysis/topeft_run2/run_analysis_diboson.py
@@ -52,6 +52,12 @@ if __name__ == '__main__':
     parser.add_argument('--offZ-3l-split', dest='offZ_3l_split', action='store_true', help = 'Split up 3l offZ categories')
     parser.add_argument('--tau-h-analysis', dest='tau_h_analysis', action='store_true', help = 'Add tau channels')
     parser.add_argument('--fwd-analysis'    , action='store_true', help = 'Add fwd channels')
+    parser.add_argument(
+        '--fwd-eta-band-pt-apply',
+        choices=('auto', 'on', 'off'),
+        default='auto',
+        help='Control forward-jet eta-band pT tightening: auto is Run 3 only, on is all years, off is disabled.',
+    )
     parser.add_argument('--skip-sr', action='store_true', help = 'Skip all signal region categories')
     parser.add_argument('--skip-cr', action='store_true', help = 'Skip all control region categories')
     parser.add_argument('--do-np'  , action='store_true', help = 'Perform nonprompt estimation on the output hist, and save a new hist with the np contribution included. Note that signal, background and data samples should all be processed together in order for this option to make sense.')
@@ -80,6 +86,7 @@ if __name__ == '__main__':
     offZ_split = args.offZ_3l_split
     tau_h_analysis = args.tau_h_analysis
     fwd_analysis = args.fwd_analysis
+    fwd_eta_band_pt_apply = args.fwd_eta_band_pt_apply
     skip_sr    = args.skip_sr
     skip_cr    = args.skip_cr
     do_np      = args.do_np
@@ -253,7 +260,7 @@ if __name__ == '__main__':
     else:
         print('No Wilson coefficients specified')
 
-    processor_instance = analysis_processor.AnalysisProcessor(samplesdict,wc_lst,hist_lst,ecut_threshold,do_errors,do_systs,split_lep_flavor,skip_sr,skip_cr,offZ_split=offZ_split,tau_h_analysis=tau_h_analysis,fwd_analysis=fwd_analysis,useRun3MVA=useRun3MVA)
+    processor_instance = analysis_processor.AnalysisProcessor(samplesdict,wc_lst,hist_lst,ecut_threshold,do_errors,do_systs,split_lep_flavor,skip_sr,skip_cr,offZ_split=offZ_split,tau_h_analysis=tau_h_analysis,fwd_analysis=fwd_analysis,useRun3MVA=useRun3MVA,fwd_eta_band_pt_apply=fwd_eta_band_pt_apply)
 
     if executor == "work_queue":
         executor_args = {

--- a/input_samples/cfgs/NDSkim_2022EE_signal_samples.cfg
+++ b/input_samples/cfgs/NDSkim_2022EE_signal_samples.cfg
@@ -1,9 +1,10 @@
 root://cmsxrootd.crc.nd.edu/
 #file:///cms/cephfs/data
-../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/ttHnobb-1Jets_NDSkim_2022EE.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/ttHnobb_NDSkim_2022EE.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/ttHnobb-1Jets_NDSkim_2022EE.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/ttHnobb_NDSkim_2022EE.json
 ../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/TTLL_MLL-4to50_NDSkim_2022EE.json
 ../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/TTLL_MLL-50_NDSkim_2022EE.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/TTTT_NDSkim_2022EE.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/TZQB-Zto2L-4FS_MLL-30_NDSkim_2022EE.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/TTLNu_NDSkim_2022EE.json
+../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/tllq_2022EE.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/TTTT_NDSkim_2022EE.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/TZQB-Zto2L-4FS_MLL-30_NDSkim_2022EE.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/TTLNu_NDSkim_2022EE.json

--- a/input_samples/cfgs/NDSkim_2022_signal_samples.cfg
+++ b/input_samples/cfgs/NDSkim_2022_signal_samples.cfg
@@ -1,10 +1,11 @@
 # Central 2022 background samples
 root://cmsxrootd.crc.nd.edu/
-#file:///cms/cephfs/data/
-../../input_samples/sample_jsons/signal_samples/ND_skim2022/ttHnobb-1Jets_NDSkim_2022.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022/ttHnobb_NDSkim_2022.json
+# file:///cms/cephfs/data/
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022/ttHnobb-1Jets_NDSkim_2022.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022/ttHnobb_NDSkim_2022.json
 ../../input_samples/sample_jsons/signal_samples/ND_skim2022/TTLL_MLL-4to50_NDSkim_2022.json
 ../../input_samples/sample_jsons/signal_samples/ND_skim2022/TTLL_MLL-50_NDSkim_2022.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022/TTLNu_NDSkim_2022.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022/TTTT_NDSkim_2022.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2022/TZQB-Zto2L-4FS_MLL-30_NDSkim_2022.json
+../../input_samples/sample_jsons/signal_samples/ND_skim2022/tllq_2022.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022/TTLNu_NDSkim_2022.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022/TTTT_NDSkim_2022.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2022/TZQB-Zto2L-4FS_MLL-30_NDSkim_2022.json

--- a/input_samples/cfgs/NDSkim_2023BPix_signal_samples.cfg
+++ b/input_samples/cfgs/NDSkim_2023BPix_signal_samples.cfg
@@ -1,9 +1,10 @@
 root://cmsxrootd.crc.nd.edu/
 #file:///cms/cephfs/data/
-#../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/ttHnobb-1Jets_NDSkim_2023BPix.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/ttHnobb_NDSkim_2023BPix.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/ttHnobb-1Jets_NDSkim_2023BPix.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/ttHnobb_NDSkim_2023BPix.json
 ../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/TTLL_MLL-4to50_NDSkim_2023BPix.json
 ../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/TTLL_MLL-50_NDSkim_2023BPix.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/TTLNu_NDSkim_2023BPix.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/TTTT_NDSkim_2023BPix.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/TZQB-Zto2L-4FS_MLL-30_NDSkim_2023BPix.json
+../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/tllq_2023BPix.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/TTLNu_NDSkim_2023BPix.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/TTTT_NDSkim_2023BPix.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/TZQB-Zto2L-4FS_MLL-30_NDSkim_2023BPix.json

--- a/input_samples/cfgs/NDSkim_2023_signal_samples.cfg
+++ b/input_samples/cfgs/NDSkim_2023_signal_samples.cfg
@@ -1,9 +1,10 @@
 root://cmsxrootd.crc.nd.edu/
 #file:///cms/cephfs/data/
-#../../input_samples/sample_jsons/signal_samples/ND_skim2023/ttHnobb-1Jets_NDSkim_2023.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023/ttHnobb_NDSkim_2023.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023/ttHnobb-1Jets_NDSkim_2023.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023/ttHnobb_NDSkim_2023.json
 ../../input_samples/sample_jsons/signal_samples/ND_skim2023/TTLL_MLL-4to50_NDSkim_2023.json
 ../../input_samples/sample_jsons/signal_samples/ND_skim2023/TTLL_MLL-50_NDSkim_2023.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023/TTLNu_NDSkim_2023.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023/TTTT_NDSkim_2023.json
-../../input_samples/sample_jsons/signal_samples/ND_skim2023/TZQB-Zto2L-4FS_MLL-30_NDSkim_2023.json
+../../input_samples/sample_jsons/signal_samples/ND_skim2023/tllq_2023.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023/TTLNu_NDSkim_2023.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023/TTTT_NDSkim_2023.json
+# ../../input_samples/sample_jsons/signal_samples/ND_skim2023/TZQB-Zto2L-4FS_MLL-30_NDSkim_2023.json

--- a/tests/test_forward_eta_jer_suppression_threading.py
+++ b/tests/test_forward_eta_jer_suppression_threading.py
@@ -15,7 +15,7 @@ from topeft.modules import corrections as cor
 _RUN_ANALYSIS_PATH = Path("analysis/topeft_run2/run_analysis.py")
 
 
-def test_apply_jet_corrections_gates_forward_eta_suppression_to_run3(monkeypatch):
+def test_apply_jet_corrections_forwards_resolved_forward_eta_suppression(monkeypatch):
     calls = []
 
     class DummyJECStack:
@@ -70,8 +70,24 @@ def test_apply_jet_corrections_gates_forward_eta_suppression_to_run3(monkeypatch
 
     assert calls[0]["kwargs"]["suppress_forward_eta_stochastic_jer"] is False
     assert calls[1]["kwargs"]["suppress_forward_eta_stochastic_jer"] is True
-    assert calls[2]["kwargs"]["suppress_forward_eta_stochastic_jer"] is False
+    assert calls[2]["kwargs"]["suppress_forward_eta_stochastic_jer"] is True
     assert calls[3]["kwargs"]["suppress_forward_eta_stochastic_jer"] is False
+
+
+@pytest.mark.parametrize(
+    "is_run3, requested, expected",
+    [
+        (True, True, True),
+        (True, False, False),
+        (False, True, False),
+        (False, False, False),
+    ],
+)
+def test_resolve_forward_eta_stochastic_jer_suppression(is_run3, requested, expected):
+    assert (
+        cor.resolve_forward_eta_stochastic_jer_suppression(is_run3, requested)
+        is expected
+    )
 
 
 def test_main_processor_stores_forward_eta_suppression_option_default_false():
@@ -95,18 +111,33 @@ def test_main_processor_can_store_forward_eta_suppression_option_true():
     assert processor.suppress_forward_eta_stochastic_jer is True
 
 
-def test_processors_pass_forward_eta_suppression_to_apply_jet_corrections():
+def test_processors_pass_effective_forward_eta_suppression_to_apply_jet_corrections():
     main_source = inspect.getsource(analysis_processor.AnalysisProcessor.process)
     diboson_source = inspect.getsource(analysis_processor_diboson.AnalysisProcessor.process)
     btag_source = inspect.getsource(btagMCeff.AnalysisProcessor.process)
 
-    expected = (
-        "suppress_forward_eta_stochastic_jer="
-        "self.suppress_forward_eta_stochastic_jer"
+    expected_resolver = (
+        "effective_suppress_forward_eta_stochastic_jer = "
+        "resolve_forward_eta_stochastic_jer_suppression("
     )
-    assert expected in main_source
-    assert expected in diboson_source
-    assert expected in btag_source
+    expected_forward = (
+        "suppress_forward_eta_stochastic_jer="
+        "effective_suppress_forward_eta_stochastic_jer"
+    )
+    for source in (main_source, diboson_source, btag_source):
+        assert expected_resolver in source
+        assert expected_forward in source
+        assert 'startswith("201")' not in source
+        assert "startswith('201')" not in source
+
+
+def test_policy_paths_do_not_use_run2_year_string_heuristic():
+    resolver_source = inspect.getsource(cor.resolve_forward_eta_stochastic_jer_suppression)
+    apply_jec_source = inspect.getsource(cor.ApplyJetCorrections)
+
+    for source in (resolver_source, apply_jec_source):
+        assert 'startswith("201")' not in source
+        assert "startswith('201')" not in source
 
 
 def test_secondary_processors_default_forward_eta_suppression_false():

--- a/tests/test_forward_eta_jer_suppression_threading.py
+++ b/tests/test_forward_eta_jer_suppression_threading.py
@@ -15,7 +15,7 @@ from topeft.modules import corrections as cor
 _RUN_ANALYSIS_PATH = Path("analysis/topeft_run2/run_analysis.py")
 
 
-def test_apply_jet_corrections_threads_forward_eta_suppression_to_factory(monkeypatch):
+def test_apply_jet_corrections_gates_forward_eta_suppression_to_run3(monkeypatch):
     calls = []
 
     class DummyJECStack:
@@ -51,9 +51,27 @@ def test_apply_jet_corrections_threads_forward_eta_suppression_to_factory(monkey
         run=123,
         suppress_forward_eta_stochastic_jer=True,
     )
+    cor.ApplyJetCorrections(
+        "2018",
+        corr_type="jets",
+        isData=False,
+        era=None,
+        run=123,
+        suppress_forward_eta_stochastic_jer=True,
+    )
+    cor.ApplyJetCorrections(
+        "2022",
+        corr_type="jets",
+        isData=False,
+        era=None,
+        run=123,
+        suppress_forward_eta_stochastic_jer=False,
+    )
 
     assert calls[0]["kwargs"]["suppress_forward_eta_stochastic_jer"] is False
     assert calls[1]["kwargs"]["suppress_forward_eta_stochastic_jer"] is True
+    assert calls[2]["kwargs"]["suppress_forward_eta_stochastic_jer"] is False
+    assert calls[3]["kwargs"]["suppress_forward_eta_stochastic_jer"] is False
 
 
 def test_main_processor_stores_forward_eta_suppression_option_default_false():
@@ -120,6 +138,7 @@ def test_run_analysis_help_exposes_forward_eta_suppression_flag(capsys):
 
     assert "--suppress-forward-eta-stochastic-jer" in help_text
     assert "requires JME/JERC approval" in help_text
+    assert "--fwd-eta-band-pt-apply" in help_text
 
 
 def test_run_analysis_threads_forward_eta_suppression_to_main_processor():
@@ -131,3 +150,6 @@ def test_run_analysis_threads_forward_eta_suppression_to_main_processor():
         "suppress_forward_eta_stochastic_jer=suppress_forward_eta_stochastic_jer"
         in source
     )
+    assert "fwd_eta_band_pt_apply = args.fwd_eta_band_pt_apply" in source
+    assert '"fwd_eta_band_pt_apply"' in source
+    assert "fwd_eta_band_pt_apply=fwd_eta_band_pt_apply" in source

--- a/tests/test_forward_jet_eta_banded_policy.py
+++ b/tests/test_forward_jet_eta_banded_policy.py
@@ -1,0 +1,100 @@
+import numpy as np
+import pytest
+
+from topeft.modules import object_selection as te_os
+
+
+_PTS = np.array([39.0, 40.0, 41.0, 49.0, 50.0, 51.0])
+
+
+def _forward_mask(abs_eta, *, apply_eta_band_pt, quality_mask=True):
+    eta = np.full_like(_PTS, abs_eta, dtype=float)
+    if isinstance(quality_mask, bool):
+        quality_mask = np.full_like(_PTS, quality_mask, dtype=bool)
+    return te_os.is_forward_jet_eta_banded(
+        _PTS,
+        eta,
+        eta_cut=2.4,
+        baseline_pt_cut=40.0,
+        apply_eta_band_pt=apply_eta_band_pt,
+        eta_band_min=2.5,
+        eta_band_max=3.0,
+        eta_band_pt_cut=50.0,
+        quality_mask=quality_mask,
+    ).tolist()
+
+
+@pytest.mark.parametrize(
+    "abs_eta, expected",
+    [
+        (2.4, [False, False, False, False, False, False]),
+        (2.5, [False, False, True, True, True, True]),
+        (2.6, [False, False, False, False, False, True]),
+        (2.9, [False, False, False, False, False, True]),
+        (3.0, [False, False, True, True, True, True]),
+        (3.1, [False, False, True, True, True, True]),
+        (4.0, [False, False, True, True, True, True]),
+    ],
+)
+def test_forward_eta_banded_policy_enabled_boundary_behavior(abs_eta, expected):
+    assert _forward_mask(abs_eta, apply_eta_band_pt=True) == expected
+
+
+@pytest.mark.parametrize("abs_eta", [2.5, 2.6, 2.9, 3.0, 3.1, 4.0])
+def test_forward_eta_banded_policy_disabled_uses_baseline_pt(abs_eta):
+    assert _forward_mask(abs_eta, apply_eta_band_pt=False) == [
+        False,
+        False,
+        True,
+        True,
+        True,
+        True,
+    ]
+
+
+def test_forward_eta_banded_policy_disabled_keeps_eta_cut():
+    assert _forward_mask(2.4, apply_eta_band_pt=False) == [
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+    ]
+
+
+def test_forward_eta_banded_policy_quality_mask_rejects_passing_jets():
+    assert _forward_mask(3.1, apply_eta_band_pt=True, quality_mask=False) == [
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+    ]
+
+
+@pytest.mark.parametrize(
+    "policy, year, expected",
+    [
+        ("auto", "2022", True),
+        ("auto", "2022EE", True),
+        ("auto", "2023", True),
+        ("auto", "2023BPix", True),
+        ("auto", "2016APV", False),
+        ("auto", "2016", False),
+        ("auto", "2017", False),
+        ("auto", "2018", False),
+        ("on", "2018", True),
+        ("on", "2022", True),
+        ("off", "2018", False),
+        ("off", "2022", False),
+    ],
+)
+def test_resolve_fwd_eta_band_pt_apply(policy, year, expected):
+    assert te_os.resolve_fwd_eta_band_pt_apply(year, policy) is expected
+
+
+def test_resolve_fwd_eta_band_pt_apply_rejects_invalid_policy():
+    with pytest.raises(ValueError, match="Unsupported forward eta-band pT policy"):
+        te_os.resolve_fwd_eta_band_pt_apply("2022", "sometimes")

--- a/tests/test_forward_jet_eta_banded_policy.py
+++ b/tests/test_forward_jet_eta_banded_policy.py
@@ -75,26 +75,29 @@ def test_forward_eta_banded_policy_quality_mask_rejects_passing_jets():
 
 
 @pytest.mark.parametrize(
-    "policy, year, expected",
+    "is_run3, policy, expected",
     [
-        ("auto", "2022", True),
-        ("auto", "2022EE", True),
-        ("auto", "2023", True),
-        ("auto", "2023BPix", True),
-        ("auto", "2016APV", False),
-        ("auto", "2016", False),
-        ("auto", "2017", False),
-        ("auto", "2018", False),
-        ("on", "2018", True),
-        ("on", "2022", True),
-        ("off", "2018", False),
-        ("off", "2022", False),
+        (True, "auto", True),
+        (False, "auto", False),
+        (True, "on", True),
+        (False, "on", True),
+        (True, "off", False),
+        (False, "off", False),
     ],
 )
-def test_resolve_fwd_eta_band_pt_apply(policy, year, expected):
-    assert te_os.resolve_fwd_eta_band_pt_apply(year, policy) is expected
+def test_resolve_fwd_eta_band_pt_apply(is_run3, policy, expected):
+    assert te_os.resolve_fwd_eta_band_pt_apply(is_run3, policy) is expected
 
 
 def test_resolve_fwd_eta_band_pt_apply_rejects_invalid_policy():
     with pytest.raises(ValueError, match="Unsupported forward eta-band pT policy"):
-        te_os.resolve_fwd_eta_band_pt_apply("2022", "sometimes")
+        te_os.resolve_fwd_eta_band_pt_apply(True, "sometimes")
+
+
+def test_resolve_fwd_eta_band_pt_apply_does_not_infer_from_year_strings():
+    import inspect
+
+    source = inspect.getsource(te_os.resolve_fwd_eta_band_pt_apply)
+
+    assert 'startswith("201")' not in source
+    assert "startswith('201')" not in source

--- a/tests/test_met_collection_policy.py
+++ b/tests/test_met_collection_policy.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+
+import pytest
+
+from topeft.modules.corrections import (
+    ApplyMETSystematics,
+    get_selected_met,
+    get_supported_met_systematics,
+    is_met_unclustered_systematic,
+)
+
+
+def test_run2_selected_met_uses_legacy_met():
+    events = SimpleNamespace(MET=object(), PuppiMET=object())
+
+    assert get_selected_met(events, "2018") is events.MET
+
+
+def test_run3_selected_met_uses_puppimet():
+    events = SimpleNamespace(MET=object(), PuppiMET=object())
+
+    assert get_selected_met(events, "2022") is events.PuppiMET
+
+
+def test_run3_selected_met_missing_puppimet_fails_clearly():
+    events = SimpleNamespace(MET=object())
+
+    with pytest.raises(RuntimeError, match="requires events.PuppiMET"):
+        get_selected_met(events, "2022")
+
+
+def test_met_unclustered_systematics_are_public_generic_labels():
+    assert get_supported_met_systematics("2022", isData=False) == [
+        "MET_UnclusteredEnergyUp",
+        "MET_UnclusteredEnergyDown",
+    ]
+    assert get_supported_met_systematics("2022", isData=True) == []
+    assert is_met_unclustered_systematic("MET_UnclusteredEnergyUp")
+    assert is_met_unclustered_systematic("MET_UnclusteredEnergyDown")
+    assert not is_met_unclustered_systematic("JER_2022Up")
+
+
+def test_apply_met_systematics_selects_unclustered_shift_only():
+    nominal = object()
+    up = object()
+    down = object()
+    met = SimpleNamespace(
+        MET_UnclusteredEnergy=SimpleNamespace(up=up, down=down)
+    )
+
+    assert ApplyMETSystematics(met, "nominal") is met
+    assert ApplyMETSystematics(met, "MET_UnclusteredEnergyUp") is up
+    assert ApplyMETSystematics(met, "MET_UnclusteredEnergyDown") is down
+    assert ApplyMETSystematics(nominal, "JER_2022Up") is nominal

--- a/tests/test_run3_nanov12_jet_id_adoption.py
+++ b/tests/test_run3_nanov12_jet_id_adoption.py
@@ -12,7 +12,7 @@ def test_main_processor_run3_uses_nanov12_tight_jet_id_for_central_and_forward_j
     assert 'abs(cleanedJets.eta) < get_te_param("eta_j_cut")) & jet_id_mask' in source
     assert 'cleanedJets["isFwd"] = te_os.is_forward_jet_eta_banded' in source
     assert 'baseline_pt_cut=get_te_param("fwd_jet_pt_cut")' in source
-    assert 'apply_eta_band_pt=te_os.resolve_fwd_eta_band_pt_apply(year, self.fwd_eta_band_pt_apply)' in source
+    assert 'apply_eta_band_pt=te_os.resolve_fwd_eta_band_pt_apply(is_run3, self.fwd_eta_band_pt_apply)' in source
     assert 'quality_mask=jet_id_mask' in source
     assert 'else:\n                jet_id_mask = True' in source
     assert 'cleanedJets["isGood"] = tc_os.is_tight_jet' in source
@@ -27,7 +27,7 @@ def test_diboson_processor_run3_uses_nanov12_tight_jet_id_for_central_and_forwar
     assert 'abs(cleanedJets.eta) < get_te_param("eta_j_cut")) & jet_id_mask' in source
     assert 'cleanedJets["isFwd"] = te_os.is_forward_jet_eta_banded' in source
     assert 'baseline_pt_cut=get_te_param("fwd_jet_pt_cut")' in source
-    assert 'apply_eta_band_pt=te_os.resolve_fwd_eta_band_pt_apply(year, self.fwd_eta_band_pt_apply)' in source
+    assert 'apply_eta_band_pt=te_os.resolve_fwd_eta_band_pt_apply(is_run3, self.fwd_eta_band_pt_apply)' in source
     assert 'quality_mask=jet_id_mask' in source
     assert 'else:\n                jet_id_mask = True' in source
     assert 'cleanedJets["isGood"] = tc_os.is_tight_jet' in source

--- a/tests/test_run3_nanov12_jet_id_adoption.py
+++ b/tests/test_run3_nanov12_jet_id_adoption.py
@@ -10,9 +10,14 @@ def test_main_processor_run3_uses_nanov12_tight_jet_id_for_central_and_forward_j
 
     assert 'if is_run3:\n                jet_id_mask = tc_os.run3_nanoV12_ak4puppi_jet_id(cleanedJets, year, working_point="tight")' in source
     assert 'abs(cleanedJets.eta) < get_te_param("eta_j_cut")) & jet_id_mask' in source
-    assert 'abs(cleanedJets.eta) > get_te_param("eta_j_cut")) & jet_id_mask' in source
-    assert 'else:\n                cleanedJets["isGood"] = tc_os.is_tight_jet' in source
-    assert 'cleanedJets["isFwd"] = te_os.isFwdJet' in source
+    assert 'cleanedJets["isFwd"] = te_os.is_forward_jet_eta_banded' in source
+    assert 'baseline_pt_cut=get_te_param("fwd_jet_pt_cut")' in source
+    assert 'apply_eta_band_pt=te_os.resolve_fwd_eta_band_pt_apply(year, self.fwd_eta_band_pt_apply)' in source
+    assert 'quality_mask=jet_id_mask' in source
+    assert 'else:\n                jet_id_mask = True' in source
+    assert 'cleanedJets["isGood"] = tc_os.is_tight_jet' in source
+    assert 'getattr(cleanedJets, jetptname) > 70.' not in source
+    assert 'jetPtCut=50.' not in source
 
 
 def test_diboson_processor_run3_uses_nanov12_tight_jet_id_for_central_and_forward_jets():
@@ -20,11 +25,14 @@ def test_diboson_processor_run3_uses_nanov12_tight_jet_id_for_central_and_forwar
 
     assert 'if is_run3:\n                jet_id_mask = tc_os.run3_nanoV12_ak4puppi_jet_id(cleanedJets, year, working_point="tight")' in source
     assert 'abs(cleanedJets.eta) < get_te_param("eta_j_cut")) & jet_id_mask' in source
-    assert "getattr(cleanedJets, jetptname) > 50." in source
-    assert 'abs(cleanedJets.eta) > get_te_param("eta_j_cut")) & jet_id_mask' in source
-    assert 'else:\n                cleanedJets["isGood"] = tc_os.is_tight_jet' in source
-    assert 'cleanedJets["isFwd"] = te_os.isFwdJet' in source
-    assert "jetPtCut=50." in source
+    assert 'cleanedJets["isFwd"] = te_os.is_forward_jet_eta_banded' in source
+    assert 'baseline_pt_cut=get_te_param("fwd_jet_pt_cut")' in source
+    assert 'apply_eta_band_pt=te_os.resolve_fwd_eta_band_pt_apply(year, self.fwd_eta_band_pt_apply)' in source
+    assert 'quality_mask=jet_id_mask' in source
+    assert 'else:\n                jet_id_mask = True' in source
+    assert 'cleanedJets["isGood"] = tc_os.is_tight_jet' in source
+    assert "getattr(cleanedJets, jetptname) > 50." not in source
+    assert "jetPtCut=50." not in source
     assert "jetPtCut=40." not in source
 
 

--- a/topeft/modules/axes.py
+++ b/topeft/modules/axes.py
@@ -93,7 +93,7 @@ info = {
         "variable": [0, 300, 500, 800],
         "label": r"H$_{T}$ (GeV) ",
     },
-    "met": {"regular": (40, 0, 400), "label": r"MET (GeV)"},
+    "met": {"regular": (20, 0, 200), "label": r"MET (GeV)"},
     "ljptsum": {
         "regular": (11, 0, 1100),
         "variable": [0, 400, 600, 1000],

--- a/topeft/modules/corrections.py
+++ b/topeft/modules/corrections.py
@@ -174,6 +174,38 @@ def get_supported_jet_systematics(year, isData=False, era=None):
         systs.append(f"JES_{base}Down")
     return systs
 
+
+MET_UNCLUSTERED_ENERGY = "MET_UnclusteredEnergy"
+
+
+def get_selected_met(events, year):
+    met_collection_name = "PuppiMET" if str(year).startswith("202") else "MET"
+    if not hasattr(events, met_collection_name):
+        raise RuntimeError(
+            f"Run {year} processing requires events.{met_collection_name}; "
+            "no fallback MET collection is used."
+        )
+    return getattr(events, met_collection_name)
+
+
+def get_supported_met_systematics(year, isData=False, era=None):
+    if isData:
+        return []
+    return [f"{MET_UNCLUSTERED_ENERGY}Up", f"{MET_UNCLUSTERED_ENERGY}Down"]
+
+
+def is_met_unclustered_systematic(syst_var):
+    return syst_var in get_supported_met_systematics(year=None, isData=False)
+
+
+def ApplyMETSystematics(met, syst_var):
+    if syst_var == f"{MET_UNCLUSTERED_ENERGY}Up":
+        return getattr(met, MET_UNCLUSTERED_ENERGY).up
+    if syst_var == f"{MET_UNCLUSTERED_ENERGY}Down":
+        return getattr(met, MET_UNCLUSTERED_ENERGY).down
+    return met
+
+
 def get_corr_inputs(objs, corr_obj, name_map):
     """
     Helper function for getting values of input variables
@@ -1856,7 +1888,7 @@ def ApplyJetSystematics(year,cleanedJets,syst_var):
         return cleanedJets.JES_jes.down
     elif (syst_var == 'nominal'):
         return cleanedJets
-    elif (syst_var in ['nominal','MuonESUp','MuonESDown', 'TESUp', 'TESDown', 'FESUp', 'FESDown']):
+    elif (syst_var in ['nominal','MuonESUp','MuonESDown', 'TESUp', 'TESDown', 'FESUp', 'FESDown']) or is_met_unclustered_systematic(syst_var):
         return cleanedJets
     elif ('JES_FlavorQCD' in syst_var):
         # Overwrite FlavorQCD with the proper jet flavor uncertainty

--- a/topeft/modules/corrections.py
+++ b/topeft/modules/corrections.py
@@ -1785,6 +1785,9 @@ def ApplyJetCorrections(
     suppress_forward_eta_stochastic_jer=False,
 ):
     usejecstack = not useclib
+    effective_suppress_forward_eta_stochastic_jer = (
+        suppress_forward_eta_stochastic_jer and not str(year).startswith("201")
+    )
 
     if year not in clib_year_map.keys():
         raise Exception(f"Error: Unknown year \"{year}\".")
@@ -1874,7 +1877,7 @@ def ApplyJetCorrections(
         name_map,
         jec_stack,
         run,
-        suppress_forward_eta_stochastic_jer=suppress_forward_eta_stochastic_jer,
+        suppress_forward_eta_stochastic_jer=effective_suppress_forward_eta_stochastic_jer,
     )
 
 def ApplyJetSystematics(year,cleanedJets,syst_var):

--- a/topeft/modules/corrections.py
+++ b/topeft/modules/corrections.py
@@ -1785,9 +1785,6 @@ def ApplyJetCorrections(
     suppress_forward_eta_stochastic_jer=False,
 ):
     usejecstack = not useclib
-    effective_suppress_forward_eta_stochastic_jer = (
-        suppress_forward_eta_stochastic_jer and not str(year).startswith("201")
-    )
 
     if year not in clib_year_map.keys():
         raise Exception(f"Error: Unknown year \"{year}\".")
@@ -1877,8 +1874,11 @@ def ApplyJetCorrections(
         name_map,
         jec_stack,
         run,
-        suppress_forward_eta_stochastic_jer=effective_suppress_forward_eta_stochastic_jer,
+        suppress_forward_eta_stochastic_jer=suppress_forward_eta_stochastic_jer,
     )
+
+def resolve_forward_eta_stochastic_jer_suppression(is_run3, suppress_forward_eta_stochastic_jer):
+    return bool(suppress_forward_eta_stochastic_jer) and bool(is_run3)
 
 def ApplyJetSystematics(year,cleanedJets,syst_var):
     if (syst_var == f'JER_{year}Up'):

--- a/topeft/modules/object_selection.py
+++ b/topeft/modules/object_selection.py
@@ -139,6 +139,41 @@ def isFwdJet(pt, eta, jet_id, jetPtCut=25.0):
     mask = ((pt>jetPtCut) & (abs(eta)>get_te_param("eta_j_cut")) & (get_te_param("jet_id_cut")))
     return mask
 
+def resolve_fwd_eta_band_pt_apply(year, policy):
+    if policy not in ("auto", "on", "off"):
+        raise ValueError(
+            f"Unsupported forward eta-band pT policy '{policy}'. "
+            "Expected one of: auto, on, off."
+        )
+    if policy == "on":
+        return True
+    if policy == "off":
+        return False
+    return not str(year).startswith("201")
+
+def is_forward_jet_eta_banded(
+    pt,
+    eta,
+    eta_cut,
+    baseline_pt_cut,
+    apply_eta_band_pt,
+    eta_band_min,
+    eta_band_max,
+    eta_band_pt_cut,
+    quality_mask=True,
+):
+    abs_eta = abs(eta)
+    base_forward = abs_eta > eta_cut
+    in_eta_band = (abs_eta > eta_band_min) & (abs_eta < eta_band_max)
+    if apply_eta_band_pt:
+        pass_pt = (
+            (in_eta_band & (pt > eta_band_pt_cut))
+            | ((~in_eta_band) & (pt > baseline_pt_cut))
+        )
+    else:
+        pass_pt = pt > baseline_pt_cut
+    return base_forward & pass_pt & quality_mask
+
 def smoothBFlav(jetpt,ptmin,ptmax,year,scale_loose=1.0,btagger="btagDeepFlavB"):
 
     # Get the btag wp for the year

--- a/topeft/modules/object_selection.py
+++ b/topeft/modules/object_selection.py
@@ -139,7 +139,7 @@ def isFwdJet(pt, eta, jet_id, jetPtCut=25.0):
     mask = ((pt>jetPtCut) & (abs(eta)>get_te_param("eta_j_cut")) & (get_te_param("jet_id_cut")))
     return mask
 
-def resolve_fwd_eta_band_pt_apply(year, policy):
+def resolve_fwd_eta_band_pt_apply(is_run3, policy):
     if policy not in ("auto", "on", "off"):
         raise ValueError(
             f"Unsupported forward eta-band pT policy '{policy}'. "
@@ -149,7 +149,7 @@ def resolve_fwd_eta_band_pt_apply(year, policy):
         return True
     if policy == "off":
         return False
-    return not str(year).startswith("201")
+    return bool(is_run3)
 
 def is_forward_jet_eta_banded(
     pt,

--- a/topeft/params/params.json
+++ b/topeft/params/params.json
@@ -4,6 +4,10 @@
     "eta_t_cut" : 2.3,
     "eta_t_cut_run3" : 2.5,
     "eta_j_cut" : 2.4,
+    "fwd_jet_pt_cut" : 40.0,
+    "fwd_jet_eta_band_min" : 2.5,
+    "fwd_jet_eta_band_max" : 3.0,
+    "fwd_jet_eta_band_pt_cut" : 50.0,
 
     "fo_pt_cut" : 10.0,
     "pres_e_pt_cut" : 7.0,

--- a/topeft/params/params.json
+++ b/topeft/params/params.json
@@ -6,8 +6,8 @@
     "eta_j_cut" : 2.4,
     "fwd_jet_pt_cut" : 40.0,
     "fwd_jet_eta_band_min" : 2.5,
-    "fwd_jet_eta_band_max" : 3.0,
-    "fwd_jet_eta_band_pt_cut" : 50.0,
+    "fwd_jet_eta_band_max" : 10.0,
+    "fwd_jet_eta_band_pt_cut" : 60.0,
 
     "fo_pt_cut" : 10.0,
     "pres_e_pt_cut" : 7.0,


### PR DESCRIPTION
### Summary

- Use `PuppiMET` for Run 3 processing and keep legacy `MET` for Run 2 through a centralized MET-selection helper.
- Add support for unclustered MET systematics via `MET_UnclusteredEnergyUp/Down` and include them in the object-correction systematic loop for the main and diboson processors.
- Centralize the forward-jet pT policy with an eta-band-aware helper, controlled by a new `--fwd-eta-band-pt-apply {auto,on,off}` option.
- Restrict the opt-in forward-eta stochastic JER suppression to Run 3 through a resolver, while preserving the default disabled behavior.
- Update Run 3 processor and b-tag MC-efficiency paths to use the centralized MET/JER policy helpers.
- Update production defaults and configs, including WorkQueue staging path, default chunksize, selected signal sample cfgs, and the MET histogram axis.

### Motivation

The Run 3 correction workflow needs to use the correct MET collection and systematic treatment consistently with the Run 3 PUPPI-MET/JERC setup. The previous processor logic accessed `events.MET` directly in several places, which is not the intended Run 3 MET collection. This PR introduces a centralized `get_selected_met(...)` helper so Run 3 uses `events.PuppiMET`, while Run 2 continues to use `events.MET`.

The PR also makes the unclustered MET variations explicit in the correction systematic loop. This allows the analysis to evaluate `MET_UnclusteredEnergyUp/Down` alongside the existing jet/tau/lepton object variations without treating them as jet-energy variations.

In parallel, the forward-jet pT requirement is made explicit and configurable. This is connected to the JME/JERC-motivated handling of the problematic forward eta region: the code now supports a baseline forward-jet threshold plus an eta-band-specific tighter threshold, with a policy switch to apply it automatically for Run 3, force it on, or disable it.

Finally, the already-added opt-in stochastic JER suppression flag is resolved through a Run-3-aware helper so it cannot accidentally affect Run 2 processing.

### Implementation details

#### A. Centralized MET collection selection

`topeft/modules/corrections.py` adds:

```python
def get_selected_met(events, year):
    met_collection_name = "PuppiMET" if str(year).startswith("202") else "MET"
    ...
```

This centralizes the Run 2 / Run 3 MET choice:

- Run 2 uses `events.MET`.
- Run 3 uses `events.PuppiMET`.
- Missing required collections now fail with a clear `RuntimeError`.
- No silent fallback is used.

The main processor, diboson processor, and b-tag MC-efficiency processor now call:

```python
met = get_selected_met(events, year)
```

instead of directly using `events.MET`.

The event-level nominal array is also aligned to the selected MET collection:

```python
events.nom = ak.ones_like(met.pt)
```

rather than always using `events.MET.pt`.

#### B. Unclustered MET systematics

`topeft/modules/corrections.py` adds:

```python
MET_UNCLUSTERED_ENERGY = "MET_UnclusteredEnergy"

def get_supported_met_systematics(year, isData=False, era=None):
    if isData:
        return []
    return ["MET_UnclusteredEnergyUp", "MET_UnclusteredEnergyDown"]

def is_met_unclustered_systematic(syst_var):
    ...

def ApplyMETSystematics(met, syst_var):
    ...
```

The main and diboson processors now extend the object-correction systematic list with the supported MET unclustered variations:

```python
obj_correction_syst_lst.extend(
    get_supported_met_systematics(year, isData=isData, era=run_era)
)
```

During the systematic loop, after MET is propagated from corrected jets, the processors apply the selected unclustered MET shift when requested:

```python
if is_met_unclustered_systematic(syst_var):
    met = ApplyMETSystematics(met, syst_var)
```

`ApplyJetSystematics(...)` is also updated so unclustered MET variations leave the jet collection unchanged, matching their role as MET-only variations.

#### C. Forward-jet eta-band pT policy

`topeft/modules/object_selection.py` adds:

```python
resolve_fwd_eta_band_pt_apply(is_run3, policy)
```

with supported policies:

```text
auto  -> apply only for Run 3
on    -> apply for all years
off   -> disable for all years
```

and:

```python
is_forward_jet_eta_banded(...)
```

This helper applies:

- a baseline forward-jet pT threshold outside the configured eta band;
- a tighter pT threshold inside the configured eta band;
- an optional quality mask, used for Run 3 NanoV12 JetID.

The main and diboson processors now build forward jets through:

```python
cleanedJets["isFwd"] = te_os.is_forward_jet_eta_banded(
    getattr(cleanedJets, jetptname),
    cleanedJets.eta,
    eta_cut=get_te_param("eta_j_cut"),
    baseline_pt_cut=get_te_param("fwd_jet_pt_cut"),
    apply_eta_band_pt=te_os.resolve_fwd_eta_band_pt_apply(
        is_run3,
        self.fwd_eta_band_pt_apply,
    ),
    eta_band_min=get_te_param("fwd_jet_eta_band_min"),
    eta_band_max=get_te_param("fwd_jet_eta_band_max"),
    eta_band_pt_cut=get_te_param("fwd_jet_eta_band_pt_cut"),
    quality_mask=jet_id_mask,
)
```

This replaces the hard-coded forward-jet selections in the processors.

New parameters are added in `topeft/params/params.json`:

```json
"fwd_jet_pt_cut": 40.0,
"fwd_jet_eta_band_min": 2.5,
"fwd_jet_eta_band_max": 10.0,
"fwd_jet_eta_band_pt_cut": 60.0
```

Reviewers should note that the configured eta-band maximum in this diff is `10.0`, so the tightened pT threshold applies to all forward jets with `abs(eta) > 2.5`, not only `2.5 < abs(eta) < 3.0`.

#### D. CLI/config plumbing for the forward-jet eta-band policy

`analysis/topeft_run2/run_analysis.py` adds:

```text
--fwd-eta-band-pt-apply {auto,on,off}
```

with default:

```text
auto
```

The option is also read from YAML options through:

```python
fwd_eta_band_pt_apply = ops.pop("fwd_eta_band_pt_apply", fwd_eta_band_pt_apply)
```

and is passed into the main processor.

`analysis/topeft_run2/run_analysis_diboson.py` gets the same CLI option and passes it into the diboson processor.

The main and diboson processors store:

```python
self.fwd_eta_band_pt_apply = fwd_eta_band_pt_apply
```

and use it when resolving the forward-jet pT policy.

#### E. Run-3-only stochastic JER suppression resolution

`topeft/modules/corrections.py` adds:

```python
def resolve_forward_eta_stochastic_jer_suppression(
    is_run3,
    suppress_forward_eta_stochastic_jer,
):
    return bool(suppress_forward_eta_stochastic_jer) and bool(is_run3)
```

The main, diboson, and b-tag MC-efficiency processors now compute:

```python
effective_suppress_forward_eta_stochastic_jer = (
    resolve_forward_eta_stochastic_jer_suppression(
        is_run3,
        self.suppress_forward_eta_stochastic_jer,
    )
)
```

and pass this effective value into `ApplyJetCorrections(...)`.

This prevents the opt-in Run 3 JER mitigation from being applied to Run 2 even if the high-level option is set.

#### F. Production/runtime defaults

`analysis/topeft_run2/run_analysis.py` changes the default WorkQueue staging directory from:

```text
/scratch365/$USER/workers
```

to:

```text
/groups/klannon/$USER/workers
```

The default chunksize changes from:

```text
20000
```

to:

```text
100000
```

These are production-behavior changes and should be reviewed with the intended execution environment in mind.

#### G. Signal sample cfg updates

The Run 3 signal cfgs are updated for 2022, 2022EE, 2023, and 2023BPix.

The diff comments out several previous signal entries, including `ttHnobb`, `TTLNu`, `TTTT`, and `TZQB-Zto2L-4FS_MLL-30`, and adds/keeps the `TTLL` samples plus the corresponding `tllq_<year>.json` entry.

Reviewers should confirm that this is the intended signal-sample composition for the production targeted by this branch.

#### H. MET histogram axis update

`topeft/modules/axes.py` changes the `met` histogram axis from:

```python
"met": {"regular": (40, 0, 400), "label": r"MET (GeV)"}
```

to:

```python
"met": {"regular": (20, 0, 200), "label": r"MET (GeV)"}
```

This changes the histogram binning and range for MET. It should be treated as an analysis-output change rather than only a technical correction.

#### I. Tests

New tests are added for:

```text
tests/test_met_collection_policy.py
tests/test_forward_jet_eta_banded_policy.py
```

Existing threading and JetID-adoption tests are updated to cover:

- Run 3 / Run 2 resolution of the JER suppression option;
- no string-heuristic use for Run 2 year detection in the new policy helpers;
- `--fwd-eta-band-pt-apply` CLI exposure;
- forwarding of `fwd_eta_band_pt_apply` from `run_analysis.py`;
- replacement of hard-coded forward-jet selections with `is_forward_jet_eta_banded(...)`.

### Testing

Suggested validation commands:

```bash
python -m pytest -q \
  tests/test_met_collection_policy.py \
  tests/test_forward_jet_eta_banded_policy.py \
  tests/test_forward_eta_jer_suppression_threading.py \
  tests/test_run3_nanov12_jet_id_adoption.py
```

Suggested compile check:

```bash
python -m compileall analysis topeft tests
```

Suggested CLI checks:

```bash
cd analysis/topeft_run2

python run_analysis.py --help | rg "fwd-eta-band-pt-apply|suppress-forward-eta-stochastic-jer|MET|JER"

python run_analysis_diboson.py --help | rg "fwd-eta-band-pt-apply"
```

Suggested small runtime smoke tests:

```bash
cd analysis/topeft_run2

./fullR3_run.sh \
  -y 2022 \
  -t test_puppimet_met_systs_fwd_eta_policy \
  -x futures \
  -c 1 \
  -s 1000 \
  --cr \
  --do-systs \
  --hist-list-override lj0pt
```

and, if validating the opt-in JER mitigation together with MET propagation:

```bash
./fullR3_run.sh \
  -y 2022 \
  -t test_puppimet_met_systs_fwd_eta_policy_noStochJER \
  -x futures \
  -c 1 \
  -s 1000 \
  --cr \
  --do-systs \
  --hist-list-override lj0pt \
  --suppress-forward-eta-stochastic-jer
```

Before merging, replace these suggested commands with the actual final validation commands and results from the branch.

### Review notes

- This PR changes analysis behavior in several places, not only technical plumbing.
- Run 3 now explicitly uses `PuppiMET`; Run 2 continues to use legacy `MET`.
- The new unclustered MET systematics are added to the correction systematic loop and should be checked in downstream datacard/systematic naming expectations.
- The forward-jet eta-band pT policy is configurable, but the current parameter values apply the tighter threshold to `abs(eta) > 2.5` because `fwd_jet_eta_band_max` is set to `10.0`.
- The baseline forward-jet pT threshold is configured as `40.0`, while the eta-band threshold is `60.0`. Reviewers should confirm this is the intended option-(a) implementation for the current analysis.
- The stochastic JER suppression remains opt-in and Run-3-only through the resolver; it is not enabled by default.
- The MET axis binning change from `(40, 0, 400)` to `(20, 0, 200)` changes output histogram content and should be approved as an analysis choice.
- The WorkQueue staging path and default chunksize changes affect production execution behavior.
- The signal cfg changes alter the sample set used by the listed Run 3 signal cfg files; reviewers should confirm these are intended for the production campaign.