### PR TITLE
 Enable Run 2 Type-1 MET in topeft

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -22,7 +22,7 @@ import topcoffea.modules.corrections as tc_cor
 from topeft.modules.axes import info as axes_info
 from topeft.modules.axes import info_2d as axes_info_2d
 from topeft.modules.paths import topeft_path
-from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, ApplyRochesterCorrections, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_selected_raw_met, get_corr_t1_met_jets, get_supported_jet_systematics, get_supported_met_systematics, is_met_unclustered_systematic, resolve_forward_eta_stochastic_jer_suppression, use_run3_type1_met
+from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, ApplyRochesterCorrections, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_selected_raw_met, get_corr_t1_met_jets, get_supported_jet_systematics, get_supported_met_systematics, is_met_unclustered_systematic, resolve_forward_eta_stochastic_jer_suppression, use_type1_met
 import topeft.modules.event_selection as te_es
 import topeft.modules.object_selection as te_os
 from topcoffea.modules.get_param_from_jsons import GetParam
@@ -552,7 +552,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         # Initialize objects
 
         met  = get_selected_met(events, year)
-        raw_met = get_selected_raw_met(events, year) if use_run3_type1_met(year) else met
+        raw_met = get_selected_raw_met(events, year)
         ele  = events.Electron
         mu   = events.Muon
         tau  = events.Tau
@@ -869,11 +869,11 @@ class AnalysisProcessor(processor.ProcessorABC):
         # Otherwise loop juse once, for nominal
         else: syst_var_list = ['nominal']
 
-        # Build the Run 3 Type-1 MET correction from the full NanoAOD Jet
+        # Build the Type-1 MET correction from the full NanoAOD Jet
         # collection. The analysis-cleaned jet path below remains separate.
         events_cache = events.caches[0]
         type1_met = None
-        if use_run3_type1_met(year):
+        if use_type1_met(year):
             type1Jets = jets
             type1Jets = ak.with_field(type1Jets, (1 - type1Jets.rawFactor)*type1Jets.pt, "pt_raw")
             type1Jets = ak.with_field(type1Jets, (1 - type1Jets.rawFactor)*type1Jets.mass, "mass_raw")
@@ -963,7 +963,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                 suppress_forward_eta_stochastic_jer=effective_suppress_forward_eta_stochastic_jer,
             ).build(cleanedJets, lazy_cache=events_cache)  #Run3 ready
             cleanedJets = ApplyJetSystematics(year,cleanedJets,syst_var)
-            if use_run3_type1_met(year):
+            if use_type1_met(year):
                 met = ApplyMETSystematics(type1_met, syst_var)
             else:
                 met = ApplyJetCorrections(year, corr_type='met', isData=isData, era=run_era, run=run).build(met_raw, cleanedJets, lazy_cache=events_cache)

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -1113,8 +1113,8 @@ if __name__ == "__main__":
         hist_lst = [
             # "lj0pt",
             "ptz",
-            # "met",
-            # "lt",
+            "met",
+            "lt",
             # # "ljptsum",
             # # "l0pt",
             # # "l0ptcorr",

--- a/tests/test_met_collection_policy.py
+++ b/tests/test_met_collection_policy.py
@@ -6,11 +6,12 @@ import pytest
 from topeft.modules.corrections import (
     ApplyMETSystematics,
     get_corr_t1_met_jets,
+    get_jerc_keys,
     get_selected_met,
     get_selected_raw_met,
     get_supported_met_systematics,
     is_met_unclustered_systematic,
-    use_run3_type1_met,
+    use_type1_met,
 )
 
 
@@ -26,9 +27,22 @@ def _processor_source():
 def _processor_type1_block():
     source = _processor_source()
     return source[
-        source.index("# Build the Run 3 Type-1 MET correction"):
+        source.index("# Build the Type-1 MET correction"):
         source.index("# Loop over the list of systematic variations")
     ]
+
+
+@pytest.mark.parametrize(
+    "year",
+    ["2016APV", "2016", "2017", "2018", "2022", "2022EE", "2023", "2023BPix"],
+)
+def test_type1_met_policy_covers_supported_run2_and_run3_years(year):
+    assert use_type1_met(year)
+
+
+def test_type1_met_policy_rejects_unknown_years():
+    assert not use_type1_met("2024")
+    assert not use_type1_met("unknown")
 
 
 def test_run2_selected_met_uses_legacy_met():
@@ -53,28 +67,74 @@ def test_run3_selected_met_missing_puppimet_fails_clearly():
 def test_run3_type1_raw_met_policy_uses_raw_puppimet():
     events = SimpleNamespace(MET=object(), PuppiMET=object(), RawPuppiMET=object())
 
-    assert use_run3_type1_met("2022")
+    assert use_type1_met("2022")
     assert get_selected_met(events, "2022") is events.PuppiMET
     assert get_selected_raw_met(events, "2022") is events.RawPuppiMET
 
 
-def test_run2_type1_policy_is_disabled_and_legacy_met_is_unchanged():
-    events = SimpleNamespace(MET=object(), RawPuppiMET=object(), PuppiMET=object())
+def test_run2_type1_raw_met_policy_uses_raw_met():
+    events = SimpleNamespace(MET=object(), RawMET=object(), PuppiMET=object())
 
-    assert not use_run3_type1_met("2018")
+    assert use_type1_met("2018")
     assert get_selected_met(events, "2018") is events.MET
-    assert get_selected_raw_met(events, "2018") is events.MET
+    assert get_selected_raw_met(events, "2018") is events.RawMET
 
 
-def test_run3_type1_requires_corr_t1_met_jet_collection():
+def test_run2_type1_raw_met_missing_rawmet_fails_clearly():
+    events = SimpleNamespace(MET=object(), PuppiMET=object())
+
+    with pytest.raises(RuntimeError, match="requires events.RawMET"):
+        get_selected_raw_met(events, "2018")
+
+
+def test_run3_type1_raw_met_missing_rawpuppimet_fails_clearly():
+    events = SimpleNamespace(MET=object(), PuppiMET=object())
+
+    with pytest.raises(RuntimeError, match="requires events.RawPuppiMET"):
+        get_selected_raw_met(events, "2022")
+
+
+@pytest.mark.parametrize("year", ["2018", "2022"])
+def test_type1_requires_corr_t1_met_jet_collection(year):
     corr_t1 = object()
     events = SimpleNamespace(CorrT1METJet=corr_t1)
 
-    assert get_corr_t1_met_jets(events, "2022") is corr_t1
-    assert get_corr_t1_met_jets(events, "2018") is None
+    assert get_corr_t1_met_jets(events, year) is corr_t1
 
     with pytest.raises(RuntimeError, match="requires events.CorrT1METJet"):
-        get_corr_t1_met_jets(SimpleNamespace(), "2022")
+        get_corr_t1_met_jets(SimpleNamespace(), year)
+
+
+@pytest.mark.parametrize("year", ["2016APV", "2016", "2017", "2018"])
+def test_run2_type1_mc_jec_levels_use_full_l1l2l3(year):
+    _, _, levels, _, _ = get_jerc_keys(year, isdata=False, corr_type="type1_met")
+
+    assert levels == ["L1FastJet", "L2Relative", "L3Absolute"]
+
+
+@pytest.mark.parametrize(
+    ("year", "era"),
+    [("2016APV", "B"), ("2016", "F"), ("2017", "B"), ("2018", "A")],
+)
+def test_run2_type1_data_jec_levels_include_residuals(year, era):
+    _, _, levels, _, _ = get_jerc_keys(year, isdata=True, era=era, corr_type="type1_met")
+
+    assert levels == ["L1FastJet", "L2Relative", "L3Absolute", "L2L3Residual"]
+
+
+@pytest.mark.parametrize("year", ["2016APV", "2016", "2017", "2018"])
+def test_regular_run2_analysis_jet_jec_levels_are_unchanged(year):
+    _, _, levels, _, _ = get_jerc_keys(year, isdata=False, corr_type="jets")
+
+    assert levels == ["L1FastJet", "L2Relative"]
+
+
+def test_run3_type1_jec_levels_are_unchanged():
+    _, _, mc_levels, _, _ = get_jerc_keys("2022", isdata=False, corr_type="type1_met")
+    _, _, data_levels, _, _ = get_jerc_keys("2022", isdata=True, era="C", corr_type="type1_met")
+
+    assert mc_levels == ["L1FastJet", "L2Relative", "L3Absolute", "L2L3Residual"]
+    assert data_levels == ["L1FastJet", "L2Relative", "L3Absolute", "L2L3Residual"]
 
 
 def test_met_unclustered_systematics_are_public_generic_labels():
@@ -142,6 +202,13 @@ def test_processor_type1_met_passes_full_jets_corrt1_and_correction_options():
     assert "suppress_forward_eta_stochastic_jer=effective_suppress_forward_eta_stochastic_jer" in block
     assert "del type1Jets" in block
     assert "del corrT1METJets" in block
+
+
+def test_processor_type1_met_build_policy_is_not_run3_only():
+    block = _processor_type1_block()
+
+    assert "if use_type1_met(year):" in block
+    assert "use_run3_type1_met" not in block
 
 
 def test_processor_keeps_cleaned_analysis_jets_separate():

--- a/topeft/modules/corrections.py
+++ b/topeft/modules/corrections.py
@@ -120,7 +120,7 @@ jet_veto_dict = {
 with open(topeft_path("modules/jerc_dict.yml"), "r") as f:
     jerc_dict = yaml.safe_load(f)
 
-def get_jerc_keys(year, isdata, era=None):
+def get_jerc_keys(year, isdata, era=None, corr_type="jets"):
     # Jet Algorithm
     if year.startswith("202"):
         jet_algo = 'AK4PFPuppi'
@@ -129,6 +129,9 @@ def get_jerc_keys(year, isdata, era=None):
 
     #jec levels
     jec_levels = jerc_dict[year]['jec_levels']
+    if corr_type == "type1_met":
+        type1_levels_key = "type1_jec_levels_data" if isdata else "type1_jec_levels_mc"
+        jec_levels = jerc_dict[year].get(type1_levels_key, jec_levels)
 
     # jerc keys and junc types
     if not isdata:
@@ -177,6 +180,16 @@ def get_supported_jet_systematics(year, isData=False, era=None):
 
 
 MET_UNCLUSTERED_ENERGY = "MET_UnclusteredEnergy"
+TYPE1_MET_YEARS = {
+    "2016APV",
+    "2016",
+    "2017",
+    "2018",
+    "2022",
+    "2022EE",
+    "2023",
+    "2023BPix",
+}
 
 
 def get_selected_met(events, year):
@@ -189,12 +202,20 @@ def get_selected_met(events, year):
     return getattr(events, met_collection_name)
 
 
+def use_type1_met(year):
+    return str(year) in TYPE1_MET_YEARS
+
+
 def use_run3_type1_met(year):
-    return str(year).startswith("202")
+    # Legacy helper kept for external callers; Type-1 policy lives in use_type1_met.
+    return use_type1_met(year) and str(year).startswith("202")
 
 
 def get_selected_raw_met(events, year):
-    raw_met_collection_name = "RawPuppiMET" if use_run3_type1_met(year) else "MET"
+    if not use_type1_met(year):
+        return get_selected_met(events, year)
+
+    raw_met_collection_name = "RawPuppiMET" if str(year).startswith("202") else "RawMET"
     if not hasattr(events, raw_met_collection_name):
         raise RuntimeError(
             f"Run {year} Type-1 MET processing requires events.{raw_met_collection_name}; "
@@ -204,7 +225,7 @@ def get_selected_raw_met(events, year):
 
 
 def get_corr_t1_met_jets(events, year):
-    if not use_run3_type1_met(year):
+    if not use_type1_met(year):
         return None
     if not hasattr(events, "CorrT1METJet"):
         raise RuntimeError(
@@ -1887,7 +1908,12 @@ def ApplyJetCorrections(
 
     elif useclib:
         # Handle clib case
-        jet_algo, jec_tag, jec_levels, jer_tag, junc_types = get_jerc_keys(year, isData, era)
+        jet_algo, jec_tag, jec_levels, jer_tag, junc_types = get_jerc_keys(
+            year,
+            isData,
+            era,
+            corr_type=corr_type,
+        )
         json_path = topcoffea_path(f"data/POG/JME/{jec_year}/jet_jerc.json.gz")
 
         # Create JECStack for clib scenario

--- a/topeft/modules/jerc_dict.yml
+++ b/topeft/modules/jerc_dict.yml
@@ -7,6 +7,15 @@
   jec_levels:
     - L1FastJet
     - L2Relative
+  type1_jec_levels_mc:
+    - L1FastJet
+    - L2Relative
+    - L3Absolute
+  type1_jec_levels_data:
+    - L1FastJet
+    - L2Relative
+    - L3Absolute
+    - L2L3Residual
   jer: Summer20UL16_JRV3_MC
   junc:
     - FlavorQCD
@@ -30,6 +39,15 @@
   jec_levels:
     - L1FastJet
     - L2Relative
+  type1_jec_levels_mc:
+    - L1FastJet
+    - L2Relative
+    - L3Absolute
+  type1_jec_levels_data:
+    - L1FastJet
+    - L2Relative
+    - L3Absolute
+    - L2L3Residual
   jer: Summer20UL16APV_JRV3_MC
   junc:
     - FlavorQCD
@@ -53,6 +71,15 @@
   jec_levels:
     - L1FastJet
     - L2Relative
+  type1_jec_levels_mc:
+    - L1FastJet
+    - L2Relative
+    - L3Absolute
+  type1_jec_levels_data:
+    - L1FastJet
+    - L2Relative
+    - L3Absolute
+    - L2L3Residual
   jer: Summer19UL17_JRV2_MC
   junc:
     - FlavorQCD
@@ -75,6 +102,15 @@
   jec_levels:
     - L1FastJet
     - L2Relative
+  type1_jec_levels_mc:
+    - L1FastJet
+    - L2Relative
+    - L3Absolute
+  type1_jec_levels_data:
+    - L1FastJet
+    - L2Relative
+    - L3Absolute
+    - L2L3Residual
   jer: Summer19UL18_JRV2_MC
   junc:
     - FlavorQCD


### PR DESCRIPTION
### Summary

* Generalize the Type-1 MET path from Run 3-only to supported Run 2 and Run 3 years.
* Use Run 2 `RawMET` as the raw Type-1 seed while preserving `MET` as the stored/reference collection.
* Require `CorrT1METJet` for Type-1 MET in both Run 2 and Run 3.
* Add Type-1-specific full Run 2 JEC levels without changing the regular Run 2 analysis-jet JEC levels.
* Add `met` and `lt` to the CR histogram list to support Type-1 MET validation in CR productions.

### Motivation

The Run 2 workflow needs to validate and eventually use the same explicit Type-1 MET machinery that was introduced for Run 3, while respecting the Run 2 NanoAOD conventions:

```text
Run 2 stored/reference MET:
  MET

Run 2 raw Type-1 seed:
  RawMET

Run 2 Type-1 jet inputs:
  full events.Jet
  events.CorrT1METJet

Run 2 JEC algorithm:
  AK4PFchs
```

Before this change, the Type-1 MET path was effectively gated as Run 3-only, and Run 2 did not use `RawMET` plus `CorrT1METJet` through the Type-1 factory path. In addition, the Run 2 JEC configuration only exposed the regular analysis-jet JEC levels. For Type-1 MET, we need the full Run 2 JEC sequence while preserving the existing regular Run 2 jet behavior.

This PR intentionally changes Run 2 MET processing semantics by enabling the Type-1 MET path for supported Run 2 years. It does not change the regular Run 2 analysis-jet JEC-level policy.

### Implementation details

#### A. General Type-1 MET policy

`analysis_processor.py` now imports and uses the generic Type-1 policy helper:

```python
use_type1_met(year)
```

instead of gating the Type-1 MET block with the Run-3-only helper.

The supported Type-1 years are defined in `topeft/modules/corrections.py`:

```text
2016APV
2016
2017
2018
2022
2022EE
2023
2023BPix
```

The legacy helper:

```python
use_run3_type1_met(year)
```

is kept as a compatibility wrapper for external callers, but the central policy now lives in `use_type1_met(year)`.

#### B. Run 2 raw/stored MET policy

`get_selected_met(events, year)` preserves the existing stored/reference MET behavior:

```text
Run 2:
  MET

Run 3:
  PuppiMET
```

`get_selected_raw_met(events, year)` now uses the Type-1-specific raw collection for supported Type-1 years:

```text
Run 2:
  RawMET

Run 3:
  RawPuppiMET
```

Missing required raw MET collections now fail clearly for Type-1 years:

```text
Run 2:
  missing RawMET raises an error

Run 3:
  missing RawPuppiMET raises an error
```

For unsupported years, the helper falls back to the stored/reference MET collection.

#### C. CorrT1METJet requirement

`get_corr_t1_met_jets(events, year)` now requires `events.CorrT1METJet` for every supported Type-1 MET year.

This is intentional for Run 2 and Run 3 Type-1 MET, because the Type-1 factory needs both:

```text
full events.Jet
events.CorrT1METJet
```

The helper still returns `None` only for years outside the supported Type-1 policy.

#### D. Processor Type-1 MET block

The Type-1 MET block in `analysis_processor.py` now runs for both Run 2 and Run 3 Type-1 years:

```python
if use_type1_met(year):
    ...
```

The processor builds the Type-1 MET correction from the full NanoAOD `Jet` collection, not from the analysis-cleaned jet collection. This keeps the intended separation:

```text
full events.Jet:
  Type-1 MET construction

cleanedJets:
  analysis selections, observables, b tagging, and forward jets
```

The Type-1 regular-jet collection is prepared with:

```text
pt_raw
mass_raw
rho
pt_gen for MC
```

`CorrT1METJet` receives the event-level `rho` broadcast to its jagged structure, because the correctionlib L1/full JEC evaluators can require `Rho`.

MET systematics are then applied to the Type-1 MET object for supported Type-1 years:

```python
met = ApplyMETSystematics(type1_met, syst_var)
```

The legacy `corr_type="met"` path is retained for unsupported/non-Type-1 years.

#### E. Type-1-specific Run 2 JEC levels

`get_jerc_keys(...)` now accepts:

```python
corr_type="jets"
corr_type="type1_met"
```

For regular Run 2 analysis jets, the existing configured levels are preserved:

```text
L1FastJet
L2Relative
```

For Run 2 Type-1 MET, dedicated full JEC levels are configured in `topeft/modules/jerc_dict.yml`:

```text
Run 2 MC Type-1 MET:
  L1FastJet
  L2Relative
  L3Absolute

Run 2 DATA Type-1 MET:
  L1FastJet
  L2Relative
  L3Absolute
  L2L3Residual
```

This avoids changing the existing regular Run 2 jet correction semantics while giving the Type-1 MET path the full JEC sequence it needs.

Run 3 Type-1 JEC behavior is unchanged.

#### F. CR histogram list

The `--hist-list cr` block in `analysis/topeft_run2/run_analysis.py` now includes:

```text
ptz
met
lt
```

and still appends:

```text
ptz_wtau
```

when `--tau-h-analysis` or `--all-analysis` is enabled.

This is intentional. The CR output now includes MET/LT histograms needed for Type-1 MET validation, and it avoids empty-output behavior for CR category groups that do not fill `ptz` or `ptz_wtau`.

### Testing

Focused tests added/updated in:

```text
tests/test_met_collection_policy.py
```

The tests cover:

```text
- Type-1 MET policy is enabled for supported Run 2 and Run 3 years.
- Unknown years are rejected by the Type-1 policy.
- Run 2 stored/reference MET remains MET.
- Run 3 stored/reference MET remains PuppiMET.
- Run 2 raw Type-1 MET uses RawMET.
- Run 3 raw Type-1 MET uses RawPuppiMET.
- Missing RawMET / RawPuppiMET fails clearly.
- CorrT1METJet is required for Run 2 and Run 3 Type-1 MET.
- Run 2 MC Type-1 JEC levels are L1FastJet + L2Relative + L3Absolute.
- Run 2 DATA Type-1 JEC levels add L2L3Residual.
- Regular Run 2 analysis-jet JEC levels remain L1FastJet + L2Relative.
- Run 3 Type-1 JEC levels remain unchanged.
- The processor Type-1 MET block is no longer Run-3-only.
- The processor still keeps full Type-1 jets separate from cleaned analysis jets.
```

Commands run during validation:

```bash
python -m compileall analysis tests
python -m pytest -q tests/test_met_collection_policy.py
```

Additional bounded validation performed during the development sequence:

```text
Run 2 MC closure, 50 events:
  rebuilt Type-1 MET residuals versus stored MET remained small.

Run 2 DATA closure, 50 events:
  rebuilt Type-1 MET residuals versus stored MET remained small.

Run 3 MC smoke closure, 50 events:
  rebuilt Type-1 MET residuals versus stored PuppiMET remained stable.

Bounded Run 2 processor validation:
  sample: UL18_WLLJJ_WToLNu_NDSkim_EWK
  executor: futures
  chunks: 1
  hist-list: met lt
  result: output pickle contained met, met_sumw2, lt, and lt_sumw2.
```

Limitations:

```text
- Full Run 2 production-scale physics validation is planned separately.
- The explicit abs(eta) < 5.2 Type-1 jet selection is still deferred.
- The forward-eta-band pT tightening policy is not changed in this PR.
```

### Review notes

* This PR intentionally changes Run 2 MET processing semantics by enabling the Type-1 MET factory path for supported Run 2 years.
* The regular Run 2 analysis-jet JEC levels are intentionally preserved; only `corr_type="type1_met"` uses the full Run 2 Type-1 JEC sequence.
* `CorrT1METJet` is now required for Run 2 Type-1 MET processing.
* The processor uses full `events.Jet` for Type-1 MET and keeps `cleanedJets` for analysis selections and observables.
* `run_analysis.py` now includes `met` and `lt` in the CR hist list; this changes the CR output content and the expected CR production filename tags.
* The legacy `use_run3_type1_met(year)` helper is retained only as a compatibility wrapper. New logic should use `use_type1_met(year)`.
* The explicit `abs(eta) < 5.2` Type-1 jet cut is not introduced here and remains a follow-up decision.
* For Run 2 production naming, tags should reflect that the default forward-eta-band 70 GeV tightening is disabled for Run 2.
