### PR TITLE
Integrate muon/tau correction systematics and HistEFT tutorial docs

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -22,7 +22,7 @@ import topcoffea.modules.corrections as tc_cor
 from topeft.modules.axes import info as axes_info
 from topeft.modules.axes import info_2d as axes_info_2d
 from topeft.modules.paths import topeft_path
-from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, ApplyRochesterCorrections, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_selected_raw_met, get_corr_t1_met_jets, get_supported_jet_systematics, get_supported_met_systematics, is_met_unclustered_systematic, resolve_forward_eta_stochastic_jer_suppression, use_type1_met
+from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, apply_muon_momentum_corrections, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_selected_raw_met, get_corr_t1_met_jets, get_supported_jet_systematics, get_supported_met_systematics, is_met_unclustered_systematic, resolve_forward_eta_stochastic_jer_suppression, use_type1_met
 import topeft.modules.event_selection as te_es
 import topeft.modules.object_selection as te_os
 from topcoffea.modules.get_param_from_jsons import GetParam
@@ -584,7 +584,16 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         ele["idEmu"] = te_os.ttH_idEmu_cuts_E3(ele.hoe, ele.eta, ele.deltaEtaSC, ele.eInvMinusPInv, ele.sieie)
         ele["conept"] = leptonSelection.coneptElec(ele)
-        mu["conept"] = leptonSelection.coneptMuon(mu)
+        corrected_muon_pt = apply_muon_momentum_corrections(
+            year,
+            mu,
+            isData,
+            event_numbers=events.event,
+            luminosity_blocks=events.luminosityBlock,
+        )
+        mu = te_os.prepare_muons_for_selection(
+            mu, corrected_muon_pt, leptonSelection
+        )
 
         if not isData:
             ele["gen_pdgId"] = ak.fill_none(ele.matched_gen.pdgId, 0)
@@ -634,8 +643,6 @@ class AnalysisProcessor(processor.ProcessorABC):
             ele["pt_raw"] = ele.pt
         ################### Muon selection ####################
 
-        mu["pt_raw"] = mu.pt
-        mu["pt"] = ApplyRochesterCorrections(year, mu, isData) # Run3 ones are not available
         mu["isPres"] = leptonSelection.isPresMuon(mu)
         mu["isLooseM"] = leptonSelection.isLooseMuon(mu)
         mu["isFO"] = leptonSelection.isFOMuon(mu, year)

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -635,7 +635,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         if self.enable_tau_blocks:
             tau_fo_tag = "VLoose" if is_run2 else "Loose"
             tau_T_tag = "Loose" if is_run2 else "Medium"
-            tau_energy_views = AttachTauEnergyCorrections(
+            taus = AttachTauEnergyCorrections(
                 year, tau, isData, vsJetWP=tau_T_tag
             )
 
@@ -823,7 +823,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             #################### Taus ####################
 
             if self.enable_tau_blocks:
-                tau = ApplyTauEnergySystematics(tau_energy_views, syst_var)
+                tau = ApplyTauEnergySystematics(taus, syst_var)
 
                 if is_run2:
                     vs_jet = tau.idDeepTau2017v2p1VSjet

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -591,9 +591,9 @@ class AnalysisProcessor(processor.ProcessorABC):
             event_numbers=events.event,
             luminosity_blocks=events.luminosityBlock,
         )
-        mu = te_os.prepare_muons_for_selection(
-            mu, corrected_muon_pt, leptonSelection
-        )
+        mu["pt_raw"] = mu.pt
+        mu["pt"] = corrected_muon_pt
+        mu["conept"] = leptonSelection.coneptMuon(mu)
 
         if not isData:
             ele["gen_pdgId"] = ak.fill_none(ele.matched_gen.pdgId, 0)

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -22,7 +22,7 @@ import topcoffea.modules.corrections as tc_cor
 from topeft.modules.axes import info as axes_info
 from topeft.modules.axes import info_2d as axes_info_2d
 from topeft.modules.paths import topeft_path
-from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, apply_muon_momentum_corrections, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_selected_raw_met, get_corr_t1_met_jets, get_supported_jet_systematics, get_supported_met_systematics, is_met_unclustered_systematic, resolve_forward_eta_stochastic_jer_suppression, use_type1_met
+from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, apply_muon_momentum_corrections, get_supported_muon_momentum_systematics, is_muon_momentum_systematic, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_selected_raw_met, get_corr_t1_met_jets, get_supported_jet_systematics, get_supported_met_systematics, is_met_unclustered_systematic, resolve_forward_eta_stochastic_jer_suppression, use_type1_met
 import topeft.modules.event_selection as te_es
 import topeft.modules.object_selection as te_os
 from topcoffea.modules.get_param_from_jsons import GetParam
@@ -806,6 +806,9 @@ class AnalysisProcessor(processor.ProcessorABC):
         obj_correction_syst_lst.extend(
             get_supported_met_systematics(year, isData=isData, era=run_era)
         )
+        obj_correction_syst_lst.extend(
+            get_supported_muon_momentum_systematics(year, isData=isData)
+        )
         if self.enable_tau_blocks:
             obj_correction_syst_lst.append("TESUp")
             obj_correction_syst_lst.append("TESDown")
@@ -925,6 +928,42 @@ class AnalysisProcessor(processor.ProcessorABC):
             # Make a copy of the base weights object, so that each time through the loop we do not double count systs
             # In this loop over systs that impact kinematics, we will add to the weights objects the SFs that depend on the object kinematics
             weights_obj_base_for_kinematic_syst = copy.deepcopy(weights_obj_base)
+            l_fo_for_syst = l_fo
+            l_fo_conept_sorted_for_syst = l_fo_conept_sorted
+            min_mll_afas_for_syst = events.minMllAFAS
+
+            if is_muon_momentum_systematic(syst_var):
+                varied_mu = ak.with_field(mu, mu.pt_raw, "pt")
+                varied_corrected_muon_pt = apply_muon_momentum_corrections(
+                    year,
+                    varied_mu,
+                    isData,
+                    event_numbers=events.event,
+                    luminosity_blocks=events.luminosityBlock,
+                    variation=syst_var,
+                )
+                varied_mu["pt_raw"] = varied_mu.pt
+                varied_mu["pt"] = varied_corrected_muon_pt
+                varied_mu["conept"] = leptonSelection.coneptMuon(varied_mu)
+                varied_mu["isPres"] = leptonSelection.isPresMuon(varied_mu)
+                varied_mu["isLooseM"] = leptonSelection.isLooseMuon(varied_mu)
+                varied_mu["isFO"] = leptonSelection.isFOMuon(varied_mu, year)
+                varied_mu["isTightLep"]= leptonSelection.tightSelMuon(varied_mu)
+
+                m_loose_for_syst = varied_mu[varied_mu.isPres & varied_mu.isLooseM]
+                l_loose_for_syst = ak.with_name(ak.concatenate([e_loose, m_loose_for_syst], axis=1), 'PtEtaPhiMCandidate')
+                llpairs_for_syst = ak.combinations(l_loose_for_syst, 2, fields=["l0","l1"])
+                min_mll_afas_for_syst = ak.min( (llpairs_for_syst.l0+llpairs_for_syst.l1).mass, axis=-1)
+
+                m_fo_for_syst = varied_mu[varied_mu.isPres & varied_mu.isLooseM & varied_mu.isFO]
+                AttachMuonSF(m_fo_for_syst, year=year, useRun3MVA=self.useRun3MVA)
+                AttachPerLeptonFR(m_fo_for_syst, flavor = "Muon", year=year)
+                m_fo_for_syst['convVeto'] = ak.ones_like(m_fo_for_syst.charge)
+                m_fo_for_syst['lostHits'] = ak.zeros_like(m_fo_for_syst.charge)
+                m_fo_for_syst['seediEtaOriX'] = ak.zeros_like(m_fo_for_syst.charge)
+                m_fo_for_syst['seediPhiOriY'] = ak.zeros_like(m_fo_for_syst.charge)
+                l_fo_for_syst = ak.with_name(ak.concatenate([e_fo, m_fo_for_syst], axis=1), 'PtEtaPhiMCandidate')
+                l_fo_conept_sorted_for_syst = l_fo_for_syst[ak.argsort(l_fo_for_syst.conept, axis=-1,ascending=False)]
 
             #################### Jets ####################
 
@@ -933,7 +972,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             # if self.enable_tau_blocks:
             #     vetos_tocleanjets = ak.with_name( ak.concatenate([cleaning_taus, l_fo], axis=1), "PtEtaPhiMCandidate")
             # else:
-            vetos_tocleanjets = ak.with_name( l_fo, "PtEtaPhiMCandidate")
+            vetos_tocleanjets = ak.with_name( l_fo_for_syst, "PtEtaPhiMCandidate")
             tmp = ak.cartesian([ak.local_index(jets.pt), vetos_tocleanjets.jetIdx], nested=True)
             cleanedJets = jets[~ak.any(tmp.slot0 == tmp.slot1, axis=-1)] # this line should go before *any selection*, otherwise lep.jetIdx is not aligned with the jet index
             
@@ -1025,7 +1064,8 @@ class AnalysisProcessor(processor.ProcessorABC):
 
             # Put njets and l_fo_conept_sorted into events
             events["njets"] = njets
-            events["l_fo_conept_sorted"] = l_fo_conept_sorted
+            events["minMllAFAS"] = min_mll_afas_for_syst
+            events["l_fo_conept_sorted"] = l_fo_conept_sorted_for_syst
 
             # The event selection
             te_es.add1lMaskAndSFs(events, year, isData, sampleType)
@@ -1035,7 +1075,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             te_es.addLepCatMasks(events)
 
             # Convenient to have l0, l1, l2 on hand
-            l_fo_conept_sorted_padded = ak.pad_none(l_fo_conept_sorted, 3)
+            l_fo_conept_sorted_padded = ak.pad_none(l_fo_conept_sorted_for_syst, 3)
             l0 = l_fo_conept_sorted_padded[:,0]
             l1 = l_fo_conept_sorted_padded[:,1]
             l2 = l_fo_conept_sorted_padded[:,2]
@@ -1432,7 +1472,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             # Calculate ptbl
             ptbl_bjet = goodJets[(isBtagJetsMedium | isBtagJetsLoose)]
             ptbl_bjet = ptbl_bjet[ak.argmax(ptbl_bjet.pt,axis=-1,keepdims=True)] # Only save hardest b-jet
-            ptbl_lep = l_fo_conept_sorted
+            ptbl_lep = l_fo_conept_sorted_for_syst
             ptbl = (ptbl_bjet.nearest(ptbl_lep) + ptbl_bjet).pt
 
             # Z pt (pt of the ll pair that form the Z for the onZ categories)
@@ -1445,7 +1485,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             # Leading (b+l) pair pt
             bjetsl = goodJets[isBtagJetsLoose][ak.argsort(goodJets[isBtagJetsLoose].pt, axis=-1, ascending=False)]
             bjetsm = goodJets[isBtagJetsMedium][ak.argsort(goodJets[isBtagJetsMedium].pt, axis=-1, ascending=False)]
-            bl_pairs = ak.cartesian({"b":bjetsl,"l":l_fo_conept_sorted})
+            bl_pairs = ak.cartesian({"b":bjetsl,"l":l_fo_conept_sorted_for_syst})
             blpt = (bl_pairs["b"] + bl_pairs["l"]).pt
             bl0pt = ak.flatten(blpt[ak.argmax(blpt,axis=-1,keepdims=True)])
 
@@ -1458,9 +1498,9 @@ class AnalysisProcessor(processor.ProcessorABC):
 
             # Collection of all objects (leptons and jets)
             if self.enable_tau_blocks:
-                l_j_collection = ak.with_name(ak.concatenate([l_fo_conept_sorted,goodJets,cleaning_taus], axis=1),"PtEtaPhiMCollection")
+                l_j_collection = ak.with_name(ak.concatenate([l_fo_conept_sorted_for_syst,goodJets,cleaning_taus], axis=1),"PtEtaPhiMCollection")
             else:
-                l_j_collection = ak.with_name(ak.concatenate([l_fo_conept_sorted,goodJets], axis=1),"PtEtaPhiMCollection")
+                l_j_collection = ak.with_name(ak.concatenate([l_fo_conept_sorted_for_syst,goodJets], axis=1),"PtEtaPhiMCollection")
 
             # Leading object (j or l) pt
             o0pt = ak.max(l_j_collection.pt,axis=-1)

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -22,7 +22,7 @@ import topcoffea.modules.corrections as tc_cor
 from topeft.modules.axes import info as axes_info
 from topeft.modules.axes import info_2d as axes_info_2d
 from topeft.modules.paths import topeft_path
-from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, AttachMuonMomentumCorrections, ApplyMuonMomentumSystematics, get_supported_muon_momentum_systematics, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_selected_raw_met, get_corr_t1_met_jets, get_supported_jet_systematics, get_supported_met_systematics, is_met_unclustered_systematic, resolve_forward_eta_stochastic_jer_suppression, use_type1_met
+from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, AttachTauEnergyCorrections, ApplyTauEnergySystematics, AttachPerLeptonFR, AttachMuonMomentumCorrections, ApplyMuonMomentumSystematics, get_supported_muon_momentum_systematics, get_supported_tau_energy_systematics, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_selected_raw_met, get_corr_t1_met_jets, get_supported_jet_systematics, get_supported_met_systematics, is_met_unclustered_systematic, resolve_forward_eta_stochastic_jer_suppression, use_type1_met
 import topeft.modules.event_selection as te_es
 import topeft.modules.object_selection as te_os
 from topcoffea.modules.get_param_from_jsons import GetParam
@@ -635,6 +635,9 @@ class AnalysisProcessor(processor.ProcessorABC):
         if self.enable_tau_blocks:
             tau_fo_tag = "VLoose" if is_run2 else "Loose"
             tau_T_tag = "Loose" if is_run2 else "Medium"
+            tau_energy_views = AttachTauEnergyCorrections(
+                year, tau, isData, vsJetWP=tau_T_tag
+            )
 
         # Define the lists of systematics we include
         obj_correction_syst_lst = get_supported_jet_systematics(
@@ -647,10 +650,9 @@ class AnalysisProcessor(processor.ProcessorABC):
             get_supported_muon_momentum_systematics(year, isData=isData)
         )
         if self.enable_tau_blocks:
-            obj_correction_syst_lst.append("TESUp")
-            obj_correction_syst_lst.append("TESDown")
-            obj_correction_syst_lst.append("FESUp")
-            obj_correction_syst_lst.append("FESDown")
+            obj_correction_syst_lst.extend(
+                get_supported_tau_energy_systematics(year, isData=isData)
+            )
 
         wgt_correction_syst_lst = [
             "lepSF_muonUp","lepSF_muonDown","lepSF_elecUp","lepSF_elecDown",f"btagSFbc_{year}Up",f"btagSFbc_{year}Down","btagSFbc_corrUp","btagSFbc_corrDown",f"btagSFlight_{year}Up",f"btagSFlight_{year}Down","btagSFlight_corrUp","btagSFlight_corrDown","PUUp","PUDown","PreFiringUp","PreFiringDown",f"triggerSF_{year}Up",f"triggerSF_{year}Down", # Exp systs
@@ -821,16 +823,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             #################### Taus ####################
 
             if self.enable_tau_blocks:
-                tau = events.Tau
-                tau["pt"], tau["mass"] = ApplyTES(
-                    year, tau, isData, tau_T_tag
-                )
-                tau["pt"], tau["mass"] = ApplyTESSystematic(
-                    year, tau, isData, syst_var, tau_T_tag
-                )
-                tau["pt"], tau["mass"] = ApplyFESSystematic(
-                    year, tau, isData, syst_var, tau_T_tag
-                )
+                tau = ApplyTauEnergySystematics(tau_energy_views, syst_var)
 
                 if is_run2:
                     vs_jet = tau.idDeepTau2017v2p1VSjet

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -22,7 +22,7 @@ import topcoffea.modules.corrections as tc_cor
 from topeft.modules.axes import info as axes_info
 from topeft.modules.axes import info_2d as axes_info_2d
 from topeft.modules.paths import topeft_path
-from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, apply_muon_momentum_corrections, get_supported_muon_momentum_systematics, is_muon_momentum_systematic, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_selected_raw_met, get_corr_t1_met_jets, get_supported_jet_systematics, get_supported_met_systematics, is_met_unclustered_systematic, resolve_forward_eta_stochastic_jer_suppression, use_type1_met
+from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, AttachMuonMomentumCorrections, ApplyMuonMomentumSystematics, get_supported_muon_momentum_systematics, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_selected_raw_met, get_corr_t1_met_jets, get_supported_jet_systematics, get_supported_met_systematics, is_met_unclustered_systematic, resolve_forward_eta_stochastic_jer_suppression, use_type1_met
 import topeft.modules.event_selection as te_es
 import topeft.modules.object_selection as te_os
 from topcoffea.modules.get_param_from_jsons import GetParam
@@ -583,17 +583,16 @@ class AnalysisProcessor(processor.ProcessorABC):
         events.nom = ak.ones_like(met.pt)
 
         ele["idEmu"] = te_os.ttH_idEmu_cuts_E3(ele.hoe, ele.eta, ele.deltaEtaSC, ele.eInvMinusPInv, ele.sieie)
-        ele["conept"] = leptonSelection.coneptElec(ele)
-        corrected_muon_pt = apply_muon_momentum_corrections(
+        mu["pt_raw"] = mu.pt
+        mu = AttachMuonMomentumCorrections(
             year,
             mu,
             isData,
             event_numbers=events.event,
             luminosity_blocks=events.luminosityBlock,
         )
-        mu["pt_raw"] = mu.pt
-        mu["pt"] = corrected_muon_pt
-        mu["conept"] = leptonSelection.coneptMuon(mu)
+        if is_run2:
+            ele["pt_raw"] = ele.pt
 
         if not isData:
             ele["gen_pdgId"] = ak.fill_none(ele.matched_gen.pdgId, 0)
@@ -633,171 +632,9 @@ class AnalysisProcessor(processor.ProcessorABC):
         # Initialize the out object
         hout = self.accumulator
 
-        ################### Electron selection ####################
-
-        ele["isPres"] = leptonSelection.isPresElec(ele)
-        ele["isLooseE"] = leptonSelection.isLooseElec(ele)
-        ele["isFO"] = leptonSelection.isFOElec(ele, year)
-        ele["isTightLep"] = leptonSelection.tightSelElec(ele)
-        if is_run2:
-            ele["pt_raw"] = ele.pt
-        ################### Muon selection ####################
-
-        mu["isPres"] = leptonSelection.isPresMuon(mu)
-        mu["isLooseM"] = leptonSelection.isLooseMuon(mu)
-        mu["isFO"] = leptonSelection.isFOMuon(mu, year)
-        mu["isTightLep"]= leptonSelection.tightSelMuon(mu)
-
-        ################### Loose selection ####################
-
-        m_loose = mu[mu.isPres & mu.isLooseM]
-        e_loose = ele[ele.isPres & ele.isLooseE]
-        l_loose = ak.with_name(ak.concatenate([e_loose, m_loose], axis=1), 'PtEtaPhiMCandidate')
-
-        # Compute pair invariant masses, for all flavors all signes
-        llpairs = ak.combinations(l_loose, 2, fields=["l0","l1"])
-        events["minMllAFAS"] = ak.min( (llpairs.l0+llpairs.l1).mass, axis=-1)
-
-        # Build FO collection
-        m_fo = mu[mu.isPres & mu.isLooseM & mu.isFO]
-        e_fo = ele[ele.isPres & ele.isLooseE & ele.isFO]
-        if "seediEtaOriX" not in ak.fields(e_fo):
-            e_fo["seediEtaOriX"] = ak.zeros_like(e_fo.pt)
-        if "seediPhiOriY" not in ak.fields(e_fo):
-            e_fo["seediPhiOriY"] = ak.zeros_like(e_fo.pt)
-
-        # Attach the lepton SFs to the electron and muons collections
-        AttachElectronSF(e_fo, year=year, looseWP="none" if is_run3 else "wpLnoiso", useRun3MVA=self.useRun3MVA) #Run3 ready
-        AttachMuonSF(m_fo, year=year, useRun3MVA=self.useRun3MVA)
-
-        # Attach per lepton fake rates
-        AttachPerLeptonFR(e_fo, flavor = "Elec", year=year)
-        AttachPerLeptonFR(m_fo, flavor = "Muon", year=year)
-        m_fo['convVeto'] = ak.ones_like(m_fo.charge)
-        m_fo['lostHits'] = ak.zeros_like(m_fo.charge)
-        m_fo['seediEtaOriX'] = ak.zeros_like(m_fo.charge)
-        m_fo['seediPhiOriY'] = ak.zeros_like(m_fo.charge)
-        l_fo = ak.with_name(ak.concatenate([e_fo, m_fo], axis=1), 'PtEtaPhiMCandidate')
-        l_fo_conept_sorted = l_fo[ak.argsort(l_fo.conept, axis=-1,ascending=False)]
-
-        ################### Tau selection ####################
-
         if self.enable_tau_blocks:
             tau_fo_tag = "VLoose" if is_run2 else "Loose"
             tau_T_tag = "Loose" if is_run2 else "Medium"
-
-            if is_run2:
-                vs_jet = tau.idDeepTau2017v2p1VSjet
-                vs_e = tau.idDeepTau2017v2p1VSe
-                vs_mu = tau.idDeepTau2017v2p1VSmu
-            else:
-                vs_jet = tau.idDeepTau2018v2p5VSjet
-                vs_e = tau.idDeepTau2018v2p5VSe
-                vs_mu = tau.idDeepTau2018v2p5VSmu
-
-            tau["pt"], tau["mass"] = ApplyTES(year, tau, isData, tau_T_tag)
-
-            tau["isVLoose"] = tauSelection.isVLooseTau(vs_jet)
-            tau["isLoose"] = tauSelection.isLooseTau(vs_jet)
-            tau["isMedium"] = tauSelection.isMediumTau(vs_jet)
-            tau["iseTight"] = tauSelection.iseTightTau(vs_e)
-            tau["ismTight"] = ak.values_astype(tauSelection.ismTightTau(vs_mu), np.int8)
-            tau["isPresVLoose"] = tauSelection.isPresTau(
-                tau.pt,
-                tau.eta,
-                tau.dxy,
-                tau.dz,
-                vs_jet,
-                vs_e,
-                vs_mu,
-                minpt=20,
-                vsJetWP="VLoose",
-            )
-            tau["isPresLoose"] = tauSelection.isPresTau(
-                tau.pt,
-                tau.eta,
-                tau.dxy,
-                tau.dz,
-                vs_jet,
-                vs_e,
-                vs_mu,
-                minpt=20,
-                vsJetWP="Loose",
-            )
-            tau["isPresMedium"] = tauSelection.isPresTau(
-                tau.pt,
-                tau.eta,
-                tau.dxy,
-                tau.dz,
-                vs_jet,
-                vs_e,
-                vs_mu,
-                minpt=20,
-                vsJetWP="Medium",
-            )
-
-            tau["isPres"] = tau[f"isPres{tau_fo_tag}"]
-
-            tau["isClean"] = te_os.isClean(tau, l_fo, drmin=0.5)
-            tau["isGood"]  =  tau["isClean"] & tau["isPres"]
-            # _log_tau_flag_counts(
-            #     "tau_h_presel",
-            #     {
-            #         "isVLoose": tau["isVLoose"],
-            #         "isLoose": tau["isLoose"],
-            #         "ismTight": tau["ismTight"],
-            #         "isPresVLoose": tau["isPresVLoose"],
-            #         "isPresLoose": tau["isPresLoose"],
-            #         "isPres": tau["isPres"],
-            #         "isClean": tau["isClean"],
-            #         "isGood": tau["isGood"],
-            #     },
-            # )
-            tau = tau[tau.isGood]
-
-            tau['DMflag'] = ((tau.decayMode==0) | (tau.decayMode==1) | (tau.decayMode==10) | (tau.decayMode==11))
-            # _log_tau_flag_counts(
-            #     "tau_h_dmflag",
-            #     {
-            #         "DMflag": tau['DMflag'],
-            #     },
-            # )
-            tau = tau[tau['DMflag']]
-
-            tau_fo = tau
-            tau_fo_padded = ak.pad_none(tau_fo, 1)
-            tau0_fo = tau_fo_padded[:,0]
-
-            tau_T = tau_fo[tau_fo[f"is{tau_T_tag}"]>0]
-            tau_T_padded = ak.pad_none(tau_T, 1)
-            tau0_T = tau_T_padded[:,0]
-
-            cleaning_taus = tau_T
-            nLtau  = ak.num(tau_T)
-
-            if self.tau_run_mode == "standard":
-                tau_F_mask = (ak.num(tau_fo) == 1)
-                tau_L_mask = (nLtau == 1)
-            elif self.tau_run_mode == "taufitter":
-                tau_F_mask = (ak.num(tau_fo) >= 1)
-                tau_L_mask = (nLtau >= 1)
-            else:
-                raise ValueError(f"Unknown tau_run_mode '{self.tau_run_mode}'")
-            no_tau_mask = (nLtau == 0)
-
-            tau0 = tau0_T
-
-            # _log_tau_flag_counts(
-            #     "tau_h_event_masks",
-            #     {
-            #         "tau_F_mask": tau_F_mask,
-            #         "tau_L_mask": tau_L_mask,
-            #         "no_tau_mask": no_tau_mask,
-            #     },
-            # )
-
-            if not isData:
-                AttachTauSF(events, tau_T, year=year, vsJetWP=tau_T_tag)
 
         # Define the lists of systematics we include
         obj_correction_syst_lst = get_supported_jet_systematics(
@@ -928,51 +765,168 @@ class AnalysisProcessor(processor.ProcessorABC):
             # Make a copy of the base weights object, so that each time through the loop we do not double count systs
             # In this loop over systs that impact kinematics, we will add to the weights objects the SFs that depend on the object kinematics
             weights_obj_base_for_kinematic_syst = copy.deepcopy(weights_obj_base)
-            l_fo_for_syst = l_fo
-            l_fo_conept_sorted_for_syst = l_fo_conept_sorted
-            min_mll_afas_for_syst = events.minMllAFAS
 
-            if is_muon_momentum_systematic(syst_var):
-                varied_mu = ak.with_field(mu, mu.pt_raw, "pt")
-                varied_corrected_muon_pt = apply_muon_momentum_corrections(
-                    year,
-                    varied_mu,
-                    isData,
-                    event_numbers=events.event,
-                    luminosity_blocks=events.luminosityBlock,
-                    variation=syst_var,
+            #################### Leptons ####################
+
+            mu = ApplyMuonMomentumSystematics(year, mu, syst_var)
+            mu["conept"] = leptonSelection.coneptMuon(mu)
+            mu["isPres"] = leptonSelection.isPresMuon(mu)
+            mu["isLooseM"] = leptonSelection.isLooseMuon(mu)
+            mu["isFO"] = leptonSelection.isFOMuon(mu, year)
+            mu["isTightLep"] = leptonSelection.tightSelMuon(mu)
+
+            ele["conept"] = leptonSelection.coneptElec(ele)
+            ele["isPres"] = leptonSelection.isPresElec(ele)
+            ele["isLooseE"] = leptonSelection.isLooseElec(ele)
+            ele["isFO"] = leptonSelection.isFOElec(ele, year)
+            ele["isTightLep"] = leptonSelection.tightSelElec(ele)
+
+            m_loose = mu[mu.isPres & mu.isLooseM]
+            e_loose = ele[ele.isPres & ele.isLooseE]
+            l_loose = ak.with_name(
+                ak.concatenate([e_loose, m_loose], axis=1),
+                "PtEtaPhiMCandidate",
+            )
+            llpairs = ak.combinations(l_loose, 2, fields=["l0", "l1"])
+            min_mll_afas = ak.min((llpairs.l0 + llpairs.l1).mass, axis=-1)
+
+            m_fo = mu[mu.isPres & mu.isLooseM & mu.isFO]
+            e_fo = ele[ele.isPres & ele.isLooseE & ele.isFO]
+            if "seediEtaOriX" not in ak.fields(e_fo):
+                e_fo["seediEtaOriX"] = ak.zeros_like(e_fo.pt)
+            if "seediPhiOriY" not in ak.fields(e_fo):
+                e_fo["seediPhiOriY"] = ak.zeros_like(e_fo.pt)
+
+            AttachElectronSF(
+                e_fo,
+                year=year,
+                looseWP="none" if is_run3 else "wpLnoiso",
+                useRun3MVA=self.useRun3MVA,
+            )
+            AttachMuonSF(m_fo, year=year, useRun3MVA=self.useRun3MVA)
+            AttachPerLeptonFR(e_fo, flavor="Elec", year=year)
+            AttachPerLeptonFR(m_fo, flavor="Muon", year=year)
+            m_fo["convVeto"] = ak.ones_like(m_fo.charge)
+            m_fo["lostHits"] = ak.zeros_like(m_fo.charge)
+            m_fo["seediEtaOriX"] = ak.zeros_like(m_fo.charge)
+            m_fo["seediPhiOriY"] = ak.zeros_like(m_fo.charge)
+            l_fo = ak.with_name(
+                ak.concatenate([e_fo, m_fo], axis=1),
+                "PtEtaPhiMCandidate",
+            )
+            l_fo_conept_sorted = l_fo[
+                ak.argsort(l_fo.conept, axis=-1, ascending=False)
+            ]
+
+            #################### Taus ####################
+
+            if self.enable_tau_blocks:
+                tau = events.Tau
+                tau["pt"], tau["mass"] = ApplyTES(
+                    year, tau, isData, tau_T_tag
                 )
-                varied_mu["pt_raw"] = varied_mu.pt
-                varied_mu["pt"] = varied_corrected_muon_pt
-                varied_mu["conept"] = leptonSelection.coneptMuon(varied_mu)
-                varied_mu["isPres"] = leptonSelection.isPresMuon(varied_mu)
-                varied_mu["isLooseM"] = leptonSelection.isLooseMuon(varied_mu)
-                varied_mu["isFO"] = leptonSelection.isFOMuon(varied_mu, year)
-                varied_mu["isTightLep"]= leptonSelection.tightSelMuon(varied_mu)
+                tau["pt"], tau["mass"] = ApplyTESSystematic(
+                    year, tau, isData, syst_var, tau_T_tag
+                )
+                tau["pt"], tau["mass"] = ApplyFESSystematic(
+                    year, tau, isData, syst_var, tau_T_tag
+                )
 
-                m_loose_for_syst = varied_mu[varied_mu.isPres & varied_mu.isLooseM]
-                l_loose_for_syst = ak.with_name(ak.concatenate([e_loose, m_loose_for_syst], axis=1), 'PtEtaPhiMCandidate')
-                llpairs_for_syst = ak.combinations(l_loose_for_syst, 2, fields=["l0","l1"])
-                min_mll_afas_for_syst = ak.min( (llpairs_for_syst.l0+llpairs_for_syst.l1).mass, axis=-1)
+                if is_run2:
+                    vs_jet = tau.idDeepTau2017v2p1VSjet
+                    vs_e = tau.idDeepTau2017v2p1VSe
+                    vs_mu = tau.idDeepTau2017v2p1VSmu
+                else:
+                    vs_jet = tau.idDeepTau2018v2p5VSjet
+                    vs_e = tau.idDeepTau2018v2p5VSe
+                    vs_mu = tau.idDeepTau2018v2p5VSmu
 
-                m_fo_for_syst = varied_mu[varied_mu.isPres & varied_mu.isLooseM & varied_mu.isFO]
-                AttachMuonSF(m_fo_for_syst, year=year, useRun3MVA=self.useRun3MVA)
-                AttachPerLeptonFR(m_fo_for_syst, flavor = "Muon", year=year)
-                m_fo_for_syst['convVeto'] = ak.ones_like(m_fo_for_syst.charge)
-                m_fo_for_syst['lostHits'] = ak.zeros_like(m_fo_for_syst.charge)
-                m_fo_for_syst['seediEtaOriX'] = ak.zeros_like(m_fo_for_syst.charge)
-                m_fo_for_syst['seediPhiOriY'] = ak.zeros_like(m_fo_for_syst.charge)
-                l_fo_for_syst = ak.with_name(ak.concatenate([e_fo, m_fo_for_syst], axis=1), 'PtEtaPhiMCandidate')
-                l_fo_conept_sorted_for_syst = l_fo_for_syst[ak.argsort(l_fo_for_syst.conept, axis=-1,ascending=False)]
+                tau["isVLoose"] = tauSelection.isVLooseTau(vs_jet)
+                tau["isLoose"] = tauSelection.isLooseTau(vs_jet)
+                tau["isMedium"] = tauSelection.isMediumTau(vs_jet)
+                tau["iseTight"] = tauSelection.iseTightTau(vs_e)
+                tau["ismTight"] = ak.values_astype(
+                    tauSelection.ismTightTau(vs_mu), np.int8
+                )
+                tau["isPresVLoose"] = tauSelection.isPresTau(
+                    tau.pt,
+                    tau.eta,
+                    tau.dxy,
+                    tau.dz,
+                    vs_jet,
+                    vs_e,
+                    vs_mu,
+                    minpt=20,
+                    vsJetWP="VLoose",
+                )
+                tau["isPresLoose"] = tauSelection.isPresTau(
+                    tau.pt,
+                    tau.eta,
+                    tau.dxy,
+                    tau.dz,
+                    vs_jet,
+                    vs_e,
+                    vs_mu,
+                    minpt=20,
+                    vsJetWP="Loose",
+                )
+                tau["isPresMedium"] = tauSelection.isPresTau(
+                    tau.pt,
+                    tau.eta,
+                    tau.dxy,
+                    tau.dz,
+                    vs_jet,
+                    vs_e,
+                    vs_mu,
+                    minpt=20,
+                    vsJetWP="Medium",
+                )
+                tau["isPres"] = tau[f"isPres{tau_fo_tag}"]
+                tau["isClean"] = te_os.isClean(tau, l_fo, drmin=0.5)
+                tau["isGood"] = tau["isClean"] & tau["isPres"]
+                tau = tau[tau.isGood]
+                tau["DMflag"] = (
+                    (tau.decayMode == 0)
+                    | (tau.decayMode == 1)
+                    | (tau.decayMode == 10)
+                    | (tau.decayMode == 11)
+                )
+                tau = tau[tau.DMflag]
+
+                tau_fo = tau
+                tau_fo_padded = ak.pad_none(tau_fo, 1)
+                tau0_fo = tau_fo_padded[:, 0]
+                tau_T = tau_fo[tau_fo[f"is{tau_T_tag}"] > 0]
+                tau_T_padded = ak.pad_none(tau_T, 1)
+                tau0_T = tau_T_padded[:, 0]
+                cleaning_taus = tau_T
+                nLtau = ak.num(tau_T)
+
+                if self.tau_run_mode == "standard":
+                    tau_F_mask = ak.num(tau_fo) == 1
+                    tau_L_mask = nLtau == 1
+                elif self.tau_run_mode == "taufitter":
+                    tau_F_mask = ak.num(tau_fo) >= 1
+                    tau_L_mask = nLtau >= 1
+                else:
+                    raise ValueError(
+                        f"Unknown tau_run_mode '{self.tau_run_mode}'"
+                    )
+                no_tau_mask = nLtau == 0
+                tau0 = tau0_T
+
+                if not isData:
+                    AttachTauSF(
+                        events,
+                        tau_T,
+                        year=year,
+                        vsJetWP=tau_T_tag,
+                    )
 
             #################### Jets ####################
 
             # Jet cleaning, before any jet selection
-            #vetos_tocleanjets = ak.with_name( ak.concatenate([tau, l_fo], axis=1), "PtEtaPhiMCandidate")
-            # if self.enable_tau_blocks:
-            #     vetos_tocleanjets = ak.with_name( ak.concatenate([cleaning_taus, l_fo], axis=1), "PtEtaPhiMCandidate")
-            # else:
-            vetos_tocleanjets = ak.with_name( l_fo_for_syst, "PtEtaPhiMCandidate")
+            vetos_tocleanjets = ak.with_name(l_fo, "PtEtaPhiMCandidate")
             tmp = ak.cartesian([ak.local_index(jets.pt), vetos_tocleanjets.jetIdx], nested=True)
             cleanedJets = jets[~ak.any(tmp.slot0 == tmp.slot1, axis=-1)] # this line should go before *any selection*, otherwise lep.jetIdx is not aligned with the jet index
             
@@ -996,9 +950,6 @@ class AnalysisProcessor(processor.ProcessorABC):
             # Jet energy corrections
             if not isData:
                 cleanedJets["pt_gen"] = ak.values_astype(ak.fill_none(cleanedJets.matched_gen.pt, 0), np.float32)
-                if self.enable_tau_blocks:
-                    tau["pt"], tau["mass"]      = ApplyTESSystematic(year, tau, isData, syst_var, tau_T_tag)
-                    tau["pt"], tau["mass"]      = ApplyFESSystematic(year, tau, isData, syst_var, tau_T_tag)
 
             cleanedJets = ApplyJetCorrections(
                 year,
@@ -1064,8 +1015,8 @@ class AnalysisProcessor(processor.ProcessorABC):
 
             # Put njets and l_fo_conept_sorted into events
             events["njets"] = njets
-            events["minMllAFAS"] = min_mll_afas_for_syst
-            events["l_fo_conept_sorted"] = l_fo_conept_sorted_for_syst
+            events["minMllAFAS"] = min_mll_afas
+            events["l_fo_conept_sorted"] = l_fo_conept_sorted
 
             # The event selection
             te_es.add1lMaskAndSFs(events, year, isData, sampleType)
@@ -1075,7 +1026,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             te_es.addLepCatMasks(events)
 
             # Convenient to have l0, l1, l2 on hand
-            l_fo_conept_sorted_padded = ak.pad_none(l_fo_conept_sorted_for_syst, 3)
+            l_fo_conept_sorted_padded = ak.pad_none(l_fo_conept_sorted, 3)
             l0 = l_fo_conept_sorted_padded[:,0]
             l1 = l_fo_conept_sorted_padded[:,1]
             l2 = l_fo_conept_sorted_padded[:,2]
@@ -1472,7 +1423,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             # Calculate ptbl
             ptbl_bjet = goodJets[(isBtagJetsMedium | isBtagJetsLoose)]
             ptbl_bjet = ptbl_bjet[ak.argmax(ptbl_bjet.pt,axis=-1,keepdims=True)] # Only save hardest b-jet
-            ptbl_lep = l_fo_conept_sorted_for_syst
+            ptbl_lep = l_fo_conept_sorted
             ptbl = (ptbl_bjet.nearest(ptbl_lep) + ptbl_bjet).pt
 
             # Z pt (pt of the ll pair that form the Z for the onZ categories)
@@ -1485,7 +1436,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             # Leading (b+l) pair pt
             bjetsl = goodJets[isBtagJetsLoose][ak.argsort(goodJets[isBtagJetsLoose].pt, axis=-1, ascending=False)]
             bjetsm = goodJets[isBtagJetsMedium][ak.argsort(goodJets[isBtagJetsMedium].pt, axis=-1, ascending=False)]
-            bl_pairs = ak.cartesian({"b":bjetsl,"l":l_fo_conept_sorted_for_syst})
+            bl_pairs = ak.cartesian({"b":bjetsl,"l":l_fo_conept_sorted})
             blpt = (bl_pairs["b"] + bl_pairs["l"]).pt
             bl0pt = ak.flatten(blpt[ak.argmax(blpt,axis=-1,keepdims=True)])
 
@@ -1498,9 +1449,9 @@ class AnalysisProcessor(processor.ProcessorABC):
 
             # Collection of all objects (leptons and jets)
             if self.enable_tau_blocks:
-                l_j_collection = ak.with_name(ak.concatenate([l_fo_conept_sorted_for_syst,goodJets,cleaning_taus], axis=1),"PtEtaPhiMCollection")
+                l_j_collection = ak.with_name(ak.concatenate([l_fo_conept_sorted,goodJets,cleaning_taus], axis=1),"PtEtaPhiMCollection")
             else:
-                l_j_collection = ak.with_name(ak.concatenate([l_fo_conept_sorted_for_syst,goodJets], axis=1),"PtEtaPhiMCollection")
+                l_j_collection = ak.with_name(ak.concatenate([l_fo_conept_sorted,goodJets], axis=1),"PtEtaPhiMCollection")
 
             # Leading object (j or l) pt
             o0pt = ak.max(l_j_collection.pt,axis=-1)

--- a/analysis/topeft_run2/analysis_processor_diboson.py
+++ b/analysis/topeft_run2/analysis_processor_diboson.py
@@ -20,7 +20,7 @@ import topcoffea.modules.corrections as tc_cor
 
 from topeft.modules.axes import info as axes_info
 from topeft.modules.paths import topeft_path
-from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, AttachMuonMomentumCorrections, ApplyMuonMomentumSystematics, get_supported_muon_momentum_systematics, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_supported_met_systematics, is_met_unclustered_systematic, resolve_forward_eta_stochastic_jer_suppression
+from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, AttachTauEnergyCorrections, ApplyTauEnergySystematics, AttachPerLeptonFR, AttachMuonMomentumCorrections, ApplyMuonMomentumSystematics, get_supported_muon_momentum_systematics, get_supported_tau_energy_systematics, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_supported_met_systematics, is_met_unclustered_systematic, resolve_forward_eta_stochastic_jer_suppression
 import topeft.modules.event_selection as te_es
 import topeft.modules.object_selection as te_os
 from topcoffea.modules.get_param_from_jsons import GetParam
@@ -305,6 +305,12 @@ class AnalysisProcessor(processor.ProcessorABC):
         # Initialize the out object
         hout = self.accumulator
 
+        if self.tau_h_analysis:
+            tau_energy_wp = "Loose" if is_run2 else "Medium"
+            tau_energy_views = AttachTauEnergyCorrections(
+                year, tau, isData, vsJetWP=tau_energy_wp
+            )
+
         ######### Systematics ###########
 
         # Define the lists of systematics we include
@@ -325,10 +331,9 @@ class AnalysisProcessor(processor.ProcessorABC):
             get_supported_muon_momentum_systematics(year, isData=isData)
         )
         if self.tau_h_analysis:
-            obj_correction_syst_lst.append("TESUp")
-            obj_correction_syst_lst.append("TESDown")
-            obj_correction_syst_lst.append("FESUp")
-            obj_correction_syst_lst.append("FESDown")
+            obj_correction_syst_lst.extend(
+                get_supported_tau_energy_systematics(year, isData=isData)
+            )
 
         wgt_correction_syst_lst = [
             "lepSF_muonUp","lepSF_muonDown","lepSF_elecUp","lepSF_elecDown",f"btagSFbc_{year}Up",f"btagSFbc_{year}Down","btagSFbc_corrUp","btagSFbc_corrDown",f"btagSFlight_{year}Up",f"btagSFlight_{year}Down","btagSFlight_corrUp","btagSFlight_corrDown","PUUp","PUDown","PreFiringUp","PreFiringDown",f"triggerSF_{year}Up",f"triggerSF_{year}Down", # Exp systs
@@ -443,15 +448,10 @@ class AnalysisProcessor(processor.ProcessorABC):
 
             #################### Taus ####################
 
-            tau = events.Tau
             if self.tau_h_analysis:
-                tau["pt"], tau["mass"] = ApplyTES(year, tau, isData)
-                tau["pt"], tau["mass"] = ApplyTESSystematic(
-                    year, tau, isData, syst_var
-                )
-                tau["pt"], tau["mass"] = ApplyFESSystematic(
-                    year, tau, isData, syst_var
-                )
+                tau = ApplyTauEnergySystematics(tau_energy_views, syst_var)
+            else:
+                tau = events.Tau
 
             if is_run2:
                 vs_jet = tau.idDeepTau2017v2p1VSjet

--- a/analysis/topeft_run2/analysis_processor_diboson.py
+++ b/analysis/topeft_run2/analysis_processor_diboson.py
@@ -268,9 +268,9 @@ class AnalysisProcessor(processor.ProcessorABC):
             event_numbers=events.event,
             luminosity_blocks=events.luminosityBlock,
         )
-        mu = te_os.prepare_muons_for_selection(
-            mu, corrected_muon_pt, leptonSelection
-        )
+        mu["pt_raw"] = mu.pt
+        mu["pt"] = corrected_muon_pt
+        mu["conept"] = leptonSelection.coneptMuon(mu)
 
         if not isData:
             ele["gen_pdgId"] = ak.fill_none(ele.matched_gen.pdgId, 0)

--- a/analysis/topeft_run2/analysis_processor_diboson.py
+++ b/analysis/topeft_run2/analysis_processor_diboson.py
@@ -307,7 +307,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         if self.tau_h_analysis:
             tau_energy_wp = "Loose" if is_run2 else "Medium"
-            tau_energy_views = AttachTauEnergyCorrections(
+            taus = AttachTauEnergyCorrections(
                 year, tau, isData, vsJetWP=tau_energy_wp
             )
 
@@ -449,7 +449,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             #################### Taus ####################
 
             if self.tau_h_analysis:
-                tau = ApplyTauEnergySystematics(tau_energy_views, syst_var)
+                tau = ApplyTauEnergySystematics(taus, syst_var)
             else:
                 tau = events.Tau
 

--- a/analysis/topeft_run2/analysis_processor_diboson.py
+++ b/analysis/topeft_run2/analysis_processor_diboson.py
@@ -20,7 +20,7 @@ import topcoffea.modules.corrections as tc_cor
 
 from topeft.modules.axes import info as axes_info
 from topeft.modules.paths import topeft_path
-from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, ApplyRochesterCorrections, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_supported_met_systematics, is_met_unclustered_systematic, resolve_forward_eta_stochastic_jer_suppression
+from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, apply_muon_momentum_corrections, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_supported_met_systematics, is_met_unclustered_systematic, resolve_forward_eta_stochastic_jer_suppression
 import topeft.modules.event_selection as te_es
 import topeft.modules.object_selection as te_os
 from topcoffea.modules.get_param_from_jsons import GetParam
@@ -261,7 +261,16 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         ele["idEmu"] = te_os.ttH_idEmu_cuts_E3(ele.hoe, ele.eta, ele.deltaEtaSC, ele.eInvMinusPInv, ele.sieie)
         ele["conept"] = leptonSelection.coneptElec(ele)
-        mu["conept"] = leptonSelection.coneptMuon(mu)
+        corrected_muon_pt = apply_muon_momentum_corrections(
+            year,
+            mu,
+            isData,
+            event_numbers=events.event,
+            luminosity_blocks=events.luminosityBlock,
+        )
+        mu = te_os.prepare_muons_for_selection(
+            mu, corrected_muon_pt, leptonSelection
+        )
 
         if not isData:
             ele["gen_pdgId"] = ak.fill_none(ele.matched_gen.pdgId, 0)
@@ -307,8 +316,6 @@ class AnalysisProcessor(processor.ProcessorABC):
             ele["pt_raw"] = ele.pt
         ################### Muon selection ####################
 
-        mu["pt_raw"] = mu.pt
-        mu["pt"] = ApplyRochesterCorrections(year, mu, isData) # Run3 ones are not available
         mu["isPres"] = leptonSelection.isPresMuon(mu)
         mu["isLooseM"] = leptonSelection.isLooseMuon(mu)
         mu["isFO"] = leptonSelection.isFOMuon(mu, year)

--- a/analysis/topeft_run2/analysis_processor_diboson.py
+++ b/analysis/topeft_run2/analysis_processor_diboson.py
@@ -20,7 +20,7 @@ import topcoffea.modules.corrections as tc_cor
 
 from topeft.modules.axes import info as axes_info
 from topeft.modules.paths import topeft_path
-from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, apply_muon_momentum_corrections, get_supported_muon_momentum_systematics, is_muon_momentum_systematic, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_supported_met_systematics, is_met_unclustered_systematic, resolve_forward_eta_stochastic_jer_suppression
+from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, AttachMuonMomentumCorrections, ApplyMuonMomentumSystematics, get_supported_muon_momentum_systematics, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_supported_met_systematics, is_met_unclustered_systematic, resolve_forward_eta_stochastic_jer_suppression
 import topeft.modules.event_selection as te_es
 import topeft.modules.object_selection as te_os
 from topcoffea.modules.get_param_from_jsons import GetParam
@@ -260,17 +260,16 @@ class AnalysisProcessor(processor.ProcessorABC):
         events.nom = ak.ones_like(met.pt)
 
         ele["idEmu"] = te_os.ttH_idEmu_cuts_E3(ele.hoe, ele.eta, ele.deltaEtaSC, ele.eInvMinusPInv, ele.sieie)
-        ele["conept"] = leptonSelection.coneptElec(ele)
-        corrected_muon_pt = apply_muon_momentum_corrections(
+        mu["pt_raw"] = mu.pt
+        mu = AttachMuonMomentumCorrections(
             year,
             mu,
             isData,
             event_numbers=events.event,
             luminosity_blocks=events.luminosityBlock,
         )
-        mu["pt_raw"] = mu.pt
-        mu["pt"] = corrected_muon_pt
-        mu["conept"] = leptonSelection.coneptMuon(mu)
+        if is_run2:
+            ele["pt_raw"] = ele.pt
 
         if not isData:
             ele["gen_pdgId"] = ak.fill_none(ele.matched_gen.pdgId, 0)
@@ -305,113 +304,6 @@ class AnalysisProcessor(processor.ProcessorABC):
         eft_w2_coeffs = efth.calc_w2_coeffs(eft_coeffs,self._dtype) if (self._do_errors and eft_coeffs is not None) else None
         # Initialize the out object
         hout = self.accumulator
-
-        ################### Electron selection ####################
-
-        ele["isPres"] = leptonSelection.isPresElec(ele)
-        ele["isLooseE"] = leptonSelection.isLooseElec(ele)
-        ele["isFO"] = leptonSelection.isFOElec(ele, year)
-        ele["isTightLep"] = leptonSelection.tightSelElec(ele)
-        if is_run2:
-            ele["pt_raw"] = ele.pt
-        ################### Muon selection ####################
-
-        mu["isPres"] = leptonSelection.isPresMuon(mu)
-        mu["isLooseM"] = leptonSelection.isLooseMuon(mu)
-        mu["isFO"] = leptonSelection.isFOMuon(mu, year)
-        mu["isTightLep"]= leptonSelection.tightSelMuon(mu)
-
-        ################### Loose selection ####################
-
-        m_loose = mu[mu.isPres & mu.isLooseM]
-        e_loose = ele[ele.isPres & ele.isLooseE]
-        l_loose = ak.with_name(ak.concatenate([e_loose, m_loose], axis=1), 'PtEtaPhiMCandidate')
-
-        # Compute pair invariant masses, for all flavors all signes
-        llpairs = ak.combinations(l_loose, 2, fields=["l0","l1"])
-        events["minMllAFAS"] = ak.min( (llpairs.l0+llpairs.l1).mass, axis=-1)
-
-        # Build FO collection
-        m_fo = mu[mu.isPres & mu.isLooseM & mu.isFO]
-        e_fo = ele[ele.isPres & ele.isLooseE & ele.isFO]
-
-        # Attach the lepton SFs to the electron and muons collections
-        AttachElectronSF(e_fo, year=year, looseWP="none" if is_run3 else "wpLnoiso", useRun3MVA=self.useRun3MVA) #Run3 ready
-        AttachMuonSF(m_fo, year=year, useRun3MVA=self.useRun3MVA)
-
-        # Attach per lepton fake rates
-        AttachPerLeptonFR(e_fo, flavor = "Elec", year=year)
-        AttachPerLeptonFR(m_fo, flavor = "Muon", year=year)
-        m_fo['convVeto'] = ak.ones_like(m_fo.charge)
-        m_fo['lostHits'] = ak.zeros_like(m_fo.charge)
-        l_fo = ak.with_name(ak.concatenate([e_fo, m_fo], axis=1), 'PtEtaPhiMCandidate')
-        l_fo_conept_sorted = l_fo[ak.argsort(l_fo.conept, axis=-1,ascending=False)]
-
-        ################### Tau selection ####################
-
-        if self.tau_h_analysis:
-            tau["pt"], tau["mass"] = ApplyTES(year, tau, isData)
-            if is_run2:
-                vs_jet = tau.idDeepTau2017v2p1VSjet
-                vs_e = tau.idDeepTau2017v2p1VSe
-                vs_mu = tau.idDeepTau2017v2p1VSmu
-            else:
-                vs_jet = tau.idDeepTau2018v2p5VSjet
-                vs_e = tau.idDeepTau2018v2p5VSe
-                vs_mu = tau.idDeepTau2018v2p5VSmu
-
-            tau["isVLoose"] = tauSelection.isVLooseTau(vs_jet)
-            tau["isLoose"] = tauSelection.isLooseTau(vs_jet)
-            tau["iseTight"] = tauSelection.iseTightTau(vs_e)
-            tau["ismTight"] = ak.values_astype(tauSelection.ismTightTau(vs_mu), np.int8)
-            tau["isPres"] = tauSelection.isPresTau(
-                tau.pt,
-                tau.eta,
-                tau.dxy,
-                tau.dz,
-                vs_jet,
-                vs_e,
-                vs_mu,
-                minpt=20,
-            )
-            tau["isClean"] = te_os.isClean(tau, l_fo, drmin=0.3)
-            tau["isGood"]  =  tau["isClean"] & tau["isPres"]
-            tau = tau[tau.isGood]
-
-            tau['DMflag'] = ((tau.decayMode==0) | (tau.decayMode==1) | (tau.decayMode==10) | (tau.decayMode==11))
-            tau = tau[tau['DMflag']]
-
-            cleaning_taus = tau[tau["isLoose"]>0]
-            nLtau  = ak.num(tau[tau["isLoose"]>0] )
-            if not isData:
-                AttachTauSF(events,tau,year=year)
-            tau_padded = ak.pad_none(tau, 1)
-            tau0 = tau_padded[:,0]
-
-        else:
-            if is_run2:
-                vs_jet = tau.idDeepTau2017v2p1VSjet
-                vs_e = tau.idDeepTau2017v2p1VSe
-                vs_mu = tau.idDeepTau2017v2p1VSmu
-            else:
-                vs_jet = tau.idDeepTau2018v2p5VSjet
-                vs_e = tau.idDeepTau2018v2p5VSe
-                vs_mu = tau.idDeepTau2018v2p5VSmu
-
-            tau["isPres"] = tauSelection.isPresTau(
-                tau.pt,
-                tau.eta,
-                tau.dxy,
-                tau.dz,
-                vs_jet,
-                vs_e,
-                vs_mu,
-                minpt=20,
-            )
-            tau["isClean"] = te_os.isClean(tau, l_loose, drmin=0.3)
-            tau["isGood"]  =  tau["isClean"] & tau["isPres"]
-            tau = tau[tau.isGood] # use these to clean jets
-            tau["isTight"] = tauSelection.isVLooseTau(vs_jet) # use these to veto
 
         ######### Systematics ###########
 
@@ -503,49 +395,133 @@ class AnalysisProcessor(processor.ProcessorABC):
             # Make a copy of the base weights object, so that each time through the loop we do not double count systs
             # In this loop over systs that impact kinematics, we will add to the weights objects the SFs that depend on the object kinematics
             weights_obj_base_for_kinematic_syst = copy.deepcopy(weights_obj_base)
-            l_fo_for_syst = l_fo
-            l_fo_conept_sorted_for_syst = l_fo_conept_sorted
-            min_mll_afas_for_syst = events.minMllAFAS
 
-            if is_muon_momentum_systematic(syst_var):
-                varied_mu = ak.with_field(mu, mu.pt_raw, "pt")
-                varied_corrected_muon_pt = apply_muon_momentum_corrections(
-                    year,
-                    varied_mu,
-                    isData,
-                    event_numbers=events.event,
-                    luminosity_blocks=events.luminosityBlock,
-                    variation=syst_var,
+            #################### Leptons ####################
+
+            mu = ApplyMuonMomentumSystematics(year, mu, syst_var)
+            mu["conept"] = leptonSelection.coneptMuon(mu)
+            mu["isPres"] = leptonSelection.isPresMuon(mu)
+            mu["isLooseM"] = leptonSelection.isLooseMuon(mu)
+            mu["isFO"] = leptonSelection.isFOMuon(mu, year)
+            mu["isTightLep"] = leptonSelection.tightSelMuon(mu)
+
+            ele["conept"] = leptonSelection.coneptElec(ele)
+            ele["isPres"] = leptonSelection.isPresElec(ele)
+            ele["isLooseE"] = leptonSelection.isLooseElec(ele)
+            ele["isFO"] = leptonSelection.isFOElec(ele, year)
+            ele["isTightLep"] = leptonSelection.tightSelElec(ele)
+
+            m_loose = mu[mu.isPres & mu.isLooseM]
+            e_loose = ele[ele.isPres & ele.isLooseE]
+            l_loose = ak.with_name(
+                ak.concatenate([e_loose, m_loose], axis=1),
+                "PtEtaPhiMCandidate",
+            )
+            llpairs = ak.combinations(l_loose, 2, fields=["l0", "l1"])
+            min_mll_afas = ak.min((llpairs.l0 + llpairs.l1).mass, axis=-1)
+
+            m_fo = mu[mu.isPres & mu.isLooseM & mu.isFO]
+            e_fo = ele[ele.isPres & ele.isLooseE & ele.isFO]
+            AttachElectronSF(
+                e_fo,
+                year=year,
+                looseWP="none" if is_run3 else "wpLnoiso",
+                useRun3MVA=self.useRun3MVA,
+            )
+            AttachMuonSF(m_fo, year=year, useRun3MVA=self.useRun3MVA)
+            AttachPerLeptonFR(e_fo, flavor="Elec", year=year)
+            AttachPerLeptonFR(m_fo, flavor="Muon", year=year)
+            m_fo["convVeto"] = ak.ones_like(m_fo.charge)
+            m_fo["lostHits"] = ak.zeros_like(m_fo.charge)
+            l_fo = ak.with_name(
+                ak.concatenate([e_fo, m_fo], axis=1),
+                "PtEtaPhiMCandidate",
+            )
+            l_fo_conept_sorted = l_fo[
+                ak.argsort(l_fo.conept, axis=-1, ascending=False)
+            ]
+
+            #################### Taus ####################
+
+            tau = events.Tau
+            if self.tau_h_analysis:
+                tau["pt"], tau["mass"] = ApplyTES(year, tau, isData)
+                tau["pt"], tau["mass"] = ApplyTESSystematic(
+                    year, tau, isData, syst_var
                 )
-                varied_mu["pt_raw"] = varied_mu.pt
-                varied_mu["pt"] = varied_corrected_muon_pt
-                varied_mu["conept"] = leptonSelection.coneptMuon(varied_mu)
-                varied_mu["isPres"] = leptonSelection.isPresMuon(varied_mu)
-                varied_mu["isLooseM"] = leptonSelection.isLooseMuon(varied_mu)
-                varied_mu["isFO"] = leptonSelection.isFOMuon(varied_mu, year)
-                varied_mu["isTightLep"]= leptonSelection.tightSelMuon(varied_mu)
+                tau["pt"], tau["mass"] = ApplyFESSystematic(
+                    year, tau, isData, syst_var
+                )
 
-                m_loose_for_syst = varied_mu[varied_mu.isPres & varied_mu.isLooseM]
-                l_loose_for_syst = ak.with_name(ak.concatenate([e_loose, m_loose_for_syst], axis=1), 'PtEtaPhiMCandidate')
-                llpairs_for_syst = ak.combinations(l_loose_for_syst, 2, fields=["l0","l1"])
-                min_mll_afas_for_syst = ak.min( (llpairs_for_syst.l0+llpairs_for_syst.l1).mass, axis=-1)
+            if is_run2:
+                vs_jet = tau.idDeepTau2017v2p1VSjet
+                vs_e = tau.idDeepTau2017v2p1VSe
+                vs_mu = tau.idDeepTau2017v2p1VSmu
+            else:
+                vs_jet = tau.idDeepTau2018v2p5VSjet
+                vs_e = tau.idDeepTau2018v2p5VSe
+                vs_mu = tau.idDeepTau2018v2p5VSmu
 
-                m_fo_for_syst = varied_mu[varied_mu.isPres & varied_mu.isLooseM & varied_mu.isFO]
-                AttachMuonSF(m_fo_for_syst, year=year, useRun3MVA=self.useRun3MVA)
-                AttachPerLeptonFR(m_fo_for_syst, flavor = "Muon", year=year)
-                m_fo_for_syst['convVeto'] = ak.ones_like(m_fo_for_syst.charge)
-                m_fo_for_syst['lostHits'] = ak.zeros_like(m_fo_for_syst.charge)
-                l_fo_for_syst = ak.with_name(ak.concatenate([e_fo, m_fo_for_syst], axis=1), 'PtEtaPhiMCandidate')
-                l_fo_conept_sorted_for_syst = l_fo_for_syst[ak.argsort(l_fo_for_syst.conept, axis=-1,ascending=False)]
+            if self.tau_h_analysis:
+                tau["isVLoose"] = tauSelection.isVLooseTau(vs_jet)
+                tau["isLoose"] = tauSelection.isLooseTau(vs_jet)
+                tau["iseTight"] = tauSelection.iseTightTau(vs_e)
+                tau["ismTight"] = ak.values_astype(
+                    tauSelection.ismTightTau(vs_mu), np.int8
+                )
+                tau["isPres"] = tauSelection.isPresTau(
+                    tau.pt,
+                    tau.eta,
+                    tau.dxy,
+                    tau.dz,
+                    vs_jet,
+                    vs_e,
+                    vs_mu,
+                    minpt=20,
+                )
+                tau["isClean"] = te_os.isClean(tau, l_fo, drmin=0.3)
+                tau["isGood"] = tau["isClean"] & tau["isPres"]
+                tau = tau[tau.isGood]
+                tau["DMflag"] = (
+                    (tau.decayMode == 0)
+                    | (tau.decayMode == 1)
+                    | (tau.decayMode == 10)
+                    | (tau.decayMode == 11)
+                )
+                tau = tau[tau.DMflag]
+
+                cleaning_taus = tau[tau.isLoose > 0]
+                nLtau = ak.num(cleaning_taus)
+                if not isData:
+                    AttachTauSF(events, tau, year=year)
+                tau_padded = ak.pad_none(tau, 1)
+                tau0 = tau_padded[:, 0]
+            else:
+                tau["isPres"] = tauSelection.isPresTau(
+                    tau.pt,
+                    tau.eta,
+                    tau.dxy,
+                    tau.dz,
+                    vs_jet,
+                    vs_e,
+                    vs_mu,
+                    minpt=20,
+                )
+                tau["isClean"] = te_os.isClean(tau, l_loose, drmin=0.3)
+                tau["isGood"] = tau["isClean"] & tau["isPres"]
+                tau = tau[tau.isGood]
+                tau["isTight"] = tauSelection.isVLooseTau(vs_jet)
 
             #################### Jets ####################
 
             # Jet cleaning, before any jet selection
-            #vetos_tocleanjets = ak.with_name( ak.concatenate([tau, l_fo], axis=1), "PtEtaPhiMCandidate")
             if self.tau_h_analysis:
-                vetos_tocleanjets = ak.with_name( ak.concatenate([cleaning_taus, l_fo_for_syst], axis=1), "PtEtaPhiMCandidate")
+                vetos_tocleanjets = ak.with_name(
+                    ak.concatenate([cleaning_taus, l_fo], axis=1),
+                    "PtEtaPhiMCandidate",
+                )
             else:
-                vetos_tocleanjets = ak.with_name( l_fo_for_syst, "PtEtaPhiMCandidate")
+                vetos_tocleanjets = ak.with_name(l_fo, "PtEtaPhiMCandidate")
             tmp = ak.cartesian([ak.local_index(jets.pt), vetos_tocleanjets.jetIdx], nested=True)
             cleanedJets = jets[~ak.any(tmp.slot0 == tmp.slot1, axis=-1)] # this line should go before *any selection*, otherwise lep.jetIdx is not aligned with the jet index
 
@@ -565,9 +541,6 @@ class AnalysisProcessor(processor.ProcessorABC):
             # Jet energy corrections
             if not isData:
                 cleanedJets["pt_gen"] = ak.values_astype(ak.fill_none(cleanedJets.matched_gen.pt, 0), np.float32)
-                if self.tau_h_analysis:
-                    tau["pt"], tau["mass"]      = ApplyTESSystematic(year, tau, isData, syst_var)
-                    tau["pt"], tau["mass"]      = ApplyFESSystematic(year, tau, isData, syst_var)
 
             events_cache = events.caches[0]
             cleanedJets = ApplyJetCorrections(
@@ -630,8 +603,8 @@ class AnalysisProcessor(processor.ProcessorABC):
 
             # Put njets and l_fo_conept_sorted into events
             events["njets"] = njets
-            events["minMllAFAS"] = min_mll_afas_for_syst
-            events["l_fo_conept_sorted"] = l_fo_conept_sorted_for_syst
+            events["minMllAFAS"] = min_mll_afas
+            events["l_fo_conept_sorted"] = l_fo_conept_sorted
 
             # The event selection
             te_es.add2lMaskAndSFs(events, year, isData, sampleType)
@@ -640,7 +613,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             te_es.addLepCatMasks(events)
 
             # Convenient to have l0, l1, l2 on hand
-            l_fo_conept_sorted_padded = ak.pad_none(l_fo_conept_sorted_for_syst, 3)
+            l_fo_conept_sorted_padded = ak.pad_none(l_fo_conept_sorted, 3)
             l0 = l_fo_conept_sorted_padded[:,0]
             l1 = l_fo_conept_sorted_padded[:,1]
             l2 = l_fo_conept_sorted_padded[:,2]
@@ -997,7 +970,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             # Calculate ptbl
             ptbl_bjet = goodJets[(isBtagJetsMedium | isBtagJetsLoose)]
             ptbl_bjet = ptbl_bjet[ak.argmax(ptbl_bjet.pt,axis=-1,keepdims=True)] # Only save hardest b-jet
-            ptbl_lep = l_fo_conept_sorted_for_syst
+            ptbl_lep = l_fo_conept_sorted
             ptbl = (ptbl_bjet.nearest(ptbl_lep) + ptbl_bjet).pt
             ptbl = ak.values_astype(ak.fill_none(ptbl, -1), np.float32)
 
@@ -1010,7 +983,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             # Leading (b+l) pair pt
             bjetsl = goodJets[isBtagJetsLoose][ak.argsort(goodJets[isBtagJetsLoose].pt, axis=-1, ascending=False)]
             bjetsm = goodJets[isBtagJetsMedium][ak.argsort(goodJets[isBtagJetsMedium].pt, axis=-1, ascending=False)]
-            bl_pairs = ak.cartesian({"b":bjetsl,"l":l_fo_conept_sorted_for_syst})
+            bl_pairs = ak.cartesian({"b":bjetsl,"l":l_fo_conept_sorted})
             blpt = (bl_pairs["b"] + bl_pairs["l"]).pt
             bl0pt = ak.flatten(blpt[ak.argmax(blpt,axis=-1,keepdims=True)])
 
@@ -1023,9 +996,9 @@ class AnalysisProcessor(processor.ProcessorABC):
 
             # Collection of all objects (leptons and jets)
             if self.tau_h_analysis:
-                l_j_collection = ak.with_name(ak.concatenate([l_fo_conept_sorted_for_syst,goodJets,cleaning_taus], axis=1),"PtEtaPhiMCollection")
+                l_j_collection = ak.with_name(ak.concatenate([l_fo_conept_sorted,goodJets,cleaning_taus], axis=1),"PtEtaPhiMCollection")
             else:
-                l_j_collection = ak.with_name(ak.concatenate([l_fo_conept_sorted_for_syst,goodJets], axis=1),"PtEtaPhiMCollection")
+                l_j_collection = ak.with_name(ak.concatenate([l_fo_conept_sorted,goodJets], axis=1),"PtEtaPhiMCollection")
 
             # Leading object (j or l) pt
             o0pt = ak.max(l_j_collection.pt,axis=-1)

--- a/analysis/topeft_run2/analysis_processor_diboson.py
+++ b/analysis/topeft_run2/analysis_processor_diboson.py
@@ -20,7 +20,7 @@ import topcoffea.modules.corrections as tc_cor
 
 from topeft.modules.axes import info as axes_info
 from topeft.modules.paths import topeft_path
-from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, apply_muon_momentum_corrections, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_supported_met_systematics, is_met_unclustered_systematic, resolve_forward_eta_stochastic_jer_suppression
+from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, ApplyTES, ApplyTESSystematic, ApplyFESSystematic, AttachPerLeptonFR, apply_muon_momentum_corrections, get_supported_muon_momentum_systematics, is_muon_momentum_systematic, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_supported_met_systematics, is_met_unclustered_systematic, resolve_forward_eta_stochastic_jer_suppression
 import topeft.modules.event_selection as te_es
 import topeft.modules.object_selection as te_os
 from topcoffea.modules.get_param_from_jsons import GetParam
@@ -429,6 +429,9 @@ class AnalysisProcessor(processor.ProcessorABC):
         obj_correction_syst_lst.extend(
             get_supported_met_systematics(year, isData=isData, era=run_era)
         )
+        obj_correction_syst_lst.extend(
+            get_supported_muon_momentum_systematics(year, isData=isData)
+        )
         if self.tau_h_analysis:
             obj_correction_syst_lst.append("TESUp")
             obj_correction_syst_lst.append("TESDown")
@@ -500,15 +503,49 @@ class AnalysisProcessor(processor.ProcessorABC):
             # Make a copy of the base weights object, so that each time through the loop we do not double count systs
             # In this loop over systs that impact kinematics, we will add to the weights objects the SFs that depend on the object kinematics
             weights_obj_base_for_kinematic_syst = copy.deepcopy(weights_obj_base)
+            l_fo_for_syst = l_fo
+            l_fo_conept_sorted_for_syst = l_fo_conept_sorted
+            min_mll_afas_for_syst = events.minMllAFAS
+
+            if is_muon_momentum_systematic(syst_var):
+                varied_mu = ak.with_field(mu, mu.pt_raw, "pt")
+                varied_corrected_muon_pt = apply_muon_momentum_corrections(
+                    year,
+                    varied_mu,
+                    isData,
+                    event_numbers=events.event,
+                    luminosity_blocks=events.luminosityBlock,
+                    variation=syst_var,
+                )
+                varied_mu["pt_raw"] = varied_mu.pt
+                varied_mu["pt"] = varied_corrected_muon_pt
+                varied_mu["conept"] = leptonSelection.coneptMuon(varied_mu)
+                varied_mu["isPres"] = leptonSelection.isPresMuon(varied_mu)
+                varied_mu["isLooseM"] = leptonSelection.isLooseMuon(varied_mu)
+                varied_mu["isFO"] = leptonSelection.isFOMuon(varied_mu, year)
+                varied_mu["isTightLep"]= leptonSelection.tightSelMuon(varied_mu)
+
+                m_loose_for_syst = varied_mu[varied_mu.isPres & varied_mu.isLooseM]
+                l_loose_for_syst = ak.with_name(ak.concatenate([e_loose, m_loose_for_syst], axis=1), 'PtEtaPhiMCandidate')
+                llpairs_for_syst = ak.combinations(l_loose_for_syst, 2, fields=["l0","l1"])
+                min_mll_afas_for_syst = ak.min( (llpairs_for_syst.l0+llpairs_for_syst.l1).mass, axis=-1)
+
+                m_fo_for_syst = varied_mu[varied_mu.isPres & varied_mu.isLooseM & varied_mu.isFO]
+                AttachMuonSF(m_fo_for_syst, year=year, useRun3MVA=self.useRun3MVA)
+                AttachPerLeptonFR(m_fo_for_syst, flavor = "Muon", year=year)
+                m_fo_for_syst['convVeto'] = ak.ones_like(m_fo_for_syst.charge)
+                m_fo_for_syst['lostHits'] = ak.zeros_like(m_fo_for_syst.charge)
+                l_fo_for_syst = ak.with_name(ak.concatenate([e_fo, m_fo_for_syst], axis=1), 'PtEtaPhiMCandidate')
+                l_fo_conept_sorted_for_syst = l_fo_for_syst[ak.argsort(l_fo_for_syst.conept, axis=-1,ascending=False)]
 
             #################### Jets ####################
 
             # Jet cleaning, before any jet selection
             #vetos_tocleanjets = ak.with_name( ak.concatenate([tau, l_fo], axis=1), "PtEtaPhiMCandidate")
             if self.tau_h_analysis:
-                vetos_tocleanjets = ak.with_name( ak.concatenate([cleaning_taus, l_fo], axis=1), "PtEtaPhiMCandidate")
+                vetos_tocleanjets = ak.with_name( ak.concatenate([cleaning_taus, l_fo_for_syst], axis=1), "PtEtaPhiMCandidate")
             else:
-                vetos_tocleanjets = ak.with_name( l_fo, "PtEtaPhiMCandidate")
+                vetos_tocleanjets = ak.with_name( l_fo_for_syst, "PtEtaPhiMCandidate")
             tmp = ak.cartesian([ak.local_index(jets.pt), vetos_tocleanjets.jetIdx], nested=True)
             cleanedJets = jets[~ak.any(tmp.slot0 == tmp.slot1, axis=-1)] # this line should go before *any selection*, otherwise lep.jetIdx is not aligned with the jet index
 
@@ -593,7 +630,8 @@ class AnalysisProcessor(processor.ProcessorABC):
 
             # Put njets and l_fo_conept_sorted into events
             events["njets"] = njets
-            events["l_fo_conept_sorted"] = l_fo_conept_sorted
+            events["minMllAFAS"] = min_mll_afas_for_syst
+            events["l_fo_conept_sorted"] = l_fo_conept_sorted_for_syst
 
             # The event selection
             te_es.add2lMaskAndSFs(events, year, isData, sampleType)
@@ -602,7 +640,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             te_es.addLepCatMasks(events)
 
             # Convenient to have l0, l1, l2 on hand
-            l_fo_conept_sorted_padded = ak.pad_none(l_fo_conept_sorted, 3)
+            l_fo_conept_sorted_padded = ak.pad_none(l_fo_conept_sorted_for_syst, 3)
             l0 = l_fo_conept_sorted_padded[:,0]
             l1 = l_fo_conept_sorted_padded[:,1]
             l2 = l_fo_conept_sorted_padded[:,2]
@@ -959,7 +997,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             # Calculate ptbl
             ptbl_bjet = goodJets[(isBtagJetsMedium | isBtagJetsLoose)]
             ptbl_bjet = ptbl_bjet[ak.argmax(ptbl_bjet.pt,axis=-1,keepdims=True)] # Only save hardest b-jet
-            ptbl_lep = l_fo_conept_sorted
+            ptbl_lep = l_fo_conept_sorted_for_syst
             ptbl = (ptbl_bjet.nearest(ptbl_lep) + ptbl_bjet).pt
             ptbl = ak.values_astype(ak.fill_none(ptbl, -1), np.float32)
 
@@ -972,7 +1010,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             # Leading (b+l) pair pt
             bjetsl = goodJets[isBtagJetsLoose][ak.argsort(goodJets[isBtagJetsLoose].pt, axis=-1, ascending=False)]
             bjetsm = goodJets[isBtagJetsMedium][ak.argsort(goodJets[isBtagJetsMedium].pt, axis=-1, ascending=False)]
-            bl_pairs = ak.cartesian({"b":bjetsl,"l":l_fo_conept_sorted})
+            bl_pairs = ak.cartesian({"b":bjetsl,"l":l_fo_conept_sorted_for_syst})
             blpt = (bl_pairs["b"] + bl_pairs["l"]).pt
             bl0pt = ak.flatten(blpt[ak.argmax(blpt,axis=-1,keepdims=True)])
 
@@ -985,9 +1023,9 @@ class AnalysisProcessor(processor.ProcessorABC):
 
             # Collection of all objects (leptons and jets)
             if self.tau_h_analysis:
-                l_j_collection = ak.with_name(ak.concatenate([l_fo_conept_sorted,goodJets,cleaning_taus], axis=1),"PtEtaPhiMCollection")
+                l_j_collection = ak.with_name(ak.concatenate([l_fo_conept_sorted_for_syst,goodJets,cleaning_taus], axis=1),"PtEtaPhiMCollection")
             else:
-                l_j_collection = ak.with_name(ak.concatenate([l_fo_conept_sorted,goodJets], axis=1),"PtEtaPhiMCollection")
+                l_j_collection = ak.with_name(ak.concatenate([l_fo_conept_sorted_for_syst,goodJets], axis=1),"PtEtaPhiMCollection")
 
             # Leading object (j or l) pt
             o0pt = ak.max(l_j_collection.pt,axis=-1)

--- a/analysis/topeft_run2/fullR3_run.sh
+++ b/analysis/topeft_run2/fullR3_run.sh
@@ -2,7 +2,7 @@
 
 # PrintUsage: display script usage information
 PrintUsage() {
-  echo "Usage: $0 [-y YEAR [YEAR ...]] [-t TAG] --cr | --sr [--hist-vars HIST [HIST ...]] [run_analysis options]"
+  echo "Usage: $0 [-y YEAR [YEAR ...]] [-t TAG] --cr | --sr [--hist-vars HIST [HIST ...]] [--sample-json JSON | --cfg-override CFG] [run_analysis options]"
   echo
   echo "Options:"
   echo "  -y YEAR    Year identifier (repeat or list multiple years)"
@@ -14,6 +14,10 @@ PrintUsage() {
   echo "  --defer-np Defer nonprompt post-processing (adds --np-postprocess=defer)"
   echo "  --hist-vars HIST [HIST ...]"
   echo "             Override the histogram list while preserving --cr/--sr region behavior"
+  echo "  --sample-json JSON"
+  echo "             Use one sample JSON instead of the default CFG bundle"
+  echo "  --cfg-override CFG"
+  echo "             Use one CFG file instead of the default CFG bundle"
   echo "  --dry-run  Print the resolved run_analysis.py command and exit"
   echo "  -h, --help Show this help message"
   echo
@@ -43,6 +47,8 @@ main() {
   local -a RESOLVED_YEARS=()
   local USER_CHUNK_OVERRIDE=false
   local TAG=""
+  local SAMPLE_JSON=""
+  local CFG_OVERRIDE=""
 
   # Parse command-line arguments
   while [[ $# -gt 0 ]]; do
@@ -103,6 +109,22 @@ main() {
       --dry-run)
         FLAG_DRY_RUN=true
         shift
+        ;;
+      --sample-json)
+        if [[ $# -lt 2 || "$2" == -* ]]; then
+          echo "Error: --sample-json requires a JSON path"
+          return 1
+        fi
+        SAMPLE_JSON="$2"
+        shift 2
+        ;;
+      --cfg-override)
+        if [[ $# -lt 2 || "$2" == -* ]]; then
+          echo "Error: --cfg-override requires a CFG path"
+          return 1
+        fi
+        CFG_OVERRIDE="$2"
+        shift 2
         ;;
       -h|--help)
         PrintUsage
@@ -165,6 +187,21 @@ main() {
 
   if [[ ${#RESOLVED_YEARS[@]} -eq 0 ]]; then
     echo "Error: No years resolved from the provided arguments." >&2
+    return 1
+  fi
+
+  if [[ -n "$SAMPLE_JSON" && -n "$CFG_OVERRIDE" ]]; then
+    echo "Error: use only one of --sample-json or --cfg-override." >&2
+    return 1
+  fi
+
+  if [[ -n "$SAMPLE_JSON" && ! -f "$SAMPLE_JSON" ]]; then
+    echo "Error: sample JSON not found: $SAMPLE_JSON" >&2
+    return 1
+  fi
+
+  if [[ -n "$CFG_OVERRIDE" && ! -f "$CFG_OVERRIDE" ]]; then
+    echo "Error: CFG override not found: $CFG_OVERRIDE" >&2
     return 1
   fi
 
@@ -231,45 +268,57 @@ main() {
     return 0
   }
 
-  local CFG YEAR_CFGS
-  for YEAR in "${RESOLVED_YEARS[@]}"; do
-    if [[ -n "${RUN2_YEAR_MAP[$YEAR]}" ]]; then
-      if [[ "$RUN2_BUNDLE_ADDED" == "false" ]]; then
-        if [[ "$FLAG_CR" == "true" ]]; then
-          for CFG in "${RUN2_CFGS_CR[@]}"; do
-            add_cfg "$CFG" || return 1
-          done
-        else
-          for CFG in "${RUN2_CFGS_SR[@]}"; do
-            add_cfg "$CFG" || return 1
-          done
+  local INPUT_OVERRIDE_LABEL=""
+  if [[ -n "$SAMPLE_JSON" ]]; then
+    CFGS_LIST=("$SAMPLE_JSON")
+    INPUT_OVERRIDE_LABEL="sample JSON: $SAMPLE_JSON"
+  elif [[ -n "$CFG_OVERRIDE" ]]; then
+    CFGS_LIST=("$CFG_OVERRIDE")
+    INPUT_OVERRIDE_LABEL="CFG: $CFG_OVERRIDE"
+  else
+    local CFG YEAR_CFGS
+    for YEAR in "${RESOLVED_YEARS[@]}"; do
+      if [[ -n "${RUN2_YEAR_MAP[$YEAR]}" ]]; then
+        if [[ "$RUN2_BUNDLE_ADDED" == "false" ]]; then
+          if [[ "$FLAG_CR" == "true" ]]; then
+            for CFG in "${RUN2_CFGS_CR[@]}"; do
+              add_cfg "$CFG" || return 1
+            done
+          else
+            for CFG in "${RUN2_CFGS_SR[@]}"; do
+              add_cfg "$CFG" || return 1
+            done
+          fi
+          RUN2_BUNDLE_ADDED=true
         fi
-        RUN2_BUNDLE_ADDED=true
-      fi
-    else
-      if [[ "$FLAG_CR" == "true" ]]; then
-        YEAR_CFGS=(
-          "${CFGS_PATH}/NDSkim_${YEAR}_background_samples_cr.cfg"
-          "${CFGS_PATH}/NDSkim_${YEAR}_data_samples.cfg"
-          "${CFGS_PATH}/NDSkim_${YEAR}_mc_signal_samples.cfg"
-        )
       else
-        YEAR_CFGS=(
-          #"${CFGS_PATH}/NDSkim_${YEAR}_signal_samples.cfg"
-          "${CFGS_PATH}/NDSkim_${YEAR}_background_samples.cfg"
-          "${CFGS_PATH}/NDSkim_${YEAR}_data_samples.cfg"
-          "${CFGS_PATH}/NDSkim_${YEAR}_mc_signal_samples_sr.cfg"
-        )
+        if [[ "$FLAG_CR" == "true" ]]; then
+          YEAR_CFGS=(
+            "${CFGS_PATH}/NDSkim_${YEAR}_background_samples_cr.cfg"
+            "${CFGS_PATH}/NDSkim_${YEAR}_data_samples.cfg"
+            "${CFGS_PATH}/NDSkim_${YEAR}_mc_signal_samples.cfg"
+          )
+        else
+          YEAR_CFGS=(
+            #"${CFGS_PATH}/NDSkim_${YEAR}_signal_samples.cfg"
+            "${CFGS_PATH}/NDSkim_${YEAR}_background_samples.cfg"
+            "${CFGS_PATH}/NDSkim_${YEAR}_data_samples.cfg"
+            "${CFGS_PATH}/NDSkim_${YEAR}_mc_signal_samples_sr.cfg"
+          )
+        fi
+        for CFG in "${YEAR_CFGS[@]}"; do
+          add_cfg "$CFG" || return 1
+        done
       fi
-      for CFG in "${YEAR_CFGS[@]}"; do
-        add_cfg "$CFG" || return 1
-      done
-    fi
-  done
+    done
+  fi
   local CFGS
   CFGS=$(IFS=,; echo "${CFGS_LIST[*]}")
 
   echo "Resolved years: ${RESOLVED_YEARS[*]}"
+  if [[ -n "$INPUT_OVERRIDE_LABEL" ]]; then
+    echo "Input override: $INPUT_OVERRIDE_LABEL"
+  fi
   echo "Resolved CFGS: $CFGS"
 
   local REGION_LABEL

--- a/analysis/topeft_run2/fullR3_run.sh
+++ b/analysis/topeft_run2/fullR3_run.sh
@@ -18,6 +18,8 @@ PrintUsage() {
   echo "             Use one sample JSON instead of the default CFG bundle"
   echo "  --cfg-override CFG"
   echo "             Use one CFG file instead of the default CFG bundle"
+  echo "  -p, --outpath PATH"
+  echo "             Override the run_analysis.py output directory"
   echo "  --dry-run  Print the resolved run_analysis.py command and exit"
   echo "  -h, --help Show this help message"
   echo
@@ -46,6 +48,10 @@ main() {
   local -a EXPANDED_YEARS=()
   local -a RESOLVED_YEARS=()
   local USER_CHUNK_OVERRIDE=false
+  local USER_OUTPATH_OVERRIDE=false
+  local USER_OUTPATH_OPTION_COUNT=0
+  local DEFAULT_OUTPATH="/groups/klannon/$USER/"
+  local RESOLVED_OUTPATH="$DEFAULT_OUTPATH"
   local TAG=""
   local SAMPLE_JSON=""
   local CFG_OVERRIDE=""
@@ -139,14 +145,43 @@ main() {
 
   # Detect if a user-specified chunk size was provided
   local ARG
-  for ARG in "${EXTRA_ARGS[@]}"; do
+  local EXTRA_INDEX
+  for ((EXTRA_INDEX=0; EXTRA_INDEX<${#EXTRA_ARGS[@]}; EXTRA_INDEX++)); do
+    ARG="${EXTRA_ARGS[$EXTRA_INDEX]}"
     case "$ARG" in
       -s|--chunksize|--chunksize=*)
         USER_CHUNK_OVERRIDE=true
-        break
+        ;;
+    esac
+
+    case "$ARG" in
+      -p|--outpath)
+        USER_OUTPATH_OPTION_COUNT=$((USER_OUTPATH_OPTION_COUNT + 1))
+        if (( EXTRA_INDEX + 1 >= ${#EXTRA_ARGS[@]} )) || [[ "${EXTRA_ARGS[$((EXTRA_INDEX + 1))]}" == -* ]]; then
+          echo "Error: $ARG requires an output path"
+          return 1
+        fi
+        RESOLVED_OUTPATH="${EXTRA_ARGS[$((EXTRA_INDEX + 1))]}"
+        ;;
+      --outpath=*)
+        USER_OUTPATH_OPTION_COUNT=$((USER_OUTPATH_OPTION_COUNT + 1))
+        RESOLVED_OUTPATH="${ARG#--outpath=}"
+        if [[ -z "$RESOLVED_OUTPATH" ]]; then
+          echo "Error: --outpath requires an output path"
+          return 1
+        fi
         ;;
     esac
   done
+
+  if (( USER_OUTPATH_OPTION_COUNT > 1 )); then
+    echo "Error: provide only one output path option (-p or --outpath)." >&2
+    return 1
+  fi
+
+  if (( USER_OUTPATH_OPTION_COUNT == 1 )); then
+    USER_OUTPATH_OVERRIDE=true
+  fi
 
   # Ensure exactly one mode is chosen
   if [[ "$FLAG_CR" == "false" && "$FLAG_SR" == "false" ]] || [[ "$FLAG_CR" == "true" && "$FLAG_SR" == "true" ]]; then
@@ -339,6 +374,7 @@ main() {
 
   echo "Resolved region: $REGION_LABEL"
   echo "Resolved histogram list: ${HIST_LIST_ARGS[*]:1}"
+  echo "Resolved output path: $RESOLVED_OUTPATH"
 
   # Define options based on mode
   local -a OPTIONS
@@ -350,20 +386,24 @@ main() {
     if [[ "$USER_CHUNK_OVERRIDE" == "false" ]]; then
       OPTIONS+=(-s 100000)
     fi
+    if [[ "$USER_OUTPATH_OVERRIDE" == "false" ]]; then
+      OPTIONS+=(-p "$RESOLVED_OUTPATH")
+    fi
     OPTIONS+=(
       #--split-lep-flavor
-      -p "/groups/klannon/$USER/"
       -o "$OUT_NAME"
       -x work_queue
     )
   else
     OPTIONS=(
-      -p "/groups/klannon/$USER/"
       "${HIST_LIST_ARGS[@]}"
       --skip-cr
       --do-systs
       --do-np
     )
+    if [[ "$USER_OUTPATH_OVERRIDE" == "false" ]]; then
+      OPTIONS+=(-p "$RESOLVED_OUTPATH")
+    fi
     if [[ "$USER_CHUNK_OVERRIDE" == "false" ]]; then
       OPTIONS+=(-s 100000)
     fi

--- a/analysis/topeft_run2/inspect_histeft_pkl.py
+++ b/analysis/topeft_run2/inspect_histeft_pkl.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Read-only summary tool for TOP EFT histogram pickle files."""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import pickle
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+try:
+    import numpy as np
+except Exception:  # pragma: no cover - numpy is expected in the analysis env.
+    np = None
+
+
+def _enable_pickle_compat() -> None:
+    try:
+        from topcoffea.modules.compat import ensure_histEFT_py39_compat
+    except Exception:
+        return
+    try:
+        ensure_histEFT_py39_compat()
+    except Exception:
+        return
+
+
+def _load_pickle(path: Path) -> Any:
+    opener = gzip.open if path.suffix == ".gz" else open
+    with opener(path, "rb") as handle:
+        return pickle.load(handle)
+
+
+def _is_mapping_like(obj: Any) -> bool:
+    if isinstance(obj, Mapping):
+        return True
+    return hasattr(obj, "items") and callable(getattr(obj, "items"))
+
+
+def _items(obj: Any):
+    if _is_mapping_like(obj):
+        return obj.items()
+    return ()
+
+
+def _is_hist_like(obj: Any) -> bool:
+    return hasattr(obj, "axes") and (
+        hasattr(obj, "values") or hasattr(obj, "view") or hasattr(obj, "eval")
+    )
+
+
+def _axis_name(axis: Any, index: int) -> str:
+    for attr in ("name", "label"):
+        try:
+            value = getattr(axis, attr)
+        except Exception:
+            value = None
+        if value not in (None, ""):
+            return str(value)
+    try:
+        metadata = getattr(axis, "metadata")
+    except Exception:
+        metadata = None
+    if isinstance(metadata, Mapping):
+        value = metadata.get("name") or metadata.get("label")
+        if value not in (None, ""):
+            return str(value)
+    return f"axis_{index}"
+
+
+def _axes(obj: Any) -> list[Any]:
+    try:
+        return list(obj.axes)
+    except Exception:
+        return []
+
+
+def _axis_names(obj: Any) -> list[str]:
+    return [_axis_name(axis, idx) for idx, axis in enumerate(_axes(obj))]
+
+
+def _axis_by_name(obj: Any, name: str) -> Any | None:
+    try:
+        return obj.axes[name]
+    except Exception:
+        pass
+    for idx, axis in enumerate(_axes(obj)):
+        if _axis_name(axis, idx) == name:
+            return axis
+    return None
+
+
+def _safe_len(obj: Any) -> int | None:
+    try:
+        return len(obj)
+    except Exception:
+        return None
+
+
+def _format_limited(values: list[str], max_labels: int) -> str:
+    if len(values) > max_labels:
+        shown = values[:max_labels]
+        return ", ".join(shown) + f", ... ({len(values)} total)"
+    return ", ".join(values)
+
+
+def _axis_labels(axis: Any, max_labels: int) -> tuple[list[str], int | None]:
+    labels: list[str] = []
+    total = _safe_len(axis)
+    try:
+        iterator = iter(axis)
+    except Exception:
+        return labels, total
+    for idx, value in enumerate(iterator):
+        if idx >= max_labels:
+            break
+        labels.append(str(value))
+    return labels, total
+
+
+def _axis_edges(axis: Any, max_labels: int) -> str | None:
+    if "Category" in type(axis).__name__:
+        return None
+    if np is None:
+        return None
+    try:
+        edges = np.asarray(axis.edges)
+    except Exception:
+        return None
+    if edges.ndim != 1 or edges.size == 0:
+        return None
+    shown = [f"{float(x):g}" for x in edges[: max_labels + 1]]
+    suffix = f", ... ({edges.size} edges)" if edges.size > max_labels + 1 else ""
+    return ", ".join(shown) + suffix
+
+
+def _wc_names(obj: Any) -> list[str]:
+    for attr in ("wc_names", "_wc_names"):
+        try:
+            value = getattr(obj, attr)
+        except Exception:
+            continue
+        if callable(value):
+            try:
+                value = value()
+            except Exception:
+                continue
+        if value is not None:
+            try:
+                return [str(x) for x in value]
+            except Exception:
+                return [str(value)]
+    return []
+
+
+def _maybe_nominal(obj: Any) -> Any:
+    axis = _axis_by_name(obj, "systematic")
+    if axis is None:
+        return obj
+    labels, _ = _axis_labels(axis, max_labels=100000)
+    if "nominal" not in labels:
+        return obj
+    for attempt in (
+        lambda: obj.integrate("systematic", "nominal"),
+        lambda: obj[{"systematic": "nominal"}],
+    ):
+        try:
+            return attempt()
+        except Exception:
+            pass
+    return obj
+
+
+def _values(obj: Any) -> Any:
+    obj = _maybe_nominal(obj)
+    if hasattr(obj, "eval"):
+        try:
+            return obj.eval({})
+        except Exception:
+            pass
+    for kwargs in ({"flow": True}, {"flow": False}, {}):
+        try:
+            return obj.values(**kwargs)
+        except Exception:
+            pass
+    return None
+
+
+def _variances(obj: Any) -> Any:
+    obj = _maybe_nominal(obj)
+    for kwargs in ({"flow": True}, {"flow": False}, {}):
+        try:
+            return obj.variances(**kwargs)
+        except Exception:
+            pass
+    return None
+
+
+def _array_sum(value: Any) -> float | None:
+    if np is None or value is None:
+        return None
+    try:
+        array = np.asarray(value, dtype=float)
+    except Exception:
+        return None
+    if array.size == 0:
+        return 0.0
+    try:
+        return float(np.nansum(array))
+    except Exception:
+        return None
+
+
+def _sum_payload(payload: Any) -> tuple[float | None, int]:
+    if payload is None:
+        return None, 0
+    if _is_mapping_like(payload):
+        total = 0.0
+        count = 0
+        for value in payload.values():
+            subtotal = _array_sum(value)
+            if subtotal is None:
+                continue
+            total += subtotal
+            count += 1
+        return (total if count else None), count
+    subtotal = _array_sum(payload)
+    return subtotal, 1 if subtotal is not None else 0
+
+
+def _print_axis_summary(obj: Any, max_labels: int) -> None:
+    axes = _axes(obj)
+    if not axes:
+        print("  axes: unavailable")
+        return
+    print(f"  axes ({len(axes)}):")
+    for idx, axis in enumerate(axes):
+        name = _axis_name(axis, idx)
+        axis_type = type(axis).__module__ + "." + type(axis).__name__
+        size = _safe_len(axis)
+        size_text = "unknown" if size is None else str(size)
+        print(f"    - {name}: {axis_type}, size={size_text}")
+        edges = _axis_edges(axis, max_labels=max_labels)
+        if edges is not None:
+            print(f"      edges: {edges}")
+            continue
+        labels, total = _axis_labels(axis, max_labels=max_labels)
+        if labels:
+            total_text = "unknown" if total is None else str(total)
+            print(f"      labels: {_format_limited(labels, max_labels)}")
+            print(f"      label_count: {total_text}")
+
+
+def _print_known_labels(obj: Any, max_labels: int) -> None:
+    for axis_name in ("process", "channel", "systematic", "appl"):
+        axis = _axis_by_name(obj, axis_name)
+        if axis is None:
+            continue
+        labels, total = _axis_labels(axis, max_labels=max_labels)
+        total_text = "unknown" if total is None else str(total)
+        if labels:
+            print(f"  {axis_name} labels: {_format_limited(labels, max_labels)}")
+            print(f"  {axis_name} label_count: {total_text}")
+        else:
+            print(f"  {axis_name} labels: unavailable")
+
+
+def _print_yield_summary(obj: Any) -> None:
+    values_total, value_entries = _sum_payload(_values(obj))
+    variances_total, variance_entries = _sum_payload(_variances(obj))
+    if values_total is None:
+        print("  total nominal yield: unavailable")
+    else:
+        print(
+            "  total nominal yield: "
+            f"{values_total:.12g} from {value_entries} value block(s)"
+        )
+    if variances_total is not None:
+        print(
+            "  total nominal variance: "
+            f"{variances_total:.12g} from {variance_entries} variance block(s)"
+        )
+
+
+def _hist_items(root: Any):
+    if _is_hist_like(root):
+        return [("<top-level>", root)]
+    if _is_mapping_like(root):
+        return [(str(key), value) for key, value in _items(root) if _is_hist_like(value)]
+    return []
+
+
+def summarize(args: argparse.Namespace) -> int:
+    path = Path(args.pkl_path)
+    if not path.exists():
+        print(f"ERROR: file does not exist: {path}", file=sys.stderr)
+        return 2
+
+    _enable_pickle_compat()
+    try:
+        root = _load_pickle(path)
+    except Exception as exc:
+        print(f"ERROR: failed to load {path}: {exc!r}", file=sys.stderr)
+        return 1
+
+    print(f"file: {path}")
+    print(f"top-level type: {type(root).__module__}.{type(root).__name__}")
+
+    if _is_mapping_like(root):
+        keys = [str(key) for key, _ in _items(root)]
+        print(f"top-level keys: {_format_limited(keys, args.max_labels)}")
+        print(f"top-level key_count: {len(keys)}")
+
+    hist_items = _hist_items(root)
+    if args.hist:
+        selected = [(name, obj) for name, obj in hist_items if name == args.hist]
+        if not selected:
+            print(f"ERROR: histogram key not found or not histogram-like: {args.hist}", file=sys.stderr)
+            return 2
+        hist_items = selected
+    else:
+        hist_items = hist_items[: args.max_hists]
+
+    print(f"histogram-like objects shown: {len(hist_items)}")
+    if not hist_items:
+        return 0
+
+    for name, obj in hist_items:
+        print("")
+        print(f"histogram: {name}")
+        print(f"  type: {type(obj).__module__}.{type(obj).__name__}")
+        dense_hists = getattr(obj, "_dense_hists", None)
+        if isinstance(dense_hists, Mapping):
+            print(f"  dense block count: {len(dense_hists)}")
+        wc_names = _wc_names(obj)
+        if wc_names:
+            print(f"  WC names: {_format_limited(wc_names, args.max_labels)}")
+            print(f"  WC count: {len(wc_names)}")
+        _print_axis_summary(obj, max_labels=args.max_labels)
+        _print_known_labels(obj, max_labels=args.max_labels)
+        if args.yield_summary:
+            _print_yield_summary(obj)
+
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Print a read-only summary of a TOP EFT histogram pkl or pkl.gz file. "
+            "The tool is intentionally introspective and does not modify the input."
+        )
+    )
+    parser.add_argument("pkl_path", help="Path to a .pkl or .pkl.gz file.")
+    parser.add_argument(
+        "--hist",
+        help="Inspect only one top-level histogram key. By default, the first histogram-like keys are shown.",
+    )
+    parser.add_argument(
+        "--max-labels",
+        type=int,
+        default=20,
+        help="Maximum labels or edges to print per axis/key list. Default: 20.",
+    )
+    parser.add_argument(
+        "--max-hists",
+        type=int,
+        default=5,
+        help="Maximum histogram-like objects to summarize when --hist is not given. Default: 5.",
+    )
+    parser.add_argument(
+        "--yield-summary",
+        action="store_true",
+        help="Also print a simple nominal total yield and variance when discoverable.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.max_labels < 1:
+        parser.error("--max-labels must be at least 1")
+    if args.max_hists < 1:
+        parser.error("--max-hists must be at least 1")
+    return summarize(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -1172,6 +1172,8 @@ if __name__ == "__main__":
         # If we don't specify this argument, it will be None, and the processor will fill all hists
         hist_lst = hist_list
 
+    print("Resolved histogram list: {}".format(", ".join(hist_lst)))
+
     ### Load samples from json
     samplesdict = {}
     sample_sources = {}

--- a/analysis/topeft_run2/run_cr.sh
+++ b/analysis/topeft_run2/run_cr.sh
@@ -12,24 +12,24 @@ chunk_size="100000"
 
 # Configurable first part of the pkl tag.
 # pkl_base_tag="CR_t1met_fwdpt70_fulleta"
-pkl_base_tag="CR_t1met_fwdpt40_noband_wjets"
+pkl_base_tag="CR_muonres"
 
 # This tag should match what run_analysis.py will actually produce for --hist-list cr.
 # With your current CR block:
 #   hist_lst = ["ptz"]
 #   + "ptz_wtau" when --tau-h-analysis or --all-analysis is enabled.
-vars=(met lt ptz ptz_wtau)
+vars=(invmass l0ptcorr l0eta) # ptz ptz_wtau)
 var_tag=$(IFS=-; echo "${vars[*]}")
 
-# years=(2022 2022EE 2023 2023BPix)
-years=(2018) # 2016APV 2016 2017 2018)
+years=(2023 2023BPix 2018)
+# years=(2018) # 2016APV 2016 2017 2018)
 
 # Each entry is one independent subset of categories.
 # The script will run all subsets for every year.
 category_sets=(
   # "2l_CR 2los_CRtt 3l_CR"
-  # "2los_CRZ 2l_CRflip"
-  "2los_1tau 1l_1tau_CRtt 1l_1tau_CRDY"
+  "2los_CRZ 2l_CRflip"
+  # "2los_1tau 1l_1tau_CRtt 1l_1tau_CRDY"
 )
 
 ###############################################################################
@@ -73,7 +73,7 @@ run_cr_block() {
   local year="$1"
   shift
 
-  assert_run2_year "${year}"
+  # assert_run2_year "${year}"
 
   local cats=("$@")
   local cat_tag
@@ -91,20 +91,21 @@ run_cr_block() {
 
   clean_env_cache
 
-  local cmd=(
-    ./fullR3_run.sh
-    -y "${year}"
-    -t "${pkl_tag}"
-    -s "${chunk_size}"
-    --cr
-    --do-systs
-    --do-np
-    -p "${output_dir}"
-    --category-groups "${cats[@]}"
-    --suppress-forward-eta-stochastic-jer
-    --tau-h-analysis
-    --fwd-eta-band-pt-apply off # only for Run 2, not for Run 3, to avoid confusion with the "fwdfix" tag which implies the band is fixed to pt > 70 GeV
-  )
+local cmd=(
+  ./fullR3_run.sh
+  -y "${year}"
+  -t "${pkl_tag}"
+  -s "${chunk_size}"
+  --cr
+  --hist-vars "${vars[@]}"
+  --do-systs
+  # --do-np
+  -p "${output_dir}"
+  --category-groups "${cats[@]}"
+  --suppress-forward-eta-stochastic-jer
+  --tau-h-analysis
+  --split-lep-flavor
+)
 
   echo "Executing:"
   printf ' %q' "${cmd[@]}"

--- a/analysis/topeft_run2/run_cr.sh
+++ b/analysis/topeft_run2/run_cr.sh
@@ -22,15 +22,14 @@ vars=(met lt ptz ptz_wtau)
 var_tag=$(IFS=-; echo "${vars[*]}")
 
 # years=(2022 2022EE 2023 2023BPix)
-years=(2016APV 2016 2017 2018)
+years=(2018) # 2016APV 2016 2017 2018)
 
 # Each entry is one independent subset of categories.
 # The script will run all subsets for every year.
 category_sets=(
   # "2l_CR 2los_CRtt 3l_CR"
   # "2los_CRZ 2l_CRflip"
-  # "2los_1tau 1l_1tau_CRtt"
-  "1l_1tau_CRDY"
+  "2los_1tau 1l_1tau_CRtt 1l_1tau_CRDY"
 )
 
 ###############################################################################

--- a/docs/histeft_api_contract.md
+++ b/docs/histeft_api_contract.md
@@ -1,0 +1,876 @@
+# HistEFT API contract and replacement parity specification
+
+## 1. Purpose and scope
+
+This document is the CL007AD compatibility contract for the current
+`HistEFT`/`SparseHist` implementation and for the way `topeft` actually uses it.
+It is intended to gate any future EFT-aware histogram replacement, including a
+possible `scikit-hist` backend.
+
+This is not an implementation plan for the replacement. It does not change
+physics behavior, `HistEFT`, `SparseHist`, processors, plotting, datacard logic,
+runner scripts, sample JSON/CFG files, payloads, or production outputs. It
+extracts the existing contract from source inspection and small current-behavior
+tests.
+
+The central distinction is:
+
+- `Implemented`: behavior present in `topcoffea.modules.histEFT.HistEFT` or
+  inherited from `topcoffea.modules.sparseHist.SparseHist`.
+- `Used by topeft`: behavior directly or practically used by processors,
+  plotting, datacards/yields, pkl helpers, or existing tests.
+- `Replacement priority`: whether a future backend must reproduce the behavior
+  immediately, only for old pkl compatibility, only if a consumer is not
+  migrated, or can defer it.
+
+## 2. Source map
+
+Implementation sources inspected read-only:
+
+| Source | Role |
+| --- | --- |
+| `../topcoffea/topcoffea/modules/histEFT.py:23-388` | `HistEFT` class, WC metadata, fill, evaluation, pickle reduce, scaling |
+| `../topcoffea/topcoffea/modules/sparseHist.py:15-529` | sparse categorical storage, slicing, grouping, views, arithmetic, pickle reduce |
+| `../topcoffea/topcoffea/modules/eft_helper.py:10-266` | quadratic-term counts, EFT evaluation, quartic sumw2 helpers, coefficient remapping |
+| `../topcoffea/topcoffea/modules/compat.py:13-51` | import compatibility helpers for old HistEFT pickles and hist utilities |
+| `../topcoffea/topcoffea/modules/utils.py:399-477` | gzip/cloudpickle pkl writing and materialized pkl loading wrapper |
+| `../topcoffea/topcoffea/modules/hist_utils.py:36-293` | streaming/lazy pkl reading, empty-hist filtering |
+
+`topeft` usage sources inspected:
+
+| Source | Role |
+| --- | --- |
+| `analysis/topeft_run2/analysis_processor.py:233-343,620-631,1896-1924` | main processor histogram declaration, EFT coefficient remapping, HistEFT/SparseHist fills |
+| `analysis/topeft_run2/analysis_processor_diboson.py:72-110,297-304,1291-1334` | diboson processor HistEFT declaration and fills |
+| `analysis/topeft_run2/run_analysis.py:1539-1595,1760-1784` | WC-list aggregation, processor construction, gzip/cloudpickle pkl writing, pkl postprocess load/write |
+| `analysis/topeft_run2/make_cr_and_sr_plots.py:49-110,732-807,1263-1321,5810-5832,6231-6277,6461-6531,6742-6785,7802-7816` | pkl load compatibility, axis labels, filtering, grouping, SM eval, SparseHist 2D views |
+| `topeft/modules/datacard_tools.py:39-172,175-302,788-854,947-1130,1176-1210,1335-1553` | pkl merge validation, axis/WC checks, grouping/pruning, scaling extraction, datacard decomposition |
+| `topeft/modules/yield_tools.py:306-345,430-482,505-582,816-827` | axis labels, channel-label restoration, integration, yield evaluation, values printing |
+| `analysis/topeft_run2/inspect_histeft_pkl.py:20-345` | read-only pkl inspection, axis/WC discovery, nominal eval/value/variance summaries |
+| `topeft/modules/axes.py:1-260` | dense axis definitions used by processors |
+| `tests/test_group_bins.py:20-80`, `tests/test_make_cards_multi_pkl.py:11-104`, `tests/test_data_driven_streaming.py:17-99` | existing lightweight HistEFT/SparseHist usage in tests |
+
+Prior documentation context:
+
+- `docs/histeft_pkl_tutorial.md:992-1365` documents student-facing API notes and
+  a broad future replacement mapping. This CL007AD document turns that material
+  into an explicit implemented-versus-used matrix and parity-test gate.
+
+## 3. Implementation inventory
+
+### HistEFT inventory
+
+`HistEFT` is defined as `class HistEFT(SparseHist, family=_family)` in
+`../topcoffea/topcoffea/modules/histEFT.py:23`.
+
+Constructor and core attributes:
+
+- `HistEFT.__init__(*args, wc_names=None, **kwargs)`, source
+  `histEFT.py:74-126`.
+- Supports only `storage="Double"` and rejects `rebin=True`.
+- Requires named axes.
+- Requires one user dense axis, last among user axes, of type
+  `Regular`, `Variable`, or `Integer`.
+- Creates or accepts a dense internal `quadratic_term` axis.
+- Rejects reserved axis names `quadratic_term`, `sample`, `weight`, and
+  `thread`.
+- Stores `_wc_names`, `_wc_count`, `_quad_count`, `_coeff_axis`,
+  `_dense_axis`, and `_init_args_eft`.
+- Delegates to `SparseHist.__init__` with user axes plus the hidden coefficient
+  axis.
+
+Public or practically public `HistEFT` methods and properties:
+
+| Method/property | Source | Contract summary |
+| --- | --- | --- |
+| `empty_from_axes(*args, **kwargs)` | `histEFT.py:128-131` | Preserve `wc_names` when reconstructing empty HistEFT objects |
+| `wc_names` | `histEFT.py:133-135` | Return WC names in evaluation order |
+| `index_of_wc(wc)` | `histEFT.py:137-138` | Return WC index, raising `KeyError` for unknown names |
+| `quadratic_term_index(*wcs)` | `histEFT.py:140-163` | Map two factors, including `"sm"`, to lower-triangle coefficient index |
+| `should_rebin()` | `histEFT.py:165-166` | Current HistEFT always reports false |
+| `dense_axis` | `histEFT.py:169-170` | Return the user physics dense axis, not `quadratic_term` |
+| `fill(eft_coeff=None, **values)` | `histEFT.py:197-249` | Fill weighted EFT coefficients into hidden coefficient axis |
+| `eval(values)` | `histEFT.py:271-284` | Evaluate populated sparse blocks at a WC point |
+| `as_hist(values)` | `histEFT.py:286-305` | Evaluate and materialize a regular `hist.Hist` without the coefficient axis |
+| `__reduce__()` | `histEFT.py:307-319` | Pickle categorical axes, dense axis, init args, WC args, and `_dense_hists` |
+| `make_scaling(flow="show", wc_list=None)` | `histEFT.py:321-353` | Produce EFT scaling coefficients, optionally remapped and flow-handled |
+| `_read_from_reduce(...)` | `histEFT.py:355-356` | Delegate pickle reconstruction to `SparseHist` |
+| `calc_eft_weights(q_coeffs, wc_values)` | `histEFT.py:361-388` | Implement local coefficient evaluation over coefficient-axis flow layout |
+
+Private helpers that affect public behavior:
+
+| Helper | Source | Behavioral impact |
+| --- | --- | --- |
+| `_fill_flatten(a, n_events)` | `histEFT.py:172-188` | Accept scalar-like, 1D, or `(n_events, 1)` arrays and repeat by `_quad_count`; raise on incompatible shape |
+| `_fill_indices(n_events)` | `histEFT.py:190-195` | Repeat coefficient-term indices for each event |
+| `_wc_for_eval(values)` | `histEFT.py:251-269` | Normalize `None`, mapping, or array-like WC inputs; missing WCs default to zero; unknown mapping keys raise `LookupError` |
+
+### SparseHist inventory
+
+`SparseHist` is defined as `class SparseHist(hist.Hist, family=hist)` in
+`../topcoffea/topcoffea/modules/sparseHist.py:15`.
+
+Constructor and storage:
+
+- `SparseHist.__init__(*args, **kwargs)`, source `sparseHist.py:18-39`.
+- Splits axes into categorical and dense groups.
+- Stores `_categorical_axes`, `_dense_axes`, `_dense_hists`, `_init_args`, and
+  a namedtuple type `_tuple_t`.
+- Calls `hist.Hist.__init__` on categorical axes only.
+- Exposes `self.axes` as categorical axes plus dense axes.
+
+Public or practically public inherited methods:
+
+| Method/property | Source | Contract summary |
+| --- | --- | --- |
+| `empty_from_axes` | `sparseHist.py:60-70` | Construct empty object preserving dense/categorical axis split |
+| `make_dense` | `sparseHist.py:72-73` | Construct dense `hist.Hist` block |
+| `__copy__`, `__deepcopy__` | `sparseHist.py:75-83` | Copy sparse histogram with deep-copied dense blocks |
+| `categories_to_index`, `index_to_categories` | `sparseHist.py:103-109` | Convert between category labels and namedtuple sparse keys |
+| `categorical_axes`, `dense_axes`, `categorical_keys` | `sparseHist.py:112-122` | Expose axis metadata and populated sparse keys |
+| `fill(**kwargs)` | `sparseHist.py:124-139` | Create dense block per categorical key and fill dense values |
+| `__getitem__`, `__setitem__` | `sparseHist.py:273-325` | Mapping/tuple selection and assignment; can return sparse hist, dense hist, or scalar |
+| `values(flow=False)` | `sparseHist.py:327-350` | Return values over populated sparse blocks as awkward arrays |
+| `counts(flow=False)` | `sparseHist.py:352-353` | Return counts over populated sparse blocks |
+| `reset()`, `empty()` | `sparseHist.py:359-443` | Reset dense blocks; test whether all dense values are zero |
+| `view(flow=False, as_dict=True)` | `sparseHist.py:362-371` | Return mapping from sparse key to dense view; `as_dict=False` raises |
+| `integrate(name, value=None)` | `sparseHist.py:373-376` | Slice by axis; `value=None` maps to `sum` |
+| `group(axis_name, groups)` | `sparseHist.py:378-406` | Merge categorical labels into group labels |
+| `remove(axis_name, bins)`, `prune(axis, to_keep)` | `sparseHist.py:408-433` | Remove or keep categorical labels |
+| `scale(factor)` | `sparseHist.py:435-437` | Mutate in place through `self *= factor`, return self |
+| arithmetic and merge operators | `sparseHist.py:445-522` | Scalar and SparseHist binary ops, including `+=`, `+`, `*=`, `*`, `/` |
+| `__reduce__`, `_read_from_reduce` | `sparseHist.py:466-483` | Pickle reconstruction from axes, init args, and dense hist blocks |
+| `identity()` | `sparseHist.py:524-529` | Deprecated old-coffea accumulator compatibility: empty copy |
+
+Not implemented directly in `SparseHist`/`HistEFT` but observed or mentioned in
+`topeft`:
+
+- `replace_axis(...)` is called by `yield_tools.restore_split_channel_labels` at
+  `topeft/modules/yield_tools.py:430-463`; this appears to rely on inherited
+  `hist.Hist` behavior or a path that needs runtime validation with SparseHist.
+- `rebin(...)` is called by `datacard_tools.read` when `h.should_rebin()` is true
+  at `topeft/modules/datacard_tools.py:832-834`, but `HistEFT.should_rebin()`
+  returns false and `HistEFT.__init__` rejects `rebin=True`.
+- `variances(...)` is probed by `inspect_histeft_pkl.py:192-199`; HistEFT does
+  not define it, and current workflow uses `_sumw2` companions.
+- `.sum(...)`, `.project(...)`, and old-coffea `.identifiers()` appear in older
+  or non-primary scripts, not in the current processor/plotter/datacard path
+  inspected for this contract.
+
+## 4. Implemented versus used feature matrix
+
+This is the required implemented-versus-used feature matrix. `Used by topeft`
+means source inspection found a direct or practical consumer in the current
+`topeft` codebase. `Implemented, apparently unused` means the feature exists in
+`HistEFT`/`SparseHist` but no current inspected topeft call site was found.
+
+| Feature / method | Implemented where | Used by processor? | Used by plotter? | Used by datacards/yields? | Used by pkl helper? | Replacement priority | Evidence | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `HistEFT.__init__` | `histEFT.py:74-126` | Yes | Indirect | Indirect | Indirect | Required immediately | `analysis_processor.py:268-292`; `analysis_processor_diboson.py:93-110` | Constructor shape is the processor-facing creation API. |
+| `HistEFT.fill(eft_coeff=...)` | `histEFT.py:197-249` | Yes | No | No | No | Required immediately | `analysis_processor.py:1900-1924`; `analysis_processor_diboson.py:1297-1334` | Must preserve weight times coefficient storage and scalar categorical labels. |
+| `HistEFT.fill(eft_coeff=None)` | `histEFT.py:214-224` | Yes | No | No | No | Required immediately | Non-EFT samples can produce `eft_coeffs_cut=None` before fill at `analysis_processor.py:1909-1911` | Needed for non-EFT samples stored in HistEFT 1D hists. |
+| `HistEFT.eval(values)` | `histEFT.py:271-284` | No | Yes | Yes | Yes | Required immediately | `make_cr_and_sr_plots.py:6231-6277`; `datacard_tools.py:1494-1553`; `yield_tools.py:548-582`; `inspect_histeft_pkl.py:177-189` | This is the primary evaluated-yield API. |
+| `HistEFT.as_hist(values)` | `histEFT.py:286-305` | No | Yes | Existing tests | No | Required if plotting is not migrated | `make_cr_and_sr_plots.py:6742-6785`; `tests/test_group_bins.py:42-80` | Plotter expects evaluated regular histograms for plotting arrays/edges. |
+| `HistEFT.wc_names` | `histEFT.py:133-135` | No | Indirect | Yes | Yes | Required immediately | `datacard_tools.py:94-165,1062-1130,1335-1341`; `inspect_histeft_pkl.py:140-156` | WC order is metadata, validation, and datacard behavior. |
+| `HistEFT.dense_axis` | `histEFT.py:169-170` | No | No | Yes | No | Required if datacards/yields are not migrated | `datacard_tools.py:1176-1185` | Datacards use dense-axis extent after channel selection. |
+| `HistEFT.make_scaling` | `histEFT.py:321-353` | No | No | Yes | No | Required if datacards/yields are not migrated | `datacard_tools.py:1335-1341` | Used for EFT scaling output. |
+| `HistEFT.should_rebin` | `histEFT.py:165-166` | No | No | Yes | No | Required if datacards/yields are not migrated | `datacard_tools.py:832-834` | Currently always false; datacard rebin branch is effectively disabled for HistEFT. |
+| `HistEFT.__reduce__` / `_read_from_reduce` | `histEFT.py:307-356` | Indirect | Yes | Yes | Yes | Required for old-pkl compatibility | `run_analysis.py:1760-1765`; `make_cr_and_sr_plots.py:49-110`; `utils.py:399-477` | Required to load existing HistEFT pkls without conversion. |
+| `HistEFT.quadratic_term_index` | `histEFT.py:140-163` | No | No | No direct call | No | Nice to have | Source only; tests in `tests/test_histeft_api_contract.py` | Public helper, useful for coefficient inspection; no topeft runtime call found. |
+| `HistEFT.index_of_wc` | `histEFT.py:137-138` | No | No | No | No | Probably unused | Source only | Implemented, apparently unused by topeft except through `quadratic_term_index`. |
+| `HistEFT.calc_eft_weights` instance method | `histEFT.py:361-388` | No | No | No | No | Probably unused | `HistEFT.eval` calls `efth.calc_eft_weights` at `histEFT.py:281` | Implemented, apparently unused by topeft. |
+| `SparseHist.__init__` | `sparseHist.py:18-39` | Yes for 2D | Yes | Indirect | Indirect | Required immediately for 2D SparseHist outputs | `analysis_processor.py:293-342`; `make_cr_and_sr_plots.py:6461-6531` | Required if 2D histograms stay in current format. |
+| `SparseHist.fill` | `sparseHist.py:124-139` | Yes for 2D; inherited by HistEFT | No | No | No | Required immediately | `analysis_processor.py:1900-1924` via `HistEFT.fill`; `analysis_processor.py:293-342` for 2D | Fill bookkeeping creates dense blocks per sparse category. |
+| `.axes` metadata | `SparseHist.__init__` sets at `sparseHist.py:38` | Indirect | Yes | Yes | Yes | Required immediately | `make_cr_and_sr_plots.py:732-807`; `datacard_tools.py:39-172`; `yield_tools.py:306-345`; `inspect_histeft_pkl.py:234-268` | Labels and bin edges are consumer-visible. |
+| `categorical_axes`, `dense_axes`, `categorical_keys` | `sparseHist.py:112-122` | No | Yes | Yes | No | Required if plotting/datacards are not migrated | `make_cr_and_sr_plots.py:6461-6531`; `datacard_tools.py:39-172,976-1060` | Datacards use populated keys directly. |
+| `values(flow=...)` | `sparseHist.py:327-350` | No | Yes | Yes | Yes | Required if consumers not migrated | `make_cr_and_sr_plots.py:6231-6531`; `yield_tools.py:816-827`; `inspect_histeft_pkl.py:177-189` | For HistEFT raw values are coefficient arrays, not evaluated yields. |
+| `view(flow=..., as_dict=True)` | `sparseHist.py:362-371` | No | Yes | Yes | No | Required immediately | `HistEFT.eval` uses it at `histEFT.py:280`; `make_cr_and_sr_plots.py:1263-1294,6522-6531`; `datacard_tools.py:1062-1130` | Raw coefficient-axis view is datacard-visible for selected-WC discovery. |
+| `integrate(name, value)` | `sparseHist.py:373-376` | No | Yes | Yes | Yes | Required immediately | `make_cr_and_sr_plots.py:1310-1321`; `datacard_tools.py:1062-1210`; `yield_tools.py:505-582`; `inspect_histeft_pkl.py:159-174` | Central category selection API. |
+| `__getitem__` with mapping and `sum` sentinel | `sparseHist.py:299-325` | No | Yes | Yes | No | Required immediately | `make_cr_and_sr_plots.py:6742-6785`; `datacard_tools.py:1062-1130` | Current code uses `h[{"process": sum}]` and similar category summing. |
+| `group(axis_name, groups)` | `sparseHist.py:378-406` | No | Yes | Yes | No | Required if plotting/datacards are not migrated | `make_cr_and_sr_plots.py:5810-5832`; `datacard_tools.py:947-973` | Process grouping depends on this exact role. |
+| `remove(axis_name, bins)` | `sparseHist.py:408-428` | No | Yes | Yes | No | Required if plotting/datacards are not migrated | `make_cr_and_sr_plots.py:786-807`; `datacard_tools.py:788-854` | Used to drop data/MC/signal groups and nuisances. |
+| `prune(axis, to_keep)` | `sparseHist.py:430-433` | No | No direct primary plotter call | Yes | No | Required if datacards/yields are not migrated | `datacard_tools.py:788-854,1062-1130` | Note one `yield_tools` path may ignore returned value. |
+| `scale(factor)` | `sparseHist.py:435-437` | No | Yes | No | No | Required if plotting is not migrated | `make_cr_and_sr_plots.py:3522-3544` | Used for unit-normalized plots. |
+| `empty()` | `sparseHist.py:439-443` | No | Yes | Yes | Indirect | Required if consumers not migrated | `make_cr_and_sr_plots.py:1263-1294`; `datacard_tools.py:788-854`; `hist_utils.py:204-211` | Empty filtering and plotting guards use it. |
+| `copy`, `__copy__`, `__deepcopy__` | `sparseHist.py:75-83` | No | Indirect | Yes | No | Required if datacards/yields are not migrated | `yield_tools.py:475-482`; binary ops use copy at `sparseHist.py:461-464` | Needed by utility transformations and non-mutating arithmetic. |
+| `__iadd__`, `__add__` | `sparseHist.py:485-493` | Indirect via coffea accumulation | Yes via merge | Yes | Yes | Required immediately | `datacard_tools.py:175-302`; `corrections.py:1695`; `corrections_240414.py:1389` | Pkl merge/add behavior is a core compatibility gate. |
+| `__imul__`, `__mul__`, scalar arithmetic | `sparseHist.py:501-514` | No | Yes through `scale` | No | No | Required if plotting is not migrated | `scale` delegates to `self *= factor` at `sparseHist.py:435-437` | Other scalar ops are implemented but no direct runtime call was found. |
+| `counts`, `reset`, `identity` | `sparseHist.py:352-359,524-529` | No | No | No | Indirect only | Probably unused | No primary topeft call found | Implemented, apparently unused by topeft except internal/legacy accumulator behavior. |
+| `replace_axis` | Inherited/unknown | No | No | Yes | No | Unknown | `yield_tools.py:430-463` | Needs runtime validation if channel-label restoration remains in scope. |
+| `rebin` | Not implemented by HistEFT current path | No | Legacy scripts | Guarded datacard branch | No | Unknown / can defer for current HistEFT | `datacard_tools.py:832-834`; `histEFT.py:89-91,165-166` | Constructor rejects rebin. Do not promise replacement rebin without consumer migration. |
+| `variances` | Not implemented by HistEFT | No | Dense regular hist paths | No | Probed | Can defer for HistEFT replacement if `_sumw2` preserved | `inspect_histeft_pkl.py:192-199`; `_sumw2` fills at `analysis_processor.py:1913-1924` | Current HistEFT uncertainty convention is top-level `_sumw2`, not `variances`. |
+| `.sum`, `.project`, `.identifiers` | Not implemented by SparseHist | No current primary processor | Older/non-primary scripts | No | No | Probably unused for current replacement | Search found older validation/training scripts, not current primary flow | Can defer unless those legacy workflows are explicitly supported. |
+
+The replacement does not need to reproduce every implemented method if the
+method is not used by topeft and old-pkl compatibility is not required. It does
+need to reproduce any feature above marked `Required immediately` before it can
+replace current runtime output.
+
+## 5. HistEFT public API contract
+
+### `HistEFT.__init__(*args, wc_names=None, **kwargs)`
+
+Source: `../topcoffea/topcoffea/modules/histEFT.py:74-126`.
+
+- Purpose: create an EFT-aware sparse histogram with one user dense axis and one
+  internal dense `quadratic_term` axis.
+- Arguments: named categorical axes followed by one physics dense axis;
+  `wc_names` list without SM; optional `storage`, `label`, and other `hist.Hist`
+  args that survive through `SparseHist`.
+- Returns: new `HistEFT`.
+- Side effects: constructs WC metadata, coefficient axis, dense-axis metadata,
+  and sparse storage dictionary.
+- Mutation: constructor only.
+- Hidden-axis dependency: yes, creates or accepts `quadratic_term`.
+- WC metadata dependency: yes, computes `_quad_count` from WC count.
+- Used by topeft: yes, processors instantiate it directly.
+- Replacement exactness: Required immediately for processor compatibility.
+
+### `HistEFT.fill(eft_coeff=None, **values)`
+
+Source: `histEFT.py:197-249`.
+
+- Purpose: fill one sparse category and one dense value array with EFT
+  coefficient arrays.
+- Arguments: scalar categorical values, dense variable keyword, optional
+  `weight`, optional `eft_coeff` shaped `(n_events, n_quad_terms)`.
+- Return value: implementation does not return `self` despite annotation.
+- Side effects: mutates `_dense_hists` by creating/filling the matching sparse
+  category block.
+- Mutation: mutates self.
+- Hidden-axis dependency: yes, repeats dense values by `_quad_count` and fills
+  `quadratic_term` indices.
+- WC metadata dependency: yes, validates coefficient length against `_quad_count`
+  indirectly through array shape and dense fill.
+- Used by topeft: yes, processor and diboson processor fill all 1D histograms.
+- Replacement exactness: Required immediately.
+
+Current fill semantics:
+
+1. Determine `n_events` from the user dense axis value.
+2. If `eft_coeff is None`, create SM-only coefficients `[1, 0, ..., 0]` per
+   event.
+3. Repeat dense values once per quadratic term.
+4. Repeat coefficient-term indices once per event.
+5. Pop `weight`; if present, repeat weights and multiply them into flattened
+   EFT coefficients.
+6. Delegate to `SparseHist.fill` with `quadratic_term=<indices>` and
+   `weight=<weighted coefficients>`.
+
+### `HistEFT.eval(values)`
+
+Source: `histEFT.py:271-284`.
+
+- Purpose: evaluate raw stored coefficient arrays at a WC point.
+- Arguments: `None`, mapping from WC names to numeric values, or array-like
+  values in `wc_names` order.
+- Return value: dictionary from sparse categorical key to NumPy array over the
+  user dense axis, including flow bins.
+- Side effects: none expected.
+- Mutation: should not mutate source histogram.
+- Hidden-axis dependency: yes, calls `view(flow=True, as_dict=True)` and removes
+  coefficient-axis flow slots with `[..., 1:-1]`.
+- WC metadata dependency: yes, mapping keys are checked against `wc_names`.
+- Used by topeft: yes, plotter, datacards, yields, and pkl helper.
+- Replacement exactness: Required immediately.
+
+Mapping behavior:
+
+- `eval({})` and `eval(None)` evaluate the SM point.
+- Missing WC names are set to zero.
+- Unknown WC names raise `LookupError`.
+- Array-like input is accepted as-is and interpreted in `wc_names` order; length
+  checks are not explicit in `_wc_for_eval`.
+
+### `HistEFT.as_hist(values)`
+
+Source: `histEFT.py:286-305`.
+
+- Purpose: evaluate at a WC point and materialize a regular `hist.Hist` with
+  categorical axes plus the user dense axis.
+- Return value: regular `hist.Hist`, filled by sparse key.
+- Side effects: none expected on source.
+- Mutation: returns a new object.
+- Hidden-axis dependency: removes hidden coefficient axis from materialized
+  output.
+- WC metadata dependency: uses `eval`.
+- Used by topeft: yes, plotter and existing tests.
+- Replacement exactness: Required if plotting is not migrated.
+
+### `HistEFT.make_scaling(flow="show", wc_list=None)`
+
+Source: `histEFT.py:321-353`.
+
+- Purpose: expose EFT scaling coefficients for datacard-style output.
+- Arguments: flow policy `"show"` or `"sum"`; optional target `wc_list`.
+- Return value: raw coefficient array transformed to scaling coefficients.
+- Side effects: none expected.
+- Mutation: returns arrays, not self.
+- Hidden-axis dependency: reads raw coefficient axis through `values(flow=True)`
+  and removes coefficient flow columns.
+- WC metadata dependency: optional remapping through `efth.remap_coeffs`.
+- Used by topeft: yes, datacard code.
+- Replacement exactness: Required if datacards/yields are not migrated.
+
+### `HistEFT.__reduce__()` and `_read_from_reduce`
+
+Sources: `histEFT.py:307-319`, `histEFT.py:355-356`,
+`sparseHist.py:477-483`.
+
+- Purpose: pickle/unpickle HistEFT objects.
+- Return value: reduce tuple with reconstruction function, categorical axes,
+  dense axis, init args, WC args, and `_dense_hists`.
+- Side effects: none during reduce; reconstructing unpickle populates dense
+  hist dictionary.
+- Hidden-axis dependency: hidden axis is recreated from WC metadata unless an
+  explicit `quadratic_term` axis was pickled in the constructor args.
+- WC metadata dependency: `wc_names` must survive.
+- Used by topeft: yes through pkl writing/loading.
+- Replacement exactness: Required for old-pkl compatibility. For new runs only,
+  an explicit converter or new serialization contract could replace it.
+
+### WC helpers and current usage
+
+- `wc_names` is Required immediately because merge validation, datacards, and pkl
+  inspection use it.
+- `quadratic_term_index` is a public coefficient-order helper, but no current
+  primary topeft runtime call was found. It is Nice to have and useful for parity
+  tests.
+- `index_of_wc` is Implemented, apparently unused by topeft except internally by
+  `quadratic_term_index`.
+- `calc_eft_weights` as an instance method is Implemented, apparently unused by
+  topeft; `HistEFT.eval` uses `eft_helper.calc_eft_weights`.
+
+## 6. SparseHist inherited behavior contract
+
+A replacement for HistEFT must either inherit/reproduce these `SparseHist`
+behaviors or migrate every consumer that relies on them:
+
+| Behavior | Required behavior | Mutation/return | Evidence |
+| --- | --- | --- | --- |
+| sparse categorical storage | Only populated category tuples need dense blocks | Mutates on fill | `sparseHist.py:124-139`; processors fill scalar `process/channel/systematic/appl` |
+| `.axes` | Ordered categorical axes plus dense axes, name-addressable | Metadata | `sparseHist.py:38`; consumers in plotter/datacards/yields/pkl helper |
+| `view(flow=True, as_dict=True)` | Dict keyed by sparse category namedtuple with dense raw views | Non-mutating | `HistEFT.eval`; `datacard_tools.py:1062-1130`; `make_cr_and_sr_plots.py:6522-6531` |
+| `values(flow=...)` | Return block values over populated sparse keys | Non-mutating | `make_cr_and_sr_plots.py:6231-6531`; `inspect_histeft_pkl.py:177-189` |
+| `integrate` and mapping `__getitem__` | Select labels, lists, slices, and `sum` sentinel by axis | Return selected object | `datacard_tools.py:1062-1210`; `make_cr_and_sr_plots.py:1310-1321` |
+| `group` | Merge categorical labels into new group labels | Return new hist | `make_cr_and_sr_plots.py:5810-5832`; `datacard_tools.py:947-973` |
+| `remove` / `prune` | Drop or keep categorical labels | Return new hist | `make_cr_and_sr_plots.py:786-807`; `datacard_tools.py:788-854` |
+| `scale` | Scalar in-place multiplication, return self | Mutates self | `make_cr_and_sr_plots.py:3522-3544` |
+| `copy`, `+`, `+=` | Compatible non-mutating and in-place merging | Both forms | `datacard_tools.py:175-302`; `sparseHist.py:461-493` |
+| `empty` | All dense views zero means empty | Non-mutating | `hist_utils.py:204-211`; plotter/datacard guards |
+| pickle reduce | Reconstruct axes/init args/dense blocks | Serialization | `sparseHist.py:466-483`; plotter fast-patch at `make_cr_and_sr_plots.py:49-110` |
+
+Unknown inherited behavior:
+
+- `replace_axis` is used in one yield-tool channel-label restoration path, but
+  is not implemented in `SparseHist`. A replacement should not promise this path
+  until a runtime fixture proves the current behavior.
+
+## 7. EFT semantics contract
+
+### Mathematical object
+
+For each populated sparse category key and each physics dense bin, `HistEFT`
+stores the coefficients of a quadratic polynomial in Wilson coefficients.
+
+Given WC names in order:
+
+```text
+wc_names = [c_1, c_2, ..., c_n]
+```
+
+define the factor vector:
+
+```text
+w_0 = 1
+w_i = c_i for i = 1..n
+```
+
+The stored bin content is an ordered coefficient vector:
+
+```text
+a = [a_00, a_10, a_11, a_20, a_21, a_22, ..., a_n0, ..., a_nn]
+```
+
+and evaluation is:
+
+```text
+yield_bin(c) = sum_{i=0..n} sum_{j=0..i} a_ij * w_i * w_j
+```
+
+Equivalently:
+
+```text
+yield_bin(c) = a_00
+             + sum_i a_i0 * c_i
+             + sum_i a_ii * c_i * c_i
+             + sum_{i>j>0} a_ij * c_i * c_j
+```
+
+Source: `eft_helper.calc_eft_weights` loops over `i` and `j <= i` at
+`../topcoffea/topcoffea/modules/eft_helper.py:10-39`. The number of stored
+terms is:
+
+```text
+n_quad_terms(n_wc) = (n_wc + 2) * (n_wc + 1) / 2
+```
+
+Source: `eft_helper.py:42-46`.
+
+For `wc_names = ["ctG", "cpt"]`, the order is:
+
+```text
+0: SM*SM
+1: ctG*SM
+2: ctG*ctG
+3: cpt*SM
+4: cpt*ctG
+5: cpt*cpt
+```
+
+This order is also checked by `tests/test_histeft_api_contract.py`.
+
+### Coefficient arrays and fill
+
+Event-level coefficient arrays come from `events["EFTfitCoefficients"]` when the
+branch exists. The main processor converts to NumPy and remaps sample WC order to
+the processor WC order at `analysis/topeft_run2/analysis_processor.py:620-626`.
+The diboson processor uses the same pattern at
+`analysis/topeft_run2/analysis_processor_diboson.py:297-304`.
+
+`eft_helper.remap_coeffs` prepends `SM`, maps lower-triangle terms from a current
+WC list into a target WC list, drops omitted WCs, and zero-fills missing target
+WCs. Source: `../topcoffea/topcoffea/modules/eft_helper.py:208-266`.
+
+During fill:
+
+```text
+stored_coeff[event, term] = event_weight[event] * eft_coeff[event, term]
+```
+
+The event weight is multiplied into coefficients during `HistEFT.fill`, not
+during later evaluation. Source: `histEFT.py:230-245`.
+
+If `eft_coeff` is missing or `None`, the current implementation stores SM-only
+coefficients:
+
+```text
+eft_coeff[event] = [1, 0, ..., 0]
+```
+
+Source: `histEFT.py:214-224`.
+
+### Evaluation behavior
+
+- `eval({})` and `eval(None)` evaluate the SM point.
+- A mapping with one WC evaluates that WC while unspecified WCs remain zero.
+- A mapping with two WCs includes linear, pure quadratic, and cross terms.
+- Unknown WC names raise `LookupError`.
+- Array-like values are interpreted in current `wc_names` order.
+- Repeated evaluation is expected not to mutate stored coefficients; this is part
+  of the parity-test specification.
+
+### Systematics and sumw2
+
+Systematic variations are categorical labels on the `systematic` sparse axis,
+not extra EFT polynomial dimensions. The processors fill nominal and variations
+under the same `HistEFT` object with different `systematic` labels. Source:
+`analysis_processor.py:642-719,1744-1760,1900-1924`.
+
+`_sumw2` companion histograms are separate top-level objects with dense axis
+names suffixed by `_sumw2`. The main processor creates them at
+`analysis_processor.py:245-292` and fills nominal sumw2 companions at
+`analysis_processor.py:1913-1924` with:
+
+```text
+weight = event_weight ** 2
+eft_coeff = same quadratic coefficient array
+```
+
+The code computes `eft_w2_coeffs` with `eft_helper.calc_w2_coeffs` in both
+processors, but no later use of `eft_w2_coeffs` was found in the inspected
+processor, plotting, datacard, or yield paths. Therefore quartic EFT sumw2
+helpers are implemented but not actually used by the current fill contract.
+
+## 8. Pickle and pkl compatibility contract
+
+### Top-level pkl structure
+
+Current processor output is a gzip-compressed pickle containing a dictionary:
+
+```text
+{
+  "<hist_name>": HistEFT or SparseHist,
+  "<hist_name>_sumw2": matching HistEFT or SparseHist companion,
+  ...
+}
+```
+
+Evidence:
+
+- `analysis/topeft_run2/run_analysis.py:1760-1765` writes `output` with
+  `gzip.open(..., "wb")` and `cloudpickle.dump`.
+- `../topcoffea/topcoffea/modules/utils.py:399-405` writes pkl.gz payloads with
+  gzip and cloudpickle.
+- `../topcoffea/topcoffea/modules/hist_utils.py:274-293` materializes pkl files
+  as dictionaries when requested.
+- `topeft/modules/datacard_tools.py:175-302` requires base histogram keys and
+  matching `_sumw2` companions by default.
+- `analysis/topeft_run2/make_cr_and_sr_plots.py:5347-5351,7802-7816` discovers
+  `_sumw2` companions and loads/merges pkl payloads.
+
+### Hist object graph
+
+Each current `HistEFT` pkl must preserve:
+
+- categorical axes and labels;
+- user dense axis name, label, type, and binning;
+- WC names and order;
+- hidden coefficient-axis storage after reconstruction;
+- `_dense_hists` dense blocks keyed by sparse categorical namedtuples;
+- class import path `topcoffea.modules.histEFT.HistEFT` for old pickle loading.
+
+`HistEFT.__reduce__` stores categorical axes, the user dense axis, init args,
+WC args, and `_dense_hists` at `histEFT.py:307-319`. `SparseHist.__reduce__`
+does the analogous storage at `sparseHist.py:466-475`.
+
+### Old-pkl compatibility hooks
+
+- `analysis/topeft_run2/make_cr_and_sr_plots.py:49-110` monkey-patches
+  `SparseHist._read_from_reduce` for faster pkl reconstruction.
+- `analysis/topeft_run2/inspect_histeft_pkl.py:20-28` attempts to call
+  `ensure_histEFT_py39_compat`.
+- `topeft/modules/yield_tools.py:7-14` calls the same compatibility helper before
+  importing HistEFT/SparseHist.
+- `../topcoffea/topcoffea/modules/compat.py:13-51` provides compatibility shims
+  for old import/type expectations.
+
+### Replacement pkl requirements
+
+Required for new runs only:
+
+- New output must be loadable by the current plotter/datacard/yield path unless
+  those consumers are migrated in the same change.
+- Top-level dictionary keys and `_sumw2` naming must remain compatible unless
+  consumers are migrated.
+- Axis names and labels must remain discoverable.
+- WC metadata must remain discoverable.
+- Histograms must be mergeable after pkl load.
+
+Required for old-pkl compatibility:
+
+- Old module/class import paths must remain importable, or an explicit converter
+  must be supplied.
+- Old `__reduce__` state shape must be readable.
+- Old `_dense_hists` block layout and sparse key namedtuple behavior must be
+  translated correctly.
+- Old WC metadata and hidden coefficient-axis state must reconstruct enough to
+  support `eval({})`, nonzero WC eval, grouping, integration, and pkl merge.
+
+Optional / legacy:
+
+- Preserving the plotter's monkey-patched fast loader is optional if replacement
+  pkl loading is already fast and old pkls are handled by a converter.
+- Preserving `identity()` is only required for old accumulator compatibility if a
+  still-supported workflow uses it.
+
+## 9. Consumer contract from current topeft usage
+
+| Consumer | File | HistEFT/SparseHist feature used | Required behavior | Evidence | Replacement priority |
+| --- | --- | --- | --- | --- | --- |
+| Main processor | `analysis/topeft_run2/analysis_processor.py` | `HistEFT.__init__`, `SparseHist.__init__`, `HistEFT.fill`, `SparseHist.fill` | Construct 1D EFT hists and 2D non-EFT sparse hists; fill scalar categories, dense arrays, weights, optional `eft_coeff` | `analysis_processor.py:245-343,620-631,1900-1924` | Required immediately |
+| Diboson processor | `analysis/topeft_run2/analysis_processor_diboson.py` | `HistEFT.__init__`, `HistEFT.fill` | Construct/fill HistEFT and `_sumw2` for all axes | `analysis_processor_diboson.py:72-110,297-304,1297-1334` | Required immediately |
+| Runner/output writer | `analysis/topeft_run2/run_analysis.py` | pickleability, dict of histograms | Output must serialize with gzip/cloudpickle and retain class state | `run_analysis.py:1539-1595,1760-1765` | Required immediately |
+| Plotter pkl loader | `analysis/topeft_run2/make_cr_and_sr_plots.py` | pkl compatibility, `_read_from_reduce`, merge helper | Load old/new pkl dicts and `_sumw2` companions | `make_cr_and_sr_plots.py:49-110,7802-7816` | Required for old-pkl compatibility |
+| Plotter axis/filter helpers | `make_cr_and_sr_plots.py` | `.axes`, `.remove`, `.group`, `.integrate`, `__getitem__`, `.empty` | Axis label discovery, sample filtering, grouping, nominal integration | `make_cr_and_sr_plots.py:732-807,1263-1321,5810-5832` | Required if plotting is not migrated |
+| Plotter value extraction | `make_cr_and_sr_plots.py` | `HistEFT.eval({})`, `as_hist({})`, `SparseHist.view`, `values` | SM values with flow handling; 2D sparse view extraction | `make_cr_and_sr_plots.py:6231-6277,6461-6531,6742-6785` | Required if plotting is not migrated |
+| Datacard merge | `topeft/modules/datacard_tools.py` | `axes`, `wc_names`, `+=`, `+`, `_sumw2` pairing | Validate axes/WC metadata and merge multiple pkl payloads | `datacard_tools.py:94-302` | Required immediately if datacards consume new output |
+| Datacard read/group | `datacard_tools.py` | `.empty`, `.remove`, `.prune`, `.group`, `should_rebin` | Drop nuisances/processes and group process labels | `datacard_tools.py:788-973` | Required if datacards are not migrated |
+| Datacard EFT logic | `datacard_tools.py` | `wc_names`, `view`, `integrate`, `make_scaling`, `eval`, `dense_axis` | Select WCs, scaling extraction, SM/linear/quadratic decomposition | `datacard_tools.py:1062-1553` | Required if datacards are not migrated |
+| Yield tools | `topeft/modules/yield_tools.py` | `.axes`, `.copy`, `.integrate`, `eval`, `values`, possibly `replace_axis` | Label discovery, integration, yield sums, channel-label restoration | `yield_tools.py:306-345,430-582,816-827` | Required if yields are not migrated; `replace_axis` Unknown |
+| Pkl inspector | `analysis/topeft_run2/inspect_histeft_pkl.py` | `.axes`, `wc_names`/`_wc_names`, `.integrate`, `.eval`, `.values`, `.variances` probe | Read-only summary of top-level keys, axes, labels, and nominal yield | `inspect_histeft_pkl.py:20-345` | Nice to have for replacement introspection; `variances` can defer if `_sumw2` preserved |
+| Pkl utilities | `topcoffea` utils/hist_utils | gzip/cloudpickle dict load/write; empty filtering | Load materialized pkl dictionaries and optionally stream entries | `utils.py:399-477`; `hist_utils.py:36-293` | Required for old-pkl/new-output compatibility unless serialization is migrated |
+
+## 10. Replacement requirements
+
+### Required immediately
+
+- Constructor compatibility for processor-created 1D HistEFT objects:
+  evidence `analysis_processor.py:268-292`,
+  `analysis_processor_diboson.py:93-110`.
+- `fill(..., eft_coeff=..., weight=..., process=..., channel=...,
+  systematic=..., appl=..., <dense axis>=...)`: evidence
+  `analysis_processor.py:1900-1924`.
+- SM-only fill when `eft_coeff is None`: evidence `histEFT.py:214-224` and
+  non-EFT processor path can pass `None`.
+- `eval({})` and named WC `eval` with current polynomial semantics: evidence
+  `histEFT.py:271-284`, `datacard_tools.py:1494-1553`,
+  `make_cr_and_sr_plots.py:6231-6277`.
+- Axis metadata: `process`, `channel`, `systematic`, `appl`, dense axis names,
+  labels, and edges: evidence `datacard_tools.py:94-165`,
+  `yield_tools.py:306-345`.
+- `wc_names` metadata and ordering: evidence `datacard_tools.py:94-165,1062-1130`.
+- Addition and in-place addition for pkl merge: evidence
+  `datacard_tools.py:175-302`.
+- Pickleability for new output and compatibility with top-level dict plus
+  `_sumw2` companions: evidence `run_analysis.py:1760-1765`,
+  `datacard_tools.py:175-302`.
+- `SparseHist` behavior for current 2D non-EFT outputs if those outputs remain
+  in scope: evidence `analysis_processor.py:293-342` and
+  `make_cr_and_sr_plots.py:6461-6531`.
+
+### Required for old-pkl compatibility
+
+- Read old `HistEFT.__reduce__` state: evidence `histEFT.py:307-319`.
+- Read old `SparseHist.__reduce__` state: evidence `sparseHist.py:466-483`.
+- Preserve or translate `_dense_hists` storage and sparse key names.
+- Preserve old module/class import paths or provide a converter.
+- Support the plotter/yield compatibility helpers or remove the need for them
+  with a documented migration.
+
+### Required if plotting is not migrated
+
+- `as_hist({})`, `.axes`, `.integrate`, `__getitem__` with `sum`, `.group`,
+  `.remove`, `.empty`, `.scale`, `.values`, and `.view`.
+- Flow-bin behavior compatible with `_values_with_flow_or_overflow` and
+  `_eval_without_underflow`.
+- Existing process/channel/systematic/appl labels and group maps.
+
+### Required if datacards/yields are not migrated
+
+- `make_scaling`, `dense_axis`, raw coefficient `view(flow=True, as_dict=True)`,
+  `categorical_keys`, `.prune`, `.group`, `.remove`, `should_rebin`.
+- `replace_axis` remains Unknown and needs a fixture if
+  `restore_split_channel_labels` remains supported.
+
+### Nice to have
+
+- `quadratic_term_index` for public coefficient-order inspection.
+- `index_of_wc` if `quadratic_term_index` is preserved.
+- Pkl inspector-friendly fallback `values` and `variances` probes, as long as
+  the official variance contract is explicit.
+
+### Can defer
+
+- Native `variances` for HistEFT if `_sumw2` companions remain the source of
+  squared-weight uncertainty.
+- Native HistEFT `rebin` if current `should_rebin()` remains false and datacard
+  paths do not require HistEFT rebinning.
+- Streaming pkl optimizations if new pkl loading is small/fast in the first
+  prototype and old pkl compatibility is out of scope.
+
+### Probably unused
+
+- `HistEFT.index_of_wc` direct runtime calls.
+- `HistEFT.calc_eft_weights` instance method.
+- `SparseHist.counts`, `reset`, and `identity` direct runtime calls.
+- `.sum`, `.project`, and old `.identifiers()` for the current primary
+  processor/plotter/datacard flow.
+
+### Unknown
+
+- `replace_axis` with SparseHist/HistEFT in `yield_tools.restore_split_channel_labels`.
+- Whether old non-primary scripts under `analysis/topeft_run2/make_cr_and_sr_plots_v*`,
+  `analysis/extreme_events_study`, and validation/training directories are still
+  supported replacement consumers.
+- Whether quartic `calc_w2_coeffs` should become the official sumw2 EFT
+  convention in a future physics review. Current processors compute but do not
+  use `eft_w2_coeffs`.
+
+## 11. HistEFT parity-test suite specification
+
+Any future histogram backend must pass these tests before replacing HistEFT.
+Tests may use current `HistEFT` as the reference implementation.
+
+### Constructor parity
+
+- Same sparse axis names, labels, growth behavior, and order.
+- Same dense physics axis metadata: name, label, type, bin edges, flow policy.
+- Same WC list and order.
+- Same quadratic-term count from `n_quad_terms`.
+- Same hidden `quadratic_term` behavior where old consumers inspect raw views.
+- Same failure modes for unsupported storage, unnamed axes, invalid dense-axis
+  position/type, reserved axis names, and `rebin=True` if replacement is claiming
+  drop-in compatibility.
+
+### Fill parity
+
+- One bin, no WC list, `eft_coeff=None` gives SM-only coefficient storage.
+- One WC coefficient array: SM, linear, quadratic terms.
+- Two WC coefficient array: SM, both linears, both pure quadratics, cross term.
+- Multiple events in different dense bins.
+- Weighted fills.
+- Negative weights.
+- Categorical labels for `process/channel/systematic/appl`.
+- Multiple systematic labels under the same object.
+- Fill without required `eft_coeff` for non-EFT samples.
+- Shape failures for incompatible coefficient arrays and dense value arrays.
+
+### Evaluation parity
+
+- SM point `eval({})`.
+- `eval(None)`.
+- Single nonzero WC.
+- Two nonzero WCs, including cross terms.
+- Zero point with explicit zeros.
+- Large coefficient point.
+- Missing WC handling: unspecified WCs are zero.
+- Unknown WC handling: `LookupError`.
+- Array-like WC input in `wc_names` order.
+- Repeated eval does not mutate source values or metadata.
+
+### Histogram operation parity
+
+- `values(flow=False)` and `values(flow=True)` raw coefficient views.
+- `view(flow=True, as_dict=True)` shape and sparse keys.
+- `integrate` by scalar label, list of labels, and `None`.
+- `__getitem__` with `{axis: sum}`.
+- `group`, including dropping or preserving unspecified labels through helper
+  logic.
+- `remove` and `prune`.
+- `scale` mutation and return value.
+- `copy`, `deepcopy`, `empty`, `identity` if old coffea compatibility is claimed.
+- Addition and in-place addition for compatible histograms.
+- Multiplication by scalar through `scale`.
+- Rebin only if the replacement claims support or datacard migration requires it.
+
+### Pickle parity
+
+- Pickle/unpickle current HistEFT and replacement object.
+- Evaluate after unpickle at SM and nonzero WC points.
+- Merge/add after unpickle.
+- Compare WC metadata after unpickle.
+- Compare axes and categorical labels after unpickle.
+- Preserve top-level dict with base hist and `_sumw2` companion.
+- Load one representative old pkl if a small safe fixture exists, or define a
+  converter test that proves old content can be translated.
+
+### Processor/plotter compatibility parity
+
+- Mock a processor-like fill with `process/channel/systematic/appl`, dense axis,
+  event weights, and `eft_coeff`.
+- Mock non-EFT fill with `eft_coeff=None`.
+- Build a top-level dict with `<hist>` and `<hist>_sumw2`.
+- Run a minimal plotter-like flow: integrate nominal, group processes, sum
+  process axis, evaluate `eval({})`, materialize `as_hist({})`, and read values.
+- Preserve `process/channel/systematic/appl` labels exactly.
+- Validate datacard-like merge for two disjoint process payloads.
+
+### Numerical tolerance policy
+
+- Use exact equality for axis names, category labels, WC names, coefficient term
+  order, top-level pkl keys, and error types.
+- Use `np.testing.assert_allclose(..., atol=1e-12, rtol=0)` for deterministic
+  small coefficients and simple hand-computed fills.
+- Use relative tolerance `rtol=1e-10` plus `atol=1e-12` for accumulated weighted
+  sums where operation order can differ.
+- Use looser tolerances only for real-input workflows with documented floating
+  point differences; do not hide label or coefficient-order mismatches with
+  numeric tolerances.
+
+## 12. Synthetic fixture design
+
+### Fixture A: one dense axis, one WC
+
+- Purpose: constructor, SM-only fill, one-WC linear/quadratic evaluation.
+- Axes: `process`, `channel`, `systematic`, `appl`, dense `x` with two bins.
+- WC names: `["ctG"]`.
+- Event inputs: one event in first bin with coefficients `[2, 3, 5]`.
+- Expected SM eval: first physical bin `2 * weight`.
+- Expected nonzero eval at `ctG=2`: `(2 + 3*2 + 5*4) * weight`.
+- Metadata: hidden coefficient term count `3`; axis labels preserved.
+- Tests: constructor, fill, eval, pickle.
+
+### Fixture B: one dense axis, two WCs
+
+- Purpose: lower-triangle coefficient order and cross-term behavior.
+- Axes: same as Fixture A.
+- WC names: `["ctG", "cpt"]`.
+- Event inputs: coefficients `[1, 2, 3, 5, 7, 11]`, weight `2`.
+- Expected SM eval: `2`.
+- Expected nonzero eval at `ctG=1`, `cpt=2`: `148`.
+- Metadata: term order
+  `SM*SM, ctG*SM, ctG*ctG, cpt*SM, cpt*ctG, cpt*cpt`.
+- Tests: fill parity, evaluation parity, coefficient-order parity.
+
+### Fixture C: realistic topeft-like sparse axes
+
+- Purpose: processor/plotter sparse-axis contract.
+- Axes: `process=["ttH", "ttlnu"]`, `channel=["2lss_p"]`,
+  `systematic=["nominal", "JESUp"]`, `appl=["isSR"]`, dense `njets`.
+- WC names: `["ctG", "cpt"]`.
+- Event inputs: tiny deterministic fills across two processes and two
+  systematics.
+- Expected SM eval: hand-computed per process and systematic.
+- Expected nonzero-WC eval: same sparse keys, changed values.
+- Metadata: labels remain exactly as filled.
+- Tests: integrate, group, remove, `__getitem__` sum, plotter-like value flow.
+
+### Fixture D: `_sumw2` companion behavior
+
+- Purpose: current squared-weight top-level companion contract.
+- Axes: same as Fixture C, but dense axis names `njets` and `njets_sumw2`.
+- WC names: same as base hist.
+- Event inputs: base fill weight `w`; sumw2 fill weight `w*w`; same
+  `eft_coeff`.
+- Expected SM eval: base first bin `w*a_00`, sumw2 first bin `w*w*a_00`.
+- Expected nonzero-WC eval: same polynomial with the different fill weight.
+- Metadata: both histograms have matching sparse axes and WC names; top-level
+  keys are `njets` and `njets_sumw2`.
+- Tests: pkl payload, datacard merge validation, plotter uncertainty input.
+
+### Fixture E: pickle round-trip fixture
+
+- Purpose: serialization and old/new pkl boundary.
+- Axes: use Fixture B or C.
+- WC names: two WCs.
+- Event inputs: at least one populated sparse key.
+- Expected SM and nonzero eval: identical before and after pickle.
+- Expected metadata: class, axes, labels, `wc_names`, and dense axis survive.
+- Tests: pickle/unpickle, add after unpickle, old-pkl converter if available.
+
+## 13. Optional tests added or proposed
+
+Added lightweight tests in `tests/test_histeft_api_contract.py`.
+
+These tests use current `HistEFT` as the reference behavior and do not require
+production files or large pkls. They cover:
+
+- quadratic-term order for two WCs;
+- weighted fill and evaluation at SM and a two-WC point;
+- SM-only fill when `eft_coeff` is omitted;
+- unknown-WC failure;
+- integrate/group/copy/add/as_hist consumer operations;
+- pickle round-trip and `_sumw2` companion shape.
+
+Proposed future tests before any replacement:
+
+- a datacard-like minimal decomposition fixture using `make_scaling`;
+- a plotter-like fixture that runs the actual value-extraction helper on the
+  replacement;
+- an old-pkl fixture or converter test once a small representative pkl can be
+  safely stored.
+
+## 14. Open questions
+
+- Does `yield_tools.restore_split_channel_labels` need to support HistEFT/
+  SparseHist long term, and does its `replace_axis` call work on current objects
+  in the relevant runtime path?
+- Are old `make_cr_and_sr_plots_v*`, validation, training, and extreme-event
+  scripts in scope for the replacement, or only the current processor/plotter/
+  datacard/yield path?
+- Should future sumw2 semantics continue using the same quadratic coefficients
+  with squared event weights, or should the currently unused quartic
+  `calc_w2_coeffs` helpers become part of the physics contract?
+- Is old pkl compatibility required inside the replacement class, or can it be
+  provided by a one-time converter plus clear migration boundary?
+- Should `as_hist` output include flow bins exactly as current plotter expects,
+  or should plotting be migrated to an explicit flow policy at the same time?
+
+## 15. Suggested next prompt
+
+CL007AE - prototype scikit-hist EFT backend behind parity suite.
+
+This is reasonable only after the CL007AD contract is accepted and the parity
+suite is treated as the gate. If old-pkl compatibility is required for CL007AE,
+first add a tiny representative old-pkl fixture or a converter specification.

--- a/docs/histeft_pkl_tutorial.md
+++ b/docs/histeft_pkl_tutorial.md
@@ -530,20 +530,27 @@ real processing.
 `fullR3_run.sh` provides the safe dry-run switch and the tutorial input
 override:
 
-- `analysis/topeft_run2/fullR3_run.sh:4-25`: usage includes `--dry-run`,
-  `--cr`, `--sr`, `--hist-vars`, `--sample-json`, and `--cfg-override`.
-- `analysis/topeft_run2/fullR3_run.sh:53-138`: parses command-line options.
-- `analysis/topeft_run2/fullR3_run.sh:151-157`: requires exactly one of CR or
+- `analysis/topeft_run2/fullR3_run.sh:4-28`: usage includes `--dry-run`,
+  `--cr`, `--sr`, `--hist-vars`, `--sample-json`, `--cfg-override`, and
+  `-p/--outpath`.
+- `analysis/topeft_run2/fullR3_run.sh:59-144`: parses command-line options.
+- `analysis/topeft_run2/fullR3_run.sh:146-184`: detects user-provided
+  chunk-size and output-path overrides, so dry-runs do not print duplicate
+  `-p` options.
+- `analysis/topeft_run2/fullR3_run.sh:186-192`: requires exactly one of CR or
   SR mode.
-- `analysis/topeft_run2/fullR3_run.sh:193-206`: rejects conflicting or missing
+- `analysis/topeft_run2/fullR3_run.sh:228-241`: rejects conflicting or missing
   tutorial input override paths.
-- `analysis/topeft_run2/fullR3_run.sh:213-222`: forms the output name as
+- `analysis/topeft_run2/fullR3_run.sh:248-257`: forms the output name as
   `<YEAR_LABEL>CRs_<TAG>` or `<YEAR_LABEL>SRs_<TAG>`.
-- `analysis/topeft_run2/fullR3_run.sh:271-322`: uses a single JSON/CFG override
+- `analysis/topeft_run2/fullR3_run.sh:306-351`: uses a single JSON/CFG override
   when requested, otherwise uses the production CFG bundle.
-- `analysis/topeft_run2/fullR3_run.sh:331-338`: forwards `--hist-vars` as
+- `analysis/topeft_run2/fullR3_run.sh:366-377`: forwards `--hist-vars` as
   `--hist-list`; CR defaults to `cr`, SR defaults to `ana`.
-- `analysis/topeft_run2/fullR3_run.sh:373-385`: prints the `run_analysis.py`
+- `analysis/topeft_run2/fullR3_run.sh:379-420`: builds mode-specific
+  `run_analysis.py` options, adding the wrapper default output path only when
+  the student did not provide `-p/--outpath`.
+- `analysis/topeft_run2/fullR3_run.sh:422-428`: prints the `run_analysis.py`
   command and exits before running it when `--dry-run` is present.
 
 ## 9. Quick-run tutorial
@@ -565,20 +572,21 @@ Why this sample:
   `input_samples/sample_jsons/signal_samples/ND_SRskim2023/ttH_NDSkim_2023.json:1-40`.
 - It is an SR skim signal sample, matching the SR-oriented tutorial target.
 
-### Dry-run the one-sample SR command
+### Level 1: Recommended wrapper path
 
 This is the safe command shape derived from the commented SR block in
 `run_cr.sh` and the option parser in `fullR3_run.sh`. The explicit
 `--sample-json` option keeps the input to one Run 3 EFT signal JSON without
 editing production CFG files. It does not launch the processor because of
-`--dry-run`.
+`--dry-run`. This is the recommended tutorial path because it keeps the same
+wrapper semantics used by the broader Run 3 runner.
 
 ```bash
 cd /users/apiccine/work/correction-lib/topeft/analysis/topeft_run2
 
 ./fullR3_run.sh \
   -y 2023 \
-  -t CL007AB_single_ttH_2023_njets \
+  -t CL007AC_single_ttH_2023_njets \
   -s 1000 \
   --sr \
   --hist-vars njets \
@@ -586,7 +594,7 @@ cd /users/apiccine/work/correction-lib/topeft/analysis/topeft_run2
   --dry-run \
   --category-groups 2l \
   --all-analysis \
-  -p /tmp/cl007ab_histeft_demo \
+  -p /tmp/cl007ac_histeft_demo \
   -x futures \
   --nworkers 1 \
   --nchunks 1 \
@@ -598,15 +606,16 @@ cd /users/apiccine/work/correction-lib/topeft/analysis/topeft_run2
 Validated dry-run output in this workspace:
 
 ```text
-OUT_NAME: 2023SRs_CL007AB_single_ttH_2023_njets
+OUT_NAME: 2023SRs_CL007AC_single_ttH_2023_njets
 Resolved years: 2023
 Input override: sample JSON: ../../input_samples/sample_jsons/signal_samples/ND_SRskim2023/ttH_NDSkim_2023.json
 Resolved CFGS: ../../input_samples/sample_jsons/signal_samples/ND_SRskim2023/ttH_NDSkim_2023.json
 Resolved region: SR
 Resolved histogram list: njets
+Resolved output path: /tmp/cl007ac_histeft_demo
 
 Running the following command:
-python run_analysis.py ../../input_samples/sample_jsons/signal_samples/ND_SRskim2023/ttH_NDSkim_2023.json --years 2023 -p /groups/klannon/apiccine/ --hist-list njets --skip-cr --do-systs --do-np -o 2023SRs_CL007AB_single_ttH_2023_njets -s 1000 --category-groups 2l --all-analysis -p /tmp/cl007ab_histeft_demo -x futures --nworkers 1 --nchunks 1 --pretend --np-postprocess=skip --prefix root://cmsxrootd.crc.nd.edu/
+python run_analysis.py ../../input_samples/sample_jsons/signal_samples/ND_SRskim2023/ttH_NDSkim_2023.json --years 2023 --hist-list njets --skip-cr --do-systs --do-np -o 2023SRs_CL007AC_single_ttH_2023_njets -s 1000 --category-groups 2l --all-analysis -p /tmp/cl007ac_histeft_demo -x futures --nworkers 1 --nchunks 1 --pretend --np-postprocess=skip --prefix root://cmsxrootd.crc.nd.edu/
 ```
 
 Option notes:
@@ -626,19 +635,63 @@ Option notes:
   nonprompt post-processing in a one-signal-sample tutorial.
 - `--prefix root://cmsxrootd.crc.nd.edu/`: supplies the redirector that the
   source CFG normally provides before listing this sample JSON.
-- `-p /tmp/cl007ab_histeft_demo`: a tutorial output path. In the dry-run output
-  this appears after the default group output path, so argparse should use the
-  later value if the command is actually run.
+- `-p /tmp/cl007ac_histeft_demo`: a tutorial output path. When `-p` or
+  `--outpath` is provided, `fullR3_run.sh` suppresses its default group output
+  path, so the reconstructed command contains one output-path option.
 
 Expected pkl path for an authorized real run without `--dry-run` and without
 `--pretend`:
 
 ```text
-/tmp/cl007ab_histeft_demo/2023SRs_CL007AB_single_ttH_2023_njets.pkl.gz
+/tmp/cl007ac_histeft_demo/2023SRs_CL007AC_single_ttH_2023_njets.pkl.gz
 ```
 
-This path follows `fullR3_run.sh:213-222` for the output name and
+This path follows `fullR3_run.sh:248-257` for the output name and
 `run_analysis.py:1017-1019` plus `run_analysis.py:1715-1765` for the pkl write.
+
+### Level 2: Lightweight/tutorial helper path
+
+No separate helper script is needed for this cleanup. The
+`fullR3_run.sh --sample-json --dry-run` path already prints the exact
+one-json command without editing production CFG files, and adding a second
+wrapper would duplicate the same command-construction logic. Use Level 1 for
+the source-of-truth wrapper path, or Level 3 when you need to inspect or run the
+exact `run_analysis.py` command.
+
+### Level 3: Advanced/internal direct run_analysis.py path
+
+This path is for students who want to understand exactly what the wrapper
+dry-run reconstructs. It is an advanced/internal path derived from the wrapper
+dry-run, not the primary production workflow. Keep `--pretend` for the first
+direct run; remove both `--dry-run` from Level 1 and `--pretend` here only after
+the real one-sample run is authorized.
+
+```bash
+cd /users/apiccine/work/correction-lib/topeft/analysis/topeft_run2
+
+python run_analysis.py \
+  ../../input_samples/sample_jsons/signal_samples/ND_SRskim2023/ttH_NDSkim_2023.json \
+  --years 2023 \
+  --hist-list njets \
+  --skip-cr \
+  --do-systs \
+  --do-np \
+  -o 2023SRs_CL007AC_single_ttH_2023_njets \
+  -s 1000 \
+  --category-groups 2l \
+  --all-analysis \
+  -p /tmp/cl007ac_histeft_demo \
+  -x futures \
+  --nworkers 1 \
+  --nchunks 1 \
+  --pretend \
+  --np-postprocess=skip \
+  --prefix root://cmsxrootd.crc.nd.edu/
+```
+
+This direct command uses exactly one sample JSON and one output-path option.
+The explicit `--prefix` is important because the one-json direct path bypasses
+the source CFG line that normally supplies the redirector.
 
 ### Prove the old CFG-bundle default still resolves
 
@@ -650,14 +703,14 @@ cd /users/apiccine/work/correction-lib/topeft/analysis/topeft_run2
 
 ./fullR3_run.sh \
   -y 2023 \
-  -t CL007AB_default_dryrun \
+  -t CL007AC_default_dryrun \
   -s 1000 \
   --sr \
   --hist-vars njets \
   --dry-run \
   --category-groups 2l \
   --all-analysis \
-  -p /tmp/cl007ab_default \
+  -p /tmp/cl007ac_default \
   -x futures \
   --nworkers 1 \
   --nchunks 1 \
@@ -673,6 +726,10 @@ This dry-run should print the standard 2023 SR CFG bundle:
 ../../input_samples/cfgs/NDSkim_2023_mc_signal_samples_sr.cfg
 ```
 
+It should also print `Resolved output path: /tmp/cl007ac_default`, and the
+reconstructed command should contain exactly one output-path option:
+`-p /tmp/cl007ac_default`.
+
 ### If you temporarily edit `run_cr.sh` for a broader tutorial
 
 Do not commit such edits unless the analysis conveners request them. The active
@@ -685,7 +742,7 @@ change modeled on the commented SR scaffold around
 - pkl_base_tag="CR_muonres"
 - vars=(invmass tau0Tpt l0ptcorr)
 + years=(2023)
-+ pkl_base_tag="CL007AB_SR_tutorial_ttH"
++ pkl_base_tag="CL007AC_SR_tutorial_ttH"
 + vars=(njets)
 ```
 
@@ -1292,6 +1349,11 @@ What can be simplified if plotting migrates too:
 
 Tests to write before swapping implementation:
 
+CL007AB and CL007AC document these requirements, but they do not add formal
+parity tests. The next dedicated prompt should be CL007AD: extract a formal
+HistEFT API contract and add parity tests before implementing a
+`scikit-hist`-based replacement.
+
 - fill one EFT sample and one non-EFT sample, then compare SM yields;
 - compare `eval({})` and several nonzero WC points against current `HistEFT`;
 - verify category, process, systematic, and `appl` labels after pickle round
@@ -1410,14 +1472,16 @@ Runner:
 - `analysis/topeft_run2/run_cr.sh:72-119`: active CR block.
 - `analysis/topeft_run2/run_cr.sh:125-130`: active main CR loop.
 - `analysis/topeft_run2/run_cr.sh:177-220`: commented SR scaffold.
-- `analysis/topeft_run2/fullR3_run.sh:4-25`: usage and options.
-- `analysis/topeft_run2/fullR3_run.sh:53-138`: option parsing.
-- `analysis/topeft_run2/fullR3_run.sh:151-206`: CR/SR, year, and input-override
+- `analysis/topeft_run2/fullR3_run.sh:4-28`: usage and options.
+- `analysis/topeft_run2/fullR3_run.sh:59-144`: option parsing.
+- `analysis/topeft_run2/fullR3_run.sh:146-184`: pass-through chunk-size and
+  output-path override detection.
+- `analysis/topeft_run2/fullR3_run.sh:186-241`: CR/SR, year, and input-override
   validation.
-- `analysis/topeft_run2/fullR3_run.sh:213-222`: output-name construction.
-- `analysis/topeft_run2/fullR3_run.sh:226-322`: CFG selection and
+- `analysis/topeft_run2/fullR3_run.sh:248-257`: output-name construction.
+- `analysis/topeft_run2/fullR3_run.sh:261-351`: CFG selection and
   `--sample-json`/`--cfg-override` handling.
-- `analysis/topeft_run2/fullR3_run.sh:331-385`: hist-list forwarding,
+- `analysis/topeft_run2/fullR3_run.sh:366-428`: hist-list forwarding,
   command construction, and dry-run exit.
 - `analysis/topeft_run2/run_analysis.py:639-860`: CLI arguments.
 - `analysis/topeft_run2/run_analysis.py:1017-1051`: output paths and test

--- a/docs/histeft_pkl_tutorial.md
+++ b/docs/histeft_pkl_tutorial.md
@@ -19,6 +19,16 @@ CFG files. The only runner ergonomics change documented here is an opt-in
 `fullR3_run.sh` input override for tutorial-scale dry-runs and single-sample
 tests; production defaults are unchanged.
 
+## Companion API contract
+
+For the formal compatibility contract, implemented-vs-used feature matrix, EFT
+semantics, pkl compatibility requirements, and parity-test specification, see
+[`docs/histeft_api_contract.md`](histeft_api_contract.md).
+
+Read this tutorial first if you are learning how to run the processor and
+inspect pkls. Read the API contract next if you are planning a future replacement
+of HistEFT or writing parity tests.
+
 ## 2. Big picture: processor -> HistEFT/coffea output -> pkl -> plotting/inspection
 
 The current workflow has four layers:
@@ -1349,10 +1359,9 @@ What can be simplified if plotting migrates too:
 
 Tests to write before swapping implementation:
 
-CL007AB and CL007AC document these requirements, but they do not add formal
-parity tests. The next dedicated prompt should be CL007AD: extract a formal
-HistEFT API contract and add parity tests before implementing a
-`scikit-hist`-based replacement.
+CL007AB and CL007AC document these requirements at tutorial level. The formal
+implemented-vs-used matrix and parity-test specification now live in
+[`docs/histeft_api_contract.md`](histeft_api_contract.md).
 
 - fill one EFT sample and one non-EFT sample, then compare SM yields;
 - compare `eval({})` and several nonzero WC points against current `HistEFT`;

--- a/docs/histeft_pkl_tutorial.md
+++ b/docs/histeft_pkl_tutorial.md
@@ -1,0 +1,1016 @@
+# HistEFT and pkl inspection tutorial
+
+## 1. Purpose and scope
+
+This note is an onboarding guide for the current TOP EFT histogram workflow:
+
+```text
+analysis processor -> HistEFT/SparseHist output -> pkl.gz file -> plotting or manual inspection
+```
+
+It is intentionally source-grounded. File and line references point to the
+implementation that was inspected for this guide. The goal is to make a new
+student autonomous enough to inspect pkl files and understand the current
+contracts before planning a future `scikit-hist` EFT-aware replacement.
+
+This guide does not change any physics behavior. It does not redesign HistEFT,
+the processor, `run_cr.sh`, `fullR3_run.sh`, `run_analysis.py`, plotting code,
+sample JSONs, or CFG files.
+
+## 2. Big picture: processor -> HistEFT/coffea output -> pkl -> plotting/inspection
+
+The current workflow has four layers:
+
+1. `analysis/topeft_run2/run_cr.sh` is the student-facing source of truth for
+   how this workspace is meant to launch the processor. It delegates to
+   `analysis/topeft_run2/fullR3_run.sh`, which builds a `run_analysis.py`
+   command.
+2. `analysis/topeft_run2/run_analysis.py` reads JSON or CFG sample inputs,
+   builds a sample dictionary and WC list, instantiates
+   `AnalysisProcessor`, runs coffea, and writes a gzip-compressed pkl with
+   `cloudpickle`.
+3. `analysis/topeft_run2/analysis_processor.py` declares one histogram per
+   requested variable. One-dimensional analysis variables are `HistEFT`
+   objects. Two-dimensional variables are `SparseHist` objects.
+4. `analysis/topeft_run2/make_cr_and_sr_plots.py` loads one or more pkl files,
+   validates and merges histograms, groups process labels, integrates channels
+   and systematics, evaluates HistEFT at SM or WC points, and produces plots.
+
+Manual inspection only needs the pkl file and the histogram object API. The
+helper added with this guide,
+`analysis/topeft_run2/inspect_histeft_pkl.py`, gives a safe first look without
+depending on the plotting script.
+
+## 3. What HistEFT is
+
+`HistEFT` is a histogram class for storing EFT polynomial coefficients instead
+of only one nominal bin content per bin.
+
+In a normal weighted histogram, each event contributes one weight to one dense
+bin. In `HistEFT`, each event contributes one value for every quadratic EFT
+coefficient term. With `n` Wilson coefficients, the number of stored quadratic
+terms is the lower-triangular count for `sm` plus all WCs. For example, with
+one WC the terms are `sm*sm`, `ctG*sm`, and `ctG*ctG`.
+
+Important source behavior:
+
+- `topcoffea/topcoffea/modules/histEFT.py:74-126`: `HistEFT` requires named
+  axes, exactly one user dense axis, that dense axis last, categorical axes with
+  growth, and `Double` storage. It creates or accepts an internal
+  `quadratic_term` axis.
+- `topcoffea/topcoffea/modules/histEFT.py:140-163`: maps WC pairs such as
+  `("sm", "ctG")` or `("ctG", "ctG")` to a quadratic-term index.
+- `topcoffea/topcoffea/modules/histEFT.py:197-249`: `fill` repeats dense
+  values and event weights across all quadratic terms, then fills the internal
+  `quadratic_term` axis with EFT coefficients multiplied by the event weight.
+- `topcoffea/topcoffea/modules/histEFT.py:271-305`: `eval({})` evaluates the
+  stored polynomial at the SM point, while `eval({"ctG": 1.0})` evaluates at a
+  specific WC point. `as_hist(values)` materializes a regular histogram after
+  evaluation.
+
+The practical consequence: for a `HistEFT` object, raw stored values are not yet
+the final physics yield at an arbitrary EFT point. Plotting and manual
+inspection must either evaluate it at a WC point or explicitly inspect the raw
+coefficient axis.
+
+## 4. Where HistEFT lives in the code
+
+The implementation is in the sibling `topcoffea` repository:
+
+```text
+/users/apiccine/work/correction-lib/topcoffea/topcoffea/modules/histEFT.py
+/users/apiccine/work/correction-lib/topcoffea/topcoffea/modules/sparseHist.py
+```
+
+`HistEFT` inherits from `SparseHist`. `SparseHist` is the sparse categorical
+storage layer: it tracks categorical axes in a small bookkeeping histogram and
+stores one dense `hist.Hist` block per populated categorical key. The relevant
+source is:
+
+- `topcoffea/topcoffea/modules/sparseHist.py:15-39`: class setup, categorical
+  axes, dense axes, and `_dense_hists`.
+- `topcoffea/topcoffea/modules/sparseHist.py:124-139`: fill bookkeeping and
+  per-key dense histogram creation.
+- `topcoffea/topcoffea/modules/sparseHist.py:299-325`: slicing/integration
+  return either a dense histogram, a new sparse histogram, or a scalar.
+- `topcoffea/topcoffea/modules/sparseHist.py:349-376`: `values`, `view`, and
+  `integrate`.
+- `topcoffea/topcoffea/modules/sparseHist.py:378-406`: grouping categorical
+  bins.
+- `topcoffea/topcoffea/modules/sparseHist.py:445-529`: arithmetic and pickle
+  reconstruction.
+
+EFT coefficient helper logic is split across:
+
+- `topcoffea/topcoffea/modules/quad_fit_tools.py:203-240`: extracts
+  `EFTfitCoefficients` from events and defines the quadratic coefficient order.
+- `topcoffea/topcoffea/modules/eft_helper.py:208-266`: remaps coefficient
+  arrays when a histogram WC list differs from the sample WC list.
+
+## 5. HistEFT data model
+
+### Axes
+
+The processor constructs a `HistEFT` with four sparse categorical axes and one
+analysis dense axis:
+
+```text
+process, channel, systematic, appl, <analysis variable>
+```
+
+Source:
+
+- `analysis/topeft_run2/analysis_processor.py:212-236`: declares the
+  categorical axes `process`, `channel`, `systematic`, and `appl`, then builds
+  histogram-variable names from `topeft/modules/axes.py`.
+- `analysis/topeft_run2/analysis_processor.py:245-292`: creates one
+  `HistEFT` per selected one-dimensional variable and a matching
+  `<name>_sumw2` histogram when sumw2 is enabled.
+- `topeft/modules/axes.py:1-32`: examples of one-dimensional variable
+  definitions such as `invmass`, `ptz`, and `njets`.
+- `topeft/modules/axes.py:230-260`: two-dimensional variable definitions use a
+  separate `info_2d` dictionary.
+
+`HistEFT` also carries an internal dense `quadratic_term` axis. That axis is
+created in `histEFT.py:105-126` and is included in the dense storage layer, but
+the user-facing analysis dense axis is still the physics variable such as
+`njets` or `ptz`.
+
+### Dense vs sparse axes
+
+`SparseHist` treats categorical axes as sparse and dense axes as regular
+histogram axes. In this codebase:
+
+- sparse axes: process, channel, systematic, appl;
+- dense physics axis: one requested analysis variable;
+- dense internal EFT axis: `quadratic_term`, managed by `HistEFT`.
+
+Only populated sparse category combinations get dense histogram blocks. That is
+why manual pkl inspection should not assume every process/channel/systematic
+combination exists.
+
+### Sample and process labels
+
+The processor uses sample JSON metadata to assign the process axis label:
+
+- `analysis/topeft_run2/analysis_processor.py:450-466`: reads `dataset`,
+  `histAxisName`, `year`, xsec, sum of weights, and whether the sample has WCs.
+- `analysis/topeft_run2/analysis_processor.py:1900-1911`: fills
+  `process=histAxisName`.
+
+The plotting script later groups these raw process labels into physics groups
+using metadata patterns:
+
+- `topeft/params/cr_sr_plots_metadata.yml:432-503`: SR group map, including
+  patterns for `ttH`, `ttlnu`, `ttll`, `tllq`, `tHq`, and `tttt`.
+- `analysis/topeft_run2/make_cr_and_sr_plots.py:5810-5832`: groups process
+  bins and validates labels.
+
+### Category and channel labels
+
+The processor stores selected analysis categories on the `channel` axis. It
+also stores application-region labels on the `appl` axis, for example signal
+region versus application region.
+
+Source:
+
+- `analysis/topeft_run2/analysis_processor.py:60-99`: resolves category-group
+  names into SR or CR category dictionaries.
+- `analysis/topeft_run2/analysis_processor.py:1136-1170`: chooses SR and/or CR
+  category lists depending on run options.
+- `analysis/topeft_run2/analysis_processor.py:1230-1412`: builds packed
+  selections, preselection, SR/CR masks, lepton flavor masks, njet masks, and
+  application-region masks.
+- `analysis/topeft_run2/analysis_processor.py:1638-1703`: builds the concrete
+  category dictionary used in the fill loop.
+- `analysis/topeft_run2/analysis_processor.py:1771-1817`: loops over category,
+  njet label, application region, lepton channel, and lepton flavor.
+- `topeft/params/cr_sr_plots_metadata.yml:20-24`: plotting metadata records
+  that CR pkls include lepton flavor in channel labels, while SR pkls do not.
+- `topeft/params/cr_sr_plots_metadata.yml:116-352`: SR channel aliases and
+  leaves.
+
+### Systematics
+
+The `systematic` axis stores nominal and variation labels. The processor loops
+over object variations and weight variations:
+
+- `analysis/topeft_run2/analysis_processor.py:642-669`: defines object and
+  weight systematic lists.
+- `analysis/topeft_run2/analysis_processor.py:716-719`: builds the object
+  systematic loop, including nominal.
+- `analysis/topeft_run2/analysis_processor.py:1744-1760`: selects nominal,
+  object-shifted, or weight-shifted event weights.
+- `analysis/topeft_run2/analysis_processor.py:1900-1911`: fills
+  `systematic=wgt_fluct`.
+
+Manual comparisons should first list the actual labels in the pkl and only then
+compare pairs such as `JESUp` and `JESDown`. Labels are not guaranteed to be
+present in tiny runs or in runs without `--do-systs`.
+
+### EFT coefficient storage
+
+For samples with EFT metadata, the processor reads event-level coefficients:
+
+- `analysis/topeft_run2/analysis_processor.py:620-631`: reads
+  `events["EFTfitCoefficients"]`, remaps coefficients to the requested WC
+  list, and prepares optional squared-weight coefficients.
+- `analysis/topeft_run2/analysis_processor.py:1900-1911`: passes
+  `eft_coeff=eft_coeffs_cut` into `HistEFT.fill`.
+- `topcoffea/topcoffea/modules/quad_fit_tools.py:217-240`: defines the
+  coefficient order with `sm` prepended.
+- `topcoffea/topcoffea/modules/eft_helper.py:208-266`: remaps coefficient
+  arrays when current and target WC lists differ.
+
+If a sample has no EFT coefficients, `HistEFT.fill` defaults to SM-only
+coefficients, according to `histEFT.py:214-224`.
+
+### Nominal vs variation content
+
+Nominal and systematic variations are not separate top-level pkl files by
+default. They are labels on the `systematic` axis. Sumw2 content, when enabled,
+is stored as a separate top-level histogram key with a `_sumw2` suffix. The
+processor creates the companion histograms in
+`analysis_processor.py:245-292` and fills them in
+`analysis_processor.py:1913-1924`.
+
+### Values and variances
+
+For `HistEFT`, call `eval(wc_values)` to get evaluated values. The plotting
+script uses this pattern for HistEFT:
+
+- `analysis/topeft_run2/make_cr_and_sr_plots.py:6231-6277`: helper functions
+  call `hist_slice.eval({})` for `HistEFT` and use `.values(...)` for ordinary
+  histograms.
+
+For sumw2, current analysis outputs use separate `_sumw2` HistEFT-like objects
+rather than relying only on regular weighted-hist variance storage. Plotting and
+datacard utilities therefore often require matching base and `_sumw2` keys.
+
+### Serialization and pickle behavior
+
+Output pkls are gzip-compressed cloudpickle files:
+
+- `topcoffea/topcoffea/modules/utils.py:399-405`: `dump_to_pkl` writes with
+  `gzip.open(..., "wb")` and `cloudpickle.dump`.
+- `analysis/topeft_run2/run_analysis.py:1715-1765`: writes the final histogram
+  dictionary to `<outpath>/<outname>.pkl.gz`.
+
+`HistEFT.__reduce__` reconstructs categorical axes, the user dense axis,
+initialization arguments, WC names, and `_dense_hists`:
+
+- `topcoffea/topcoffea/modules/histEFT.py:307-319`.
+
+The plotting script also monkey-patches `SparseHist._read_from_reduce` for
+faster loading:
+
+- `analysis/topeft_run2/make_cr_and_sr_plots.py:55-110`.
+
+## 6. How the analysis processor fills histograms
+
+### Histogram declaration
+
+`AnalysisProcessor.__init__` resolves the requested histogram list, builds
+axes, and creates histograms:
+
+- `analysis/topeft_run2/analysis_processor.py:114-150`: normalizes requested
+  histogram names.
+- `analysis/topeft_run2/analysis_processor.py:212-236`: creates sparse axes and
+  finds available 1D and 2D variables.
+- `analysis/topeft_run2/analysis_processor.py:245-292`: creates one
+  `HistEFT` and one optional `_sumw2` HistEFT per 1D variable.
+- `analysis/topeft_run2/analysis_processor.py:293-343`: creates `SparseHist`
+  objects for 2D variables, without EFT coefficient storage.
+
+### Event selection
+
+Selections are built with masks for lepton multiplicity, trigger, Z windows,
+b-tag regions, category definitions, application regions, and optional lepton
+flavor splitting. The main selection-building block is:
+
+- `analysis/topeft_run2/analysis_processor.py:1014-1020`: lepton-multiplicity
+  selections.
+- `analysis/topeft_run2/analysis_processor.py:1230-1412`: preselection,
+  category, njet, lepton flavor, and `appl` selections.
+- `analysis/topeft_run2/analysis_processor.py:1718-1817`: per-histogram,
+  per-systematic, per-category fill loop.
+
+### Weights
+
+The base MC event weight is normalized by luminosity, cross section, generator
+weight, and sum of weights:
+
+- `analysis/topeft_run2/analysis_processor.py:681-692`.
+
+Additional nominal and systematic weights are added through correction helpers:
+
+- `analysis/topeft_run2/analysis_processor.py:694-711`: prefiring, parton
+  shower, scale, and pileup weight setup.
+- `analysis/topeft_run2/analysis_processor.py:1135-1226`: category-specific
+  lepton SF, fake-factor, flip-rate, and data-driven behavior.
+- `analysis/topeft_run2/analysis_processor.py:1744-1760`: chooses which
+  weight variation is used for the current systematic label.
+
+### Nominal fills
+
+The nominal fill is just one pass through the same systematic loop with
+`wgt_fluct == "nominal"`. The fill payload includes the dense variable,
+category labels, application region, process label, systematic label, event
+weight, and EFT coefficients when the histogram requires them:
+
+- `analysis/topeft_run2/analysis_processor.py:1900-1911`.
+
+### Systematic fills
+
+Object systematic variations change the event collections before the selection
+and dense variable are computed. Weight systematic variations keep the same
+object collection but use a shifted weight. The relevant source ranges are:
+
+- `analysis/topeft_run2/analysis_processor.py:766-961`: object variation
+  handling for muons, taus, jets, and MET.
+- `analysis/topeft_run2/analysis_processor.py:1718-1760`: variable and weight
+  choice for each systematic loop.
+
+### EFT fills
+
+`eft_coeffs_cut` is selected with the same event mask as the event weights and
+dense variable:
+
+- `analysis/topeft_run2/analysis_processor.py:1771-1817`: category mask and
+  `eft_coeffs_cut`.
+- `analysis/topeft_run2/analysis_processor.py:1900-1911`: `eft_coeff` is
+  included only for histograms marked as requiring EFT.
+
+### CR vs SR behavior
+
+`run_analysis.py` controls CR and SR behavior through `--skip-sr`, `--skip-cr`,
+category dictionaries, and histogram-list aliases:
+
+- `analysis/topeft_run2/run_analysis.py:1058-1067`: resolves requested
+  category groups.
+- `analysis/topeft_run2/run_analysis.py:1081-1175`: expands histogram-list
+  aliases such as `ana` and `cr`.
+- `analysis/topeft_run2/analysis_processor.py:359-362`: processor flags for
+  systematics, lepton flavor splitting, skip SR, and skip CR.
+- `analysis/topeft_run2/analysis_processor.py:1136-1170`: selects SR and/or
+  CR category dictionaries.
+
+### Run 2 vs Run 3 behavior
+
+The processor marks an event sample as Run 2 or Run 3 from the sample JSON
+`year` string:
+
+- `analysis/topeft_run2/analysis_processor.py:450-466`: `is_run2` is true for
+  years starting with `201`, and `is_run3` for years starting with `202`.
+
+The runner expands year aliases:
+
+- `analysis/topeft_run2/fullR3_run.sh:143-156`: `run3` expands to
+  `2022 2022EE 2023 2023BPix`.
+- `analysis/topeft_run2/fullR3_run.sh:190-270`: chooses CFG files by year and
+  CR/SR mode.
+
+## 7. `run_cr.sh` as the source-of-truth runner
+
+The source-of-truth student runner is:
+
+```text
+analysis/topeft_run2/run_cr.sh
+```
+
+Important local behavior:
+
+- `analysis/topeft_run2/run_cr.sh:10-33`: workspace-specific output path,
+  chunk size, pkl tag, default histogram variables, years, and category sets.
+- `analysis/topeft_run2/run_cr.sh:72-119`: active `run_cr_block` delegates to
+  `./fullR3_run.sh` with `--cr`, `--hist-vars`, `--do-systs`, output path,
+  category groups, tau analysis, and split lepton flavor.
+- `analysis/topeft_run2/run_cr.sh:125-130`: active main loop runs CR jobs over
+  the configured years and category sets.
+- `analysis/topeft_run2/run_cr.sh:177-220`: commented SR scaffold shows the
+  same script family used for SR runs, with `--sr`, `--do-systs`, `--do-np`,
+  category groups, and `--all-analysis`.
+
+Do not run this script blindly for a tutorial. As inspected, the active body is
+a CR production-style loop over multiple years and category sets. For an SR
+tutorial, treat `run_cr.sh` as the source of the command shape, then use
+`fullR3_run.sh --dry-run` to source-validate the downstream command before any
+real processing.
+
+`fullR3_run.sh` provides the safe dry-run switch:
+
+- `analysis/topeft_run2/fullR3_run.sh:4-21`: usage includes `--dry-run`,
+  `--cr`, `--sr`, and `--hist-vars`.
+- `analysis/topeft_run2/fullR3_run.sh:48-116`: parses command-line options.
+- `analysis/topeft_run2/fullR3_run.sh:129-135`: requires exactly one of CR or
+  SR mode.
+- `analysis/topeft_run2/fullR3_run.sh:176-185`: forms the output name as
+  `<YEAR_LABEL>CRs_<TAG>` or `<YEAR_LABEL>SRs_<TAG>`.
+- `analysis/topeft_run2/fullR3_run.sh:282-289`: forwards `--hist-vars` as
+  `--hist-list`; CR defaults to `cr`, SR defaults to `ana`.
+- `analysis/topeft_run2/fullR3_run.sh:325-337`: prints the `run_analysis.py`
+  command and exits before running it when `--dry-run` is present.
+
+## 8. Quick-run tutorial
+
+### Choose a Run 3 EFT signal sample
+
+For the SR tutorial, use:
+
+```text
+input_samples/sample_jsons/signal_samples/ND_SRskim2023/ttH_NDSkim_2023.json
+```
+
+Why this sample:
+
+- It is directly listed in the 2023 SR signal CFG used by `fullR3_run.sh`:
+  `input_samples/cfgs/NDSkim_2023_mc_signal_samples_sr.cfg:7-12`.
+- It has `year: "2023"`, `histAxisName: "ttH_private2023"`, and a non-empty
+  `WCnames` list:
+  `input_samples/sample_jsons/signal_samples/ND_SRskim2023/ttH_NDSkim_2023.json:1-40`.
+- It is an SR skim signal sample, matching the SR-oriented tutorial target.
+
+### Dry-run the source-derived SR command
+
+This is the safe command shape derived from the commented SR block in
+`run_cr.sh` and the option parser in `fullR3_run.sh`. It does not launch the
+processor because of `--dry-run`.
+
+```bash
+cd /users/apiccine/work/correction-lib/topeft/analysis/topeft_run2
+
+./fullR3_run.sh \
+  -y 2023 \
+  -t CL007AA_SR_tutorial_ttH_2023_njets \
+  -s 1000 \
+  --sr \
+  --hist-vars njets \
+  --dry-run \
+  --category-groups 2l \
+  --all-analysis \
+  -p /tmp/cl007aa_histeft_demo \
+  -x futures \
+  --nworkers 1 \
+  --nchunks 1 \
+  --pretend
+```
+
+Validated dry-run output in this workspace:
+
+```text
+OUT_NAME: 2023SRs_CL007AA_SR_tutorial_ttH_2023_njets
+Resolved years: 2023
+Resolved CFGS: ../../input_samples/cfgs/NDSkim_2023_background_samples.cfg,../../input_samples/cfgs/NDSkim_2023_data_samples.cfg,../../input_samples/cfgs/NDSkim_2023_mc_signal_samples_sr.cfg
+Resolved region: SR
+Resolved histogram list: njets
+
+Running the following command:
+python run_analysis.py ../../input_samples/cfgs/NDSkim_2023_background_samples.cfg,../../input_samples/cfgs/NDSkim_2023_data_samples.cfg,../../input_samples/cfgs/NDSkim_2023_mc_signal_samples_sr.cfg --years 2023 -p /groups/klannon/apiccine/ --hist-list njets --skip-cr --do-systs --do-np -o 2023SRs_CL007AA_SR_tutorial_ttH_2023_njets -s 1000 --category-groups 2l --all-analysis -p /tmp/cl007aa_histeft_demo -x futures --nworkers 1 --nchunks 1 --pretend
+```
+
+Option notes:
+
+- `-y 2023`: one Run 3 year, not the full `run3` alias.
+- `--sr`: selects SR mode and makes `fullR3_run.sh` choose SR CFG files.
+- `--hist-vars njets`: asks for one small histogram variable.
+- `--category-groups 2l`: limits category construction to the 2l SR group.
+- `--dry-run`: prints the downstream command and exits before running Python.
+- `-x futures --nworkers 1 --nchunks 1 --pretend`: bounded internal
+  `run_analysis.py` options, included in the printed command. `--pretend`
+  would stop `run_analysis.py` after input discovery if the dry-run guard were
+  removed.
+- `-p /tmp/cl007aa_histeft_demo`: a tutorial output path. In the dry-run output
+  this appears after the default group output path, so argparse should use the
+  later value if the command is actually run.
+
+Expected pkl path for an authorized real run without `--dry-run` and without
+`--pretend`:
+
+```text
+/tmp/cl007aa_histeft_demo/2023SRs_CL007AA_SR_tutorial_ttH_2023_njets.pkl.gz
+```
+
+This path follows `fullR3_run.sh:176-185` for the output name and
+`run_analysis.py:1017-1019` plus `run_analysis.py:1715-1765` for the pkl write.
+
+### Important limitation: one-sample-only running
+
+The source-of-truth runner does not currently expose a public option to run
+only one JSON from the SR CFG. The dry-run command above uses the 2023 SR CFG
+set, and the chosen `ttH_NDSkim_2023.json` is one of the EFT signal JSONs in
+that CFG. A truly one-sample run would require either a temporary one-entry CFG
+or an internal direct `run_analysis.py` call. That direct path is not the
+primary student workflow; treat it as an advanced path derived from the
+dry-run output and use it only after authorization.
+
+### If you temporarily edit `run_cr.sh` for a tutorial
+
+Do not commit such edits unless the analysis conveners request them. The active
+file currently runs CR blocks. For an SR tutorial edit, make a temporary local
+change modeled on the commented SR scaffold around
+`analysis/topeft_run2/run_cr.sh:177-220`, for example:
+
+```diff
+- years=(2022 2022EE 2023 2023BPix 2018)
+- pkl_base_tag="CR_muonres"
+- vars=(invmass tau0Tpt l0ptcorr)
++ years=(2023)
++ pkl_base_tag="CL007AA_SR_tutorial_ttH"
++ vars=(njets)
+```
+
+Then use the SR scaffold, add `--dry-run` first, and keep the output path in a
+scratch location. The point is to prove command construction before launching
+any real processing.
+
+## 9. How `make_cr_and_sr_plots.py` consumes pkl files
+
+The plotting script accepts one or more pkl files and merges them before
+plotting:
+
+- `analysis/topeft_run2/make_cr_and_sr_plots.py:7528-7676`: CLI arguments
+  include repeated `-f/--pkl-file-path`, pkl list files, output path/name,
+  years, region override, variables, workers, merge options, cache options, and
+  systematic switches.
+- `analysis/topeft_run2/make_cr_and_sr_plots.py:7679-7692`: resolves pkl paths.
+- `analysis/topeft_run2/make_cr_and_sr_plots.py:7727-7854`: detects region,
+  loads and merges histograms with `load_and_merge_histogram_pkls`, writes an
+  optional cached merged pkl, and dispatches plotting.
+- `topeft/modules/datacard_tools.py:175-302`: opens each pkl, requires a
+  dictionary with string keys, checks base and `_sumw2` companions when
+  requested, validates histogram compatibility, and merges matching keys.
+
+Expected pkl structure:
+
+- top-level object: dictionary;
+- top-level keys: histogram variable names such as `njets`, `ptz`, `invmass`;
+- optional companion keys: `<hist>_sumw2`;
+- values: `HistEFT` for 1D variables, `SparseHist` for 2D variables.
+
+Histogram selection and process grouping:
+
+- `analysis/topeft_run2/make_cr_and_sr_plots.py:2365-2479`: prepares variable
+  payloads, finds available channels, handles sumw2 histograms, and filters
+  process labels.
+- `analysis/topeft_run2/make_cr_and_sr_plots.py:732-808`: resolves channel and
+  process axis labels.
+- `analysis/topeft_run2/make_cr_and_sr_plots.py:5810-5832`: groups process
+  bins from metadata patterns.
+
+Category/channel handling:
+
+- `analysis/topeft_run2/make_cr_and_sr_plots.py:1738-1767`: integrates
+  application region and category labels.
+- `topeft/modules/yield_tools.py:475-513`: integrates categories and `appl`
+  labels for yield extraction.
+
+Systematics:
+
+- `analysis/topeft_run2/make_cr_and_sr_plots.py:6140-6214`: discovers
+  systematic labels, completes Up/Down pairs, integrates nominal and variation
+  histograms, and prepares arrays.
+
+Yields and HistEFT evaluation:
+
+- `analysis/topeft_run2/make_cr_and_sr_plots.py:6231-6277`: evaluates HistEFT
+  with `eval({})` for SM values and uses regular `.values(...)` for other
+  histogram types.
+- `topeft/modules/yield_tools.py:548-567`: yield code integrates categories,
+  evaluates HistEFT at a requested WC point, and combines value and variance
+  arrays.
+
+Manual inspectors must reproduce these assumptions: dictionary pkl, string
+keys, base and `_sumw2` pairing, categorical axes named `process`, `channel`,
+`systematic`, and `appl`, and explicit HistEFT evaluation before using values
+as physics yields.
+
+## 10. Manual pkl inspection
+
+### Use the helper script
+
+The helper is read-only:
+
+```bash
+WRAP=/users/apiccine/work/correction-lib/codex-run.sh
+PYTHON_ENV=/users/apiccine/work/miniconda3/envs/clib-env/bin/python
+
+$WRAP /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && "$PYTHON_ENV" analysis/topeft_run2/inspect_histeft_pkl.py --help'
+```
+
+Inspect a pkl:
+
+```bash
+$WRAP /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && "$PYTHON_ENV" analysis/topeft_run2/inspect_histeft_pkl.py /path/to/output.pkl.gz --max-labels 10'
+```
+
+Inspect one histogram and ask for a simple nominal total when discoverable:
+
+```bash
+$WRAP /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && "$PYTHON_ENV" analysis/topeft_run2/inspect_histeft_pkl.py /path/to/output.pkl.gz --hist njets --max-labels 10 --yield-summary'
+```
+
+The helper prints:
+
+- top-level object type;
+- top-level keys;
+- histogram-like object types;
+- axes and labels;
+- `process`, `channel`, `systematic`, and `appl` labels when discoverable;
+- WC names when the object exposes them;
+- optional simple nominal yield and variance sums.
+
+### Minimal manual Python snippets
+
+Use the same analysis environment when opening analysis pkls. A pkl may require
+`topcoffea` classes to be importable.
+
+List top-level keys:
+
+```bash
+WRAP=/users/apiccine/work/correction-lib/codex-run.sh
+PYTHON_ENV=/users/apiccine/work/miniconda3/envs/clib-env/bin/python
+
+$WRAP /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && "$PYTHON_ENV" -c "import gzip,pickle; p=\"/path/to/output.pkl.gz\"; f=gzip.open(p,\"rb\") if p.endswith(\".gz\") else open(p,\"rb\"); obj=pickle.load(f); print(type(obj)); print(list(obj)[:20])"'
+```
+
+List axes for one histogram:
+
+```bash
+$WRAP /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && "$PYTHON_ENV" -c "import gzip,pickle; p=\"/path/to/output.pkl.gz\"; obj=pickle.load(gzip.open(p,\"rb\")); h=obj[\"njets\"]; print(type(h)); print([ax.name for ax in h.axes])"'
+```
+
+List labels on common categorical axes:
+
+```bash
+$WRAP /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && "$PYTHON_ENV" -c "import gzip,pickle; p=\"/path/to/output.pkl.gz\"; h=pickle.load(gzip.open(p,\"rb\"))[\"njets\"]; print(list(h.axes[\"process\"])[:20]); print(list(h.axes[\"channel\"])[:20]); print(list(h.axes[\"systematic\"])[:20])"'
+```
+
+Evaluate a HistEFT at the SM point and sum all returned blocks:
+
+```bash
+$WRAP /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && "$PYTHON_ENV" -c "import gzip,pickle,numpy as np; p=\"/path/to/output.pkl.gz\"; h=pickle.load(gzip.open(p,\"rb\"))[\"njets\"]; vals=h.integrate(\"systematic\",\"nominal\").eval({}); print(sum(float(np.nansum(v)) for v in vals.values()))"'
+```
+
+Compare nominal to one systematic label:
+
+```bash
+$WRAP /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && "$PYTHON_ENV" -c "import gzip,pickle,numpy as np; p=\"/path/to/output.pkl.gz\"; h=pickle.load(gzip.open(p,\"rb\"))[\"njets\"]; nom=h.integrate(\"systematic\",\"nominal\").eval({}); up=h.integrate(\"systematic\",\"JESUp\").eval({}); print(sum(float(np.nansum(up[k]-nom.get(k,0))) for k in up))"'
+```
+
+The last snippet assumes `JESUp` exists. Always list systematic labels first.
+
+### Make a small yield table
+
+For a quick manual table, select one histogram, integrate one systematic label,
+then loop over process labels:
+
+```bash
+$WRAP /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && "$PYTHON_ENV" -c "import gzip,pickle,numpy as np; p=\"/path/to/output.pkl.gz\"; h=pickle.load(gzip.open(p,\"rb\"))[\"njets\"].integrate(\"systematic\",\"nominal\"); procs=list(h.axes[\"process\"]); print(\"process yield\"); [print(proc, sum(float(np.nansum(v)) for v in h.integrate(\"process\",proc).eval({}).values())) for proc in procs[:20]]"'
+```
+
+This is deliberately simple. It does not group processes, handle overflow
+policy, or combine sumw2 uncertainties the same way the plotter does. Use it as
+a first sanity check, not as a publication number.
+
+### Check EFT/WC content
+
+For a `HistEFT`, inspect WC names:
+
+```bash
+$WRAP /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && "$PYTHON_ENV" -c "import gzip,pickle; p=\"/path/to/output.pkl.gz\"; h=pickle.load(gzip.open(p,\"rb\"))[\"njets\"]; print(getattr(h,\"wc_names\", getattr(h,\"_wc_names\", None)))"'
+```
+
+Evaluate a non-SM point if the WC exists:
+
+```bash
+$WRAP /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && "$PYTHON_ENV" -c "import gzip,pickle,numpy as np; p=\"/path/to/output.pkl.gz\"; h=pickle.load(gzip.open(p,\"rb\"))[\"njets\"].integrate(\"systematic\",\"nominal\"); vals=h.eval({\"ctG\": 1.0}); print(sum(float(np.nansum(v)) for v in vals.values()))"'
+```
+
+If this raises a `LookupError`, the histogram WC list does not include that WC.
+
+## 11. Debugging checklist
+
+Missing pkl:
+
+- Check whether the command was a dry-run or used `--pretend`; those do not
+  write the final pkl.
+- Check the final `-p` output path and `-o` output name in the printed
+  `run_analysis.py` command.
+- Check `run_analysis.py:1017-1019` and `run_analysis.py:1715-1765` for output
+  path construction and writing.
+
+Empty histograms:
+
+- Verify the category group exists in the active `ch_lst.json` block.
+- Check whether `--skip-sr` or `--skip-cr` removed the target region.
+- List `channel`, `process`, and `systematic` labels with the helper.
+- Use a broad category first, then narrow.
+
+Missing category:
+
+- Confirm the category group passed through `--category-groups`.
+- Check `analysis_processor.py:60-99` for group resolution and
+  `analysis_processor.py:1638-1703` for concrete category labels.
+- For plotting, check `topeft/params/cr_sr_plots_metadata.yml:20-24` because
+  CR and SR channel-label expectations differ.
+
+Missing process/sample:
+
+- Confirm the sample JSON is present in the CFG selected by `fullR3_run.sh`.
+- Check the sample JSON `histAxisName`; this is the raw process-axis label.
+- Check plot grouping patterns in `topeft/params/cr_sr_plots_metadata.yml`.
+
+Missing systematic:
+
+- Confirm the run used `--do-systs`.
+- Tiny or pretend runs may not fill all requested variations.
+- List actual `systematic` labels before comparing Up/Down pairs.
+
+Missing EFT coefficients:
+
+- Check the sample JSON `WCnames` list.
+- Check whether event files have `EFTfitCoefficients`.
+- Check `analysis_processor.py:620-631` for the coefficient read/remap path.
+- If `HistEFT.eval({"ctG": 1.0})` fails, list the histogram's WC names.
+
+Mismatched histogram variable names:
+
+- `fullR3_run.sh --hist-vars` forwards to `run_analysis.py --hist-list`.
+- Valid 1D names are in `topeft/modules/axes.py:1-228`.
+- Valid 2D names are in `topeft/modules/axes.py:230-260` and later entries.
+
+CR/SR mismatch:
+
+- `--cr` makes `fullR3_run.sh` add `--skip-sr`.
+- `--sr` makes `fullR3_run.sh` add `--skip-cr`.
+- The active `run_cr.sh` body is CR-oriented in this workspace.
+
+Wrong sample JSON/CFG:
+
+- For 2023 SR, `fullR3_run.sh` uses:
+  `NDSkim_2023_background_samples.cfg`,
+  `NDSkim_2023_data_samples.cfg`, and
+  `NDSkim_2023_mc_signal_samples_sr.cfg`.
+- The chosen tutorial sample is listed in
+  `input_samples/cfgs/NDSkim_2023_mc_signal_samples_sr.cfg:9`.
+
+Pkl too large to inspect naively:
+
+- Use the helper with `--hist` and small `--max-labels`.
+- Avoid printing full `.values()` arrays.
+- Start with top-level keys and axes.
+- For many pkls, use the plotter merge-only path or a small custom inspector
+  before loading every histogram into plotting.
+
+## 12. Mapping to a future scikit-hist EFT-aware replacement
+
+A future `scikit-hist` EFT-aware histogram class must reproduce current
+behavior before it can replace `HistEFT` safely.
+
+Core histogram behavior:
+
+- accept named categorical axes and dense axes;
+- preserve sparse categorical behavior or provide an equivalent memory-safe
+  representation;
+- support fill calls with scalar categorical labels, dense arrays, event
+  weights, and optional EFT coefficient arrays;
+- support addition and in-place addition for merging pkl outputs;
+- support pruning, removal, grouping, slicing, projection, and integration
+  patterns used by the processor and plotter.
+
+Axes and metadata behavior:
+
+- preserve axis names: `process`, `channel`, `systematic`, `appl`, dense
+  variable name, and EFT coefficient dimension;
+- preserve process labels from sample JSON `histAxisName`;
+- preserve channel labels exactly as produced by the processor;
+- preserve systematic labels exactly as filled;
+- keep WC names and their order available after pickle load;
+- preserve enough metadata for plotting group maps and yield tools.
+
+Values and variances behavior:
+
+- expose SM and WC-evaluated values with clear flow-bin policy;
+- preserve or replace the current `_sumw2` companion convention;
+- make variance behavior explicit, because current plotting often treats
+  `<hist>_sumw2` as the variance source rather than using only weighted storage;
+- support efficient summed yields over process/channel/systematic selections.
+
+EFT coefficient storage and evaluation:
+
+- store the quadratic coefficient order currently produced by
+  `quad_fit_tools.py:217-240`;
+- reproduce `HistEFT.quadratic_term_index` behavior from
+  `histEFT.py:140-163`;
+- reproduce `fill(eft_coeff=...)` semantics from `histEFT.py:197-249`,
+  including SM-only default coefficients for non-EFT samples;
+- reproduce `eval({})`, `eval({"wc": value})`, and unknown-WC error behavior;
+- support coefficient remapping or define a stricter common WC-list contract.
+
+Systematic variation handling:
+
+- allow `systematic` to remain a categorical axis;
+- support nominal and Up/Down comparisons without forcing all variations to be
+  dense axes;
+- preserve missing-variation behavior for small or partial runs.
+
+Processor API assumptions:
+
+- constructor can be called where `analysis_processor.py:245-292` currently
+  calls `HistEFT(...)`;
+- `fill` accepts `process=`, `channel=`, `systematic=`, `appl=`, dense variable
+  keyword, `weight=`, and `eft_coeff=`;
+- histograms are pickleable and mergeable after coffea execution;
+- 2D non-EFT histograms can remain separate if the first replacement only
+  targets 1D EFT-aware histograms.
+
+Plotting API assumptions:
+
+- pkl top-level dictionary keys remain variable names plus optional `_sumw2`;
+- objects expose `.axes`, `.integrate(...)`, `.group(...)`, `.remove(...)`,
+  `.prune(...)`, `.values(...)`, and HistEFT-like `.eval(...)`;
+- process grouping and channel integration work with existing labels;
+- `load_and_merge_histogram_pkls` compatibility checks can validate axes,
+  dense binning, and WC metadata.
+
+Serialization compatibility:
+
+- old pkls may need a compatibility reader;
+- new pkls should load without monkey-patches;
+- pkl size and load time matter because plotting merges large outputs;
+- a migration may need a converter from old HistEFT pkls to the new format.
+
+What can be simplified if plotting migrates too:
+
+- the new class does not need to mimic every legacy `SparseHist` method if the
+  plotter and yield tools move to a clearer shared API at the same time;
+- process grouping can be centralized outside histogram objects;
+- sumw2 handling can be made explicit as variance storage instead of separate
+  top-level keys;
+- WC evaluation can return regular `hist` or `scikit-hist` objects with a
+  documented flow-bin convention.
+
+Tests to write before swapping implementation:
+
+- fill one EFT sample and one non-EFT sample, then compare SM yields;
+- compare `eval({})` and several nonzero WC points against current `HistEFT`;
+- verify category, process, systematic, and `appl` labels after pickle round
+  trip;
+- verify `_sumw2` or replacement variance behavior;
+- verify merge/add behavior for two compatible pkls;
+- verify plotting path on a small SR and CR pkl;
+- verify failure messages for unknown WCs, incompatible axes, and missing
+  sumw2 companions.
+
+## 13. Glossary
+
+`HistEFT`
+: EFT-aware histogram class implemented in `topcoffea`. Stores quadratic EFT
+  coefficient terms and evaluates bin contents at a chosen WC point.
+
+`SparseHist`
+: Sparse categorical histogram layer used by `HistEFT`. Stores dense histogram
+  blocks only for populated categorical keys.
+
+`WC`
+: Wilson coefficient.
+
+`EFTfitCoefficients`
+: Event branch containing quadratic coefficient values used by `HistEFT.fill`.
+
+`process`
+: Histogram axis label usually sourced from sample JSON `histAxisName`.
+
+`channel`
+: Histogram axis label for analysis category, sometimes including lepton flavor
+  and njet suffixes.
+
+`systematic`
+: Histogram axis label for nominal and systematic variations.
+
+`appl`
+: Histogram axis label for signal/application-region selection.
+
+`_sumw2`
+: Companion histogram key convention for storing squared-weight content.
+
+`CR`
+: Control region.
+
+`SR`
+: Signal region.
+
+`CFG`
+: Text file listing sample JSON files and optional redirector prefixes.
+
+## 14. Source map: relevant files and line ranges
+
+HistEFT and sparse histogram implementation:
+
+- `topcoffea/topcoffea/modules/histEFT.py:23-72`: class purpose and examples.
+- `topcoffea/topcoffea/modules/histEFT.py:74-126`: constructor restrictions,
+  WC metadata, and `quadratic_term` axis.
+- `topcoffea/topcoffea/modules/histEFT.py:140-163`: quadratic-term indexing.
+- `topcoffea/topcoffea/modules/histEFT.py:197-249`: EFT-aware fill.
+- `topcoffea/topcoffea/modules/histEFT.py:271-305`: `eval` and `as_hist`.
+- `topcoffea/topcoffea/modules/histEFT.py:307-319`: pickle reduce state.
+- `topcoffea/topcoffea/modules/sparseHist.py:15-39`: sparse/dense axis model.
+- `topcoffea/topcoffea/modules/sparseHist.py:124-139`: fill bookkeeping.
+- `topcoffea/topcoffea/modules/sparseHist.py:299-325`: slicing behavior.
+- `topcoffea/topcoffea/modules/sparseHist.py:349-406`: values, view,
+  integrate, and group.
+
+EFT helpers and pkl helpers:
+
+- `topcoffea/topcoffea/modules/quad_fit_tools.py:203-240`: coefficient
+  extraction and ordering.
+- `topcoffea/topcoffea/modules/eft_helper.py:208-266`: coefficient remapping.
+- `topcoffea/topcoffea/modules/utils.py:399-405`: pkl writing helper.
+- `topcoffea/topcoffea/modules/compat.py:13-39`: HistEFT pickle compatibility
+  hook used by local yield tools and the inspector.
+
+Processor:
+
+- `analysis/topeft_run2/analysis_processor.py:1-30`: imports `HistEFT`.
+- `analysis/topeft_run2/analysis_processor.py:60-99`: category group
+  resolution.
+- `analysis/topeft_run2/analysis_processor.py:112-158`: processor init and
+  histogram-name normalization.
+- `analysis/topeft_run2/analysis_processor.py:212-343`: histogram axes and
+  declarations.
+- `analysis/topeft_run2/analysis_processor.py:450-466`: sample metadata.
+- `analysis/topeft_run2/analysis_processor.py:620-631`: EFT coefficient read
+  and remap.
+- `analysis/topeft_run2/analysis_processor.py:642-719`: systematic lists.
+- `analysis/topeft_run2/analysis_processor.py:681-711`: nominal weight setup.
+- `analysis/topeft_run2/analysis_processor.py:1135-1226`: category-specific
+  weights and data-driven behavior.
+- `analysis/topeft_run2/analysis_processor.py:1230-1412`: selections.
+- `analysis/topeft_run2/analysis_processor.py:1414-1629`: dense variables.
+- `analysis/topeft_run2/analysis_processor.py:1638-1703`: category dictionary.
+- `analysis/topeft_run2/analysis_processor.py:1718-1924`: fill loop and sumw2
+  fill.
+
+Runner:
+
+- `analysis/topeft_run2/run_cr.sh:10-33`: local runner defaults.
+- `analysis/topeft_run2/run_cr.sh:72-119`: active CR block.
+- `analysis/topeft_run2/run_cr.sh:125-130`: active main CR loop.
+- `analysis/topeft_run2/run_cr.sh:177-220`: commented SR scaffold.
+- `analysis/topeft_run2/fullR3_run.sh:4-21`: usage and options.
+- `analysis/topeft_run2/fullR3_run.sh:48-116`: option parsing.
+- `analysis/topeft_run2/fullR3_run.sh:129-156`: CR/SR and year resolution.
+- `analysis/topeft_run2/fullR3_run.sh:176-185`: output-name construction.
+- `analysis/topeft_run2/fullR3_run.sh:190-270`: CFG selection.
+- `analysis/topeft_run2/fullR3_run.sh:282-337`: hist-list forwarding,
+  command construction, and dry-run exit.
+- `analysis/topeft_run2/run_analysis.py:639-860`: CLI arguments.
+- `analysis/topeft_run2/run_analysis.py:1017-1051`: output paths and test
+  mode.
+- `analysis/topeft_run2/run_analysis.py:1058-1175`: category and histogram-list
+  resolution.
+- `analysis/topeft_run2/run_analysis.py:1177-1463`: JSON/CFG loading and sample
+  setup.
+- `analysis/topeft_run2/run_analysis.py:1532-1556`: pretend mode and WC-list
+  aggregation.
+- `analysis/topeft_run2/run_analysis.py:1575-1595`: processor construction.
+- `analysis/topeft_run2/run_analysis.py:1678-1765`: runner execution and pkl
+  writing.
+
+Run 3 EFT signal sample:
+
+- `input_samples/cfgs/NDSkim_2023_mc_signal_samples_sr.cfg:7-12`: 2023 SR EFT
+  signal JSON list.
+- `input_samples/sample_jsons/signal_samples/ND_SRskim2023/ttH_NDSkim_2023.json:1-40`:
+  selected tutorial sample metadata and WC names.
+
+Plotting and yield consumers:
+
+- `analysis/topeft_run2/make_cr_and_sr_plots.py:55-110`: SparseHist pickle
+  load patch.
+- `analysis/topeft_run2/make_cr_and_sr_plots.py:732-808`: process/channel axis
+  helpers.
+- `analysis/topeft_run2/make_cr_and_sr_plots.py:1738-1767`: category and appl
+  integration.
+- `analysis/topeft_run2/make_cr_and_sr_plots.py:2365-2479`: variable payload
+  preparation.
+- `analysis/topeft_run2/make_cr_and_sr_plots.py:5810-5832`: process grouping.
+- `analysis/topeft_run2/make_cr_and_sr_plots.py:6140-6214`: systematic
+  extraction.
+- `analysis/topeft_run2/make_cr_and_sr_plots.py:6231-6277`: HistEFT value
+  evaluation.
+- `analysis/topeft_run2/make_cr_and_sr_plots.py:7528-7854`: plotter CLI,
+  loading, merging, and dispatch.
+- `topeft/modules/datacard_tools.py:175-302`: pkl loading and merge validation.
+- `topeft/modules/yield_tools.py:305-383`: axis and category label helpers.
+- `topeft/modules/yield_tools.py:475-567`: category/appl integration and yield
+  extraction.
+
+Plot metadata:
+
+- `topeft/params/cr_sr_plots_metadata.yml:20-24`: CR/SR channel-label
+  convention.
+- `topeft/params/cr_sr_plots_metadata.yml:116-352`: SR channels.
+- `topeft/params/cr_sr_plots_metadata.yml:432-503`: SR process group patterns.
+- `topeft/params/cr_sr_plots_metadata.yml:530-554`: Run 2 and Run 3 lumi
+  metadata.

--- a/docs/histeft_pkl_tutorial.md
+++ b/docs/histeft_pkl_tutorial.md
@@ -14,8 +14,10 @@ student autonomous enough to inspect pkl files and understand the current
 contracts before planning a future `scikit-hist` EFT-aware replacement.
 
 This guide does not change any physics behavior. It does not redesign HistEFT,
-the processor, `run_cr.sh`, `fullR3_run.sh`, `run_analysis.py`, plotting code,
-sample JSONs, or CFG files.
+the processor, `run_cr.sh`, `run_analysis.py`, plotting code, sample JSONs, or
+CFG files. The only runner ergonomics change documented here is an opt-in
+`fullR3_run.sh` input override for tutorial-scale dry-runs and single-sample
+tests; production defaults are unchanged.
 
 ## 2. Big picture: processor -> HistEFT/coffea output -> pkl -> plotting/inspection
 
@@ -266,7 +268,135 @@ faster loading:
 
 - `analysis/topeft_run2/make_cr_and_sr_plots.py:55-110`.
 
-## 6. How the analysis processor fills histograms
+## 6. EFT parametrization through the analysis pipeline
+
+This section follows the EFT information, not the generic event selection.
+
+### What the stored polynomial means
+
+For each event and each analysis bin, `HistEFT` stores the coefficients of a
+quadratic polynomial in the Wilson coefficients. Conceptually, the evaluated
+weight is:
+
+```text
+yield(WC) = c(sm,sm)
+          + sum_i c(wc_i,sm) * wc_i
+          + sum_i c(wc_i,wc_i) * wc_i * wc_i
+          + sum_{i>j} c(wc_i,wc_j) * wc_i * wc_j
+```
+
+The `sm*sm` term is the Standard Model contribution. Terms with one `sm` and
+one WC are linear EFT terms. Terms with two non-SM WCs are quadratic or cross
+terms. The actual coefficient order is lower triangular after prepending `SM`
+to the WC list: `SM*SM`, `wc0*SM`, `wc0*wc0`, `wc1*SM`, `wc1*wc0`,
+`wc1*wc1`, and so on. This ordering is implemented in
+`topcoffea/topcoffea/modules/quad_fit_tools.py:217-240` and the lower-triangle
+helpers in `topcoffea/topcoffea/modules/eft_helper.py:41-99`.
+
+`HistEFT.eval({})` evaluates that polynomial at all WCs equal to zero, so it
+returns the SM prediction. A nonzero point such as `eval({"ctG": 1.0})` uses the
+same stored coefficient arrays and substitutes the requested WC values.
+
+### Input metadata and WC names
+
+The Run 3 EFT signal sample JSON supplies the sample-level WC order:
+
+- `input_samples/sample_jsons/signal_samples/ND_SRskim2023/ttH_NDSkim_2023.json:1-40`:
+  `histAxisName`, `year`, and `WCnames`.
+- `input_samples/cfgs/NDSkim_2023_mc_signal_samples_sr.cfg:7-12`: the 2023 SR
+  signal CFG lists the same JSON.
+
+`run_analysis.py` loads JSONs directly or through CFG files:
+
+- `analysis/topeft_run2/run_analysis.py:1206-1260`: loads one JSON payload,
+  validates required keys, records `histAxisName`, and attaches the active
+  redirector prefix.
+- `analysis/topeft_run2/run_analysis.py:1279-1314`: parses CFG files, resolving
+  JSON paths relative to the CFG file when possible.
+- `analysis/topeft_run2/run_analysis.py:1349-1415`: applies the requested year
+  filter before processing.
+- `analysis/topeft_run2/run_analysis.py:1539-1556`: if `--wc-list` was not
+  supplied, aggregates the processor WC list from sample JSON `WCnames`.
+
+That aggregate WC list is passed into `AnalysisProcessor` at
+`analysis/topeft_run2/run_analysis.py:1575-1595`.
+
+### Event-level coefficient arrays
+
+The event files provide the per-event `EFTfitCoefficients` branch. The processor
+reads and remaps it:
+
+- `analysis/topeft_run2/analysis_processor.py:620-631`: reads
+  `events["EFTfitCoefficients"]`; if the sample WC list differs from the
+  processor WC list, calls `efth.remap_coeffs(...)`.
+- `topcoffea/topcoffea/modules/eft_helper.py:208-266`: `remap_coeffs` prepends
+  `SM`, maps old lower-triangle terms into the target WC order, drops omitted
+  WCs, and fills coefficients for missing target WCs with zero.
+
+The same event mask used for the dense histogram variable and event weight is
+also applied to the EFT coefficient array:
+
+- `analysis/topeft_run2/analysis_processor.py:1771-1817`: applies category,
+  njet, application-region, lepton-channel, and lepton-flavor masks.
+- `analysis/topeft_run2/analysis_processor.py:1866-1873`: applies any combined
+  axis finite-value mask to the weights and `eft_coeffs_cut`.
+
+### Filling HistEFT
+
+One-dimensional analysis histograms are instantiated as `HistEFT` with the
+processor WC list:
+
+- `analysis/topeft_run2/analysis_processor.py:245-292`: creates base and
+  `_sumw2` `HistEFT` objects and marks them as requiring EFT coefficients.
+
+The fill call passes categorical labels, dense values, nominal or shifted event
+weights, and `eft_coeff`:
+
+- `analysis/topeft_run2/analysis_processor.py:1900-1911`: base histogram fill
+  uses `weight=weights_flat` and `eft_coeff=eft_coeffs_cut`.
+- `analysis/topeft_run2/analysis_processor.py:1913-1924`: `_sumw2` companion
+  fills only for nominal systematics, uses `weight=np.square(weights_flat)`, and
+  passes the same `eft_coeffs_cut`.
+
+Inside `HistEFT.fill`, dense values and event weights are repeated once per
+quadratic term, the coefficient array is flattened, and the event weight is
+multiplied into every coefficient before filling the hidden `quadratic_term`
+axis. Source: `topcoffea/topcoffea/modules/histEFT.py:197-249`.
+
+If `eft_coeff` is absent or `None`, `HistEFT.fill` uses SM-only coefficients
+`[1, 0, 0, ...]` for every event. This behavior matters for non-EFT samples and
+for defensive inspection of partial outputs. Source:
+`topcoffea/topcoffea/modules/histEFT.py:214-224`.
+
+### Evaluation, systematics, and sumw2
+
+Systematics are not separate EFT polynomials. They are separate categorical
+labels on the same `systematic` axis, each filled with its own selected event
+weights and object variations:
+
+- `analysis/topeft_run2/analysis_processor.py:642-719`: systematic labels and
+  object/weight variation loops.
+- `analysis/topeft_run2/analysis_processor.py:1744-1760`: chooses the active
+  nominal or shifted weight.
+
+For a nominal SM yield, select `systematic="nominal"` and call `eval({})`. For a
+nonzero WC point, call `eval({"wc_name": value})` after the same category,
+process, and systematic selections. Unknown WC names raise a `LookupError` in
+`HistEFT._wc_for_eval`; source:
+`topcoffea/topcoffea/modules/histEFT.py:251-284`.
+
+The `_sumw2` companion histograms are filled with squared event weights and the
+same EFT coefficient arrays. They are a codebase convention for uncertainty
+handling. The plotter and datacard utilities expect base and `_sumw2` keys to
+remain compatible, so a future implementation must either preserve this
+convention or migrate the consumers at the same time:
+
+- `topeft/modules/datacard_tools.py:175-302`: validates base and `_sumw2`
+  companions during pkl loading/merging.
+- `analysis/topeft_run2/make_cr_and_sr_plots.py:6231-6277`: evaluates HistEFT
+  values at the SM point for plotting.
+
+## 7. How the analysis processor fills histograms
 
 ### Histogram declaration
 
@@ -365,12 +495,12 @@ The processor marks an event sample as Run 2 or Run 3 from the sample JSON
 
 The runner expands year aliases:
 
-- `analysis/topeft_run2/fullR3_run.sh:143-156`: `run3` expands to
+- `analysis/topeft_run2/fullR3_run.sh:165-178`: `run3` expands to
   `2022 2022EE 2023 2023BPix`.
-- `analysis/topeft_run2/fullR3_run.sh:190-270`: chooses CFG files by year and
+- `analysis/topeft_run2/fullR3_run.sh:226-316`: chooses CFG files by year and
   CR/SR mode.
 
-## 7. `run_cr.sh` as the source-of-truth runner
+## 8. `run_cr.sh` as the source-of-truth runner
 
 The source-of-truth student runner is:
 
@@ -397,21 +527,26 @@ tutorial, treat `run_cr.sh` as the source of the command shape, then use
 `fullR3_run.sh --dry-run` to source-validate the downstream command before any
 real processing.
 
-`fullR3_run.sh` provides the safe dry-run switch:
+`fullR3_run.sh` provides the safe dry-run switch and the tutorial input
+override:
 
-- `analysis/topeft_run2/fullR3_run.sh:4-21`: usage includes `--dry-run`,
-  `--cr`, `--sr`, and `--hist-vars`.
-- `analysis/topeft_run2/fullR3_run.sh:48-116`: parses command-line options.
-- `analysis/topeft_run2/fullR3_run.sh:129-135`: requires exactly one of CR or
+- `analysis/topeft_run2/fullR3_run.sh:4-25`: usage includes `--dry-run`,
+  `--cr`, `--sr`, `--hist-vars`, `--sample-json`, and `--cfg-override`.
+- `analysis/topeft_run2/fullR3_run.sh:53-138`: parses command-line options.
+- `analysis/topeft_run2/fullR3_run.sh:151-157`: requires exactly one of CR or
   SR mode.
-- `analysis/topeft_run2/fullR3_run.sh:176-185`: forms the output name as
+- `analysis/topeft_run2/fullR3_run.sh:193-206`: rejects conflicting or missing
+  tutorial input override paths.
+- `analysis/topeft_run2/fullR3_run.sh:213-222`: forms the output name as
   `<YEAR_LABEL>CRs_<TAG>` or `<YEAR_LABEL>SRs_<TAG>`.
-- `analysis/topeft_run2/fullR3_run.sh:282-289`: forwards `--hist-vars` as
+- `analysis/topeft_run2/fullR3_run.sh:271-322`: uses a single JSON/CFG override
+  when requested, otherwise uses the production CFG bundle.
+- `analysis/topeft_run2/fullR3_run.sh:331-338`: forwards `--hist-vars` as
   `--hist-list`; CR defaults to `cr`, SR defaults to `ana`.
-- `analysis/topeft_run2/fullR3_run.sh:325-337`: prints the `run_analysis.py`
+- `analysis/topeft_run2/fullR3_run.sh:373-385`: prints the `run_analysis.py`
   command and exits before running it when `--dry-run` is present.
 
-## 8. Quick-run tutorial
+## 9. Quick-run tutorial
 
 ### Choose a Run 3 EFT signal sample
 
@@ -430,42 +565,48 @@ Why this sample:
   `input_samples/sample_jsons/signal_samples/ND_SRskim2023/ttH_NDSkim_2023.json:1-40`.
 - It is an SR skim signal sample, matching the SR-oriented tutorial target.
 
-### Dry-run the source-derived SR command
+### Dry-run the one-sample SR command
 
 This is the safe command shape derived from the commented SR block in
-`run_cr.sh` and the option parser in `fullR3_run.sh`. It does not launch the
-processor because of `--dry-run`.
+`run_cr.sh` and the option parser in `fullR3_run.sh`. The explicit
+`--sample-json` option keeps the input to one Run 3 EFT signal JSON without
+editing production CFG files. It does not launch the processor because of
+`--dry-run`.
 
 ```bash
 cd /users/apiccine/work/correction-lib/topeft/analysis/topeft_run2
 
 ./fullR3_run.sh \
   -y 2023 \
-  -t CL007AA_SR_tutorial_ttH_2023_njets \
+  -t CL007AB_single_ttH_2023_njets \
   -s 1000 \
   --sr \
   --hist-vars njets \
+  --sample-json ../../input_samples/sample_jsons/signal_samples/ND_SRskim2023/ttH_NDSkim_2023.json \
   --dry-run \
   --category-groups 2l \
   --all-analysis \
-  -p /tmp/cl007aa_histeft_demo \
+  -p /tmp/cl007ab_histeft_demo \
   -x futures \
   --nworkers 1 \
   --nchunks 1 \
-  --pretend
+  --pretend \
+  --np-postprocess=skip \
+  --prefix root://cmsxrootd.crc.nd.edu/
 ```
 
 Validated dry-run output in this workspace:
 
 ```text
-OUT_NAME: 2023SRs_CL007AA_SR_tutorial_ttH_2023_njets
+OUT_NAME: 2023SRs_CL007AB_single_ttH_2023_njets
 Resolved years: 2023
-Resolved CFGS: ../../input_samples/cfgs/NDSkim_2023_background_samples.cfg,../../input_samples/cfgs/NDSkim_2023_data_samples.cfg,../../input_samples/cfgs/NDSkim_2023_mc_signal_samples_sr.cfg
+Input override: sample JSON: ../../input_samples/sample_jsons/signal_samples/ND_SRskim2023/ttH_NDSkim_2023.json
+Resolved CFGS: ../../input_samples/sample_jsons/signal_samples/ND_SRskim2023/ttH_NDSkim_2023.json
 Resolved region: SR
 Resolved histogram list: njets
 
 Running the following command:
-python run_analysis.py ../../input_samples/cfgs/NDSkim_2023_background_samples.cfg,../../input_samples/cfgs/NDSkim_2023_data_samples.cfg,../../input_samples/cfgs/NDSkim_2023_mc_signal_samples_sr.cfg --years 2023 -p /groups/klannon/apiccine/ --hist-list njets --skip-cr --do-systs --do-np -o 2023SRs_CL007AA_SR_tutorial_ttH_2023_njets -s 1000 --category-groups 2l --all-analysis -p /tmp/cl007aa_histeft_demo -x futures --nworkers 1 --nchunks 1 --pretend
+python run_analysis.py ../../input_samples/sample_jsons/signal_samples/ND_SRskim2023/ttH_NDSkim_2023.json --years 2023 -p /groups/klannon/apiccine/ --hist-list njets --skip-cr --do-systs --do-np -o 2023SRs_CL007AB_single_ttH_2023_njets -s 1000 --category-groups 2l --all-analysis -p /tmp/cl007ab_histeft_demo -x futures --nworkers 1 --nchunks 1 --pretend --np-postprocess=skip --prefix root://cmsxrootd.crc.nd.edu/
 ```
 
 Option notes:
@@ -473,13 +614,19 @@ Option notes:
 - `-y 2023`: one Run 3 year, not the full `run3` alias.
 - `--sr`: selects SR mode and makes `fullR3_run.sh` choose SR CFG files.
 - `--hist-vars njets`: asks for one small histogram variable.
+- `--sample-json .../ttH_NDSkim_2023.json`: overrides the default SR CFG bundle
+  with one EFT signal JSON. This is the tutorial-only one-sample path.
 - `--category-groups 2l`: limits category construction to the 2l SR group.
 - `--dry-run`: prints the downstream command and exits before running Python.
 - `-x futures --nworkers 1 --nchunks 1 --pretend`: bounded internal
   `run_analysis.py` options, included in the printed command. `--pretend`
   would stop `run_analysis.py` after input discovery if the dry-run guard were
   removed.
-- `-p /tmp/cl007aa_histeft_demo`: a tutorial output path. In the dry-run output
+- `--np-postprocess=skip`: prevents the SR default `--do-np` from trying to run
+  nonprompt post-processing in a one-signal-sample tutorial.
+- `--prefix root://cmsxrootd.crc.nd.edu/`: supplies the redirector that the
+  source CFG normally provides before listing this sample JSON.
+- `-p /tmp/cl007ab_histeft_demo`: a tutorial output path. In the dry-run output
   this appears after the default group output path, so argparse should use the
   later value if the command is actually run.
 
@@ -487,23 +634,46 @@ Expected pkl path for an authorized real run without `--dry-run` and without
 `--pretend`:
 
 ```text
-/tmp/cl007aa_histeft_demo/2023SRs_CL007AA_SR_tutorial_ttH_2023_njets.pkl.gz
+/tmp/cl007ab_histeft_demo/2023SRs_CL007AB_single_ttH_2023_njets.pkl.gz
 ```
 
-This path follows `fullR3_run.sh:176-185` for the output name and
+This path follows `fullR3_run.sh:213-222` for the output name and
 `run_analysis.py:1017-1019` plus `run_analysis.py:1715-1765` for the pkl write.
 
-### Important limitation: one-sample-only running
+### Prove the old CFG-bundle default still resolves
 
-The source-of-truth runner does not currently expose a public option to run
-only one JSON from the SR CFG. The dry-run command above uses the 2023 SR CFG
-set, and the chosen `ttH_NDSkim_2023.json` is one of the EFT signal JSONs in
-that CFG. A truly one-sample run would require either a temporary one-entry CFG
-or an internal direct `run_analysis.py` call. That direct path is not the
-primary student workflow; treat it as an advanced path derived from the
-dry-run output and use it only after authorization.
+When changing runner options, first dry-run without `--sample-json` to confirm
+the production CFG bundle still resolves:
 
-### If you temporarily edit `run_cr.sh` for a tutorial
+```bash
+cd /users/apiccine/work/correction-lib/topeft/analysis/topeft_run2
+
+./fullR3_run.sh \
+  -y 2023 \
+  -t CL007AB_default_dryrun \
+  -s 1000 \
+  --sr \
+  --hist-vars njets \
+  --dry-run \
+  --category-groups 2l \
+  --all-analysis \
+  -p /tmp/cl007ab_default \
+  -x futures \
+  --nworkers 1 \
+  --nchunks 1 \
+  --pretend \
+  --np-postprocess=skip
+```
+
+This dry-run should print the standard 2023 SR CFG bundle:
+
+```text
+../../input_samples/cfgs/NDSkim_2023_background_samples.cfg,
+../../input_samples/cfgs/NDSkim_2023_data_samples.cfg,
+../../input_samples/cfgs/NDSkim_2023_mc_signal_samples_sr.cfg
+```
+
+### If you temporarily edit `run_cr.sh` for a broader tutorial
 
 Do not commit such edits unless the analysis conveners request them. The active
 file currently runs CR blocks. For an SR tutorial edit, make a temporary local
@@ -515,7 +685,7 @@ change modeled on the commented SR scaffold around
 - pkl_base_tag="CR_muonres"
 - vars=(invmass tau0Tpt l0ptcorr)
 + years=(2023)
-+ pkl_base_tag="CL007AA_SR_tutorial_ttH"
++ pkl_base_tag="CL007AB_SR_tutorial_ttH"
 + vars=(njets)
 ```
 
@@ -523,7 +693,7 @@ Then use the SR scaffold, add `--dry-run` first, and keep the output path in a
 scratch location. The point is to prove command construction before launching
 any real processing.
 
-## 9. How `make_cr_and_sr_plots.py` consumes pkl files
+## 10. How `make_cr_and_sr_plots.py` consumes pkl files
 
 The plotting script accepts one or more pkl files and merges them before
 plotting:
@@ -584,29 +754,32 @@ keys, base and `_sumw2` pairing, categorical axes named `process`, `channel`,
 `systematic`, and `appl`, and explicit HistEFT evaluation before using values
 as physics yields.
 
-## 10. Manual pkl inspection
+## 11. Manual pkl inspection
 
 ### Use the helper script
+
+Before running these commands, activate the analysis environment you normally
+use for `topeft` and `topcoffea`. Codex validation uses a workspace wrapper in
+reports, but students should not copy that machinery into ordinary inspection
+commands.
 
 The helper is read-only:
 
 ```bash
-WRAP=/users/apiccine/work/correction-lib/codex-run.sh
-PYTHON_ENV=/users/apiccine/work/miniconda3/envs/clib-env/bin/python
-
-$WRAP /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && "$PYTHON_ENV" analysis/topeft_run2/inspect_histeft_pkl.py --help'
+cd /users/apiccine/work/correction-lib/topeft
+python analysis/topeft_run2/inspect_histeft_pkl.py --help
 ```
 
 Inspect a pkl:
 
 ```bash
-$WRAP /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && "$PYTHON_ENV" analysis/topeft_run2/inspect_histeft_pkl.py /path/to/output.pkl.gz --max-labels 10'
+python analysis/topeft_run2/inspect_histeft_pkl.py /path/to/output.pkl.gz --max-labels 10
 ```
 
 Inspect one histogram and ask for a simple nominal total when discoverable:
 
 ```bash
-$WRAP /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && "$PYTHON_ENV" analysis/topeft_run2/inspect_histeft_pkl.py /path/to/output.pkl.gz --hist njets --max-labels 10 --yield-summary'
+python analysis/topeft_run2/inspect_histeft_pkl.py /path/to/output.pkl.gz --hist njets --max-labels 10 --yield-summary
 ```
 
 The helper prints:
@@ -627,34 +800,31 @@ Use the same analysis environment when opening analysis pkls. A pkl may require
 List top-level keys:
 
 ```bash
-WRAP=/users/apiccine/work/correction-lib/codex-run.sh
-PYTHON_ENV=/users/apiccine/work/miniconda3/envs/clib-env/bin/python
-
-$WRAP /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && "$PYTHON_ENV" -c "import gzip,pickle; p=\"/path/to/output.pkl.gz\"; f=gzip.open(p,\"rb\") if p.endswith(\".gz\") else open(p,\"rb\"); obj=pickle.load(f); print(type(obj)); print(list(obj)[:20])"'
+python -c 'import gzip,pickle; p="/path/to/output.pkl.gz"; f=gzip.open(p,"rb") if p.endswith(".gz") else open(p,"rb"); obj=pickle.load(f); print(type(obj)); print(list(obj)[:20])'
 ```
 
 List axes for one histogram:
 
 ```bash
-$WRAP /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && "$PYTHON_ENV" -c "import gzip,pickle; p=\"/path/to/output.pkl.gz\"; obj=pickle.load(gzip.open(p,\"rb\")); h=obj[\"njets\"]; print(type(h)); print([ax.name for ax in h.axes])"'
+python -c 'import gzip,pickle; p="/path/to/output.pkl.gz"; obj=pickle.load(gzip.open(p,"rb")); h=obj["njets"]; print(type(h)); print([ax.name for ax in h.axes])'
 ```
 
 List labels on common categorical axes:
 
 ```bash
-$WRAP /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && "$PYTHON_ENV" -c "import gzip,pickle; p=\"/path/to/output.pkl.gz\"; h=pickle.load(gzip.open(p,\"rb\"))[\"njets\"]; print(list(h.axes[\"process\"])[:20]); print(list(h.axes[\"channel\"])[:20]); print(list(h.axes[\"systematic\"])[:20])"'
+python -c 'import gzip,pickle; p="/path/to/output.pkl.gz"; h=pickle.load(gzip.open(p,"rb"))["njets"]; print(list(h.axes["process"])[:20]); print(list(h.axes["channel"])[:20]); print(list(h.axes["systematic"])[:20])'
 ```
 
 Evaluate a HistEFT at the SM point and sum all returned blocks:
 
 ```bash
-$WRAP /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && "$PYTHON_ENV" -c "import gzip,pickle,numpy as np; p=\"/path/to/output.pkl.gz\"; h=pickle.load(gzip.open(p,\"rb\"))[\"njets\"]; vals=h.integrate(\"systematic\",\"nominal\").eval({}); print(sum(float(np.nansum(v)) for v in vals.values()))"'
+python -c 'import gzip,pickle,numpy as np; p="/path/to/output.pkl.gz"; h=pickle.load(gzip.open(p,"rb"))["njets"]; vals=h.integrate("systematic","nominal").eval({}); print(sum(float(np.nansum(v)) for v in vals.values()))'
 ```
 
 Compare nominal to one systematic label:
 
 ```bash
-$WRAP /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && "$PYTHON_ENV" -c "import gzip,pickle,numpy as np; p=\"/path/to/output.pkl.gz\"; h=pickle.load(gzip.open(p,\"rb\"))[\"njets\"]; nom=h.integrate(\"systematic\",\"nominal\").eval({}); up=h.integrate(\"systematic\",\"JESUp\").eval({}); print(sum(float(np.nansum(up[k]-nom.get(k,0))) for k in up))"'
+python -c 'import gzip,pickle,numpy as np; p="/path/to/output.pkl.gz"; h=pickle.load(gzip.open(p,"rb"))["njets"]; nom=h.integrate("systematic","nominal").eval({}); up=h.integrate("systematic","JESUp").eval({}); print(sum(float(np.nansum(up[k]-nom.get(k,0))) for k in up))'
 ```
 
 The last snippet assumes `JESUp` exists. Always list systematic labels first.
@@ -665,7 +835,7 @@ For a quick manual table, select one histogram, integrate one systematic label,
 then loop over process labels:
 
 ```bash
-$WRAP /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && "$PYTHON_ENV" -c "import gzip,pickle,numpy as np; p=\"/path/to/output.pkl.gz\"; h=pickle.load(gzip.open(p,\"rb\"))[\"njets\"].integrate(\"systematic\",\"nominal\"); procs=list(h.axes[\"process\"]); print(\"process yield\"); [print(proc, sum(float(np.nansum(v)) for v in h.integrate(\"process\",proc).eval({}).values())) for proc in procs[:20]]"'
+python -c 'import gzip,pickle,numpy as np; p="/path/to/output.pkl.gz"; h=pickle.load(gzip.open(p,"rb"))["njets"].integrate("systematic","nominal"); procs=list(h.axes["process"]); print("process yield"); [print(proc, sum(float(np.nansum(v)) for v in h.integrate("process",proc).eval({}).values())) for proc in procs[:20]]'
 ```
 
 This is deliberately simple. It does not group processes, handle overflow
@@ -677,18 +847,18 @@ a first sanity check, not as a publication number.
 For a `HistEFT`, inspect WC names:
 
 ```bash
-$WRAP /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && "$PYTHON_ENV" -c "import gzip,pickle; p=\"/path/to/output.pkl.gz\"; h=pickle.load(gzip.open(p,\"rb\"))[\"njets\"]; print(getattr(h,\"wc_names\", getattr(h,\"_wc_names\", None)))"'
+python -c 'import gzip,pickle; p="/path/to/output.pkl.gz"; h=pickle.load(gzip.open(p,"rb"))["njets"]; print(getattr(h,"wc_names", getattr(h,"_wc_names", None)))'
 ```
 
 Evaluate a non-SM point if the WC exists:
 
 ```bash
-$WRAP /bin/bash --noprofile --norc -c 'cd /users/apiccine/work/correction-lib/topeft && "$PYTHON_ENV" -c "import gzip,pickle,numpy as np; p=\"/path/to/output.pkl.gz\"; h=pickle.load(gzip.open(p,\"rb\"))[\"njets\"].integrate(\"systematic\",\"nominal\"); vals=h.eval({\"ctG\": 1.0}); print(sum(float(np.nansum(v)) for v in vals.values()))"'
+python -c 'import gzip,pickle,numpy as np; p="/path/to/output.pkl.gz"; h=pickle.load(gzip.open(p,"rb"))["njets"].integrate("systematic","nominal"); vals=h.eval({"ctG": 1.0}); print(sum(float(np.nansum(v)) for v in vals.values()))'
 ```
 
 If this raises a `LookupError`, the histogram WC list does not include that WC.
 
-## 11. Debugging checklist
+## 12. Debugging checklist
 
 Missing pkl:
 
@@ -762,7 +932,261 @@ Pkl too large to inspect naively:
 - For many pkls, use the plotter merge-only path or a small custom inspector
   before loading every histogram into plotting.
 
-## 12. Mapping to a future scikit-hist EFT-aware replacement
+## 13. Detailed HistEFT API reference
+
+This section documents the public and practically relevant `HistEFT` API as it
+exists now. It is source-grounded in
+`topcoffea/topcoffea/modules/histEFT.py` and inherited behavior from
+`topcoffea/topcoffea/modules/sparseHist.py`.
+
+### Constructor and core attributes
+
+`HistEFT(*args, wc_names=None, **kwargs)`
+
+Source: `topcoffea/topcoffea/modules/histEFT.py:74-126`.
+
+- `*args`: histogram axes. All axes must be named. Categorical axes should come
+  first and use growth categories. The last user axis must be the one physics
+  dense axis and must be `Regular`, `Variable`, or `Integer`.
+- `wc_names`: list of Wilson coefficient names, without `SM`. If omitted or
+  falsey, the histogram has no non-SM WCs and stores only the SM coefficient
+  term.
+- `storage`: accepted through `kwargs`, but only `"Double"` is supported. If not
+  supplied, the constructor sets it to `"Double"`.
+- `rebin`: accepted in `kwargs` but rejected when true; current HistEFT does not
+  implement rebinning.
+- `quadratic_term`: if the last supplied axis is named `quadratic_term`, HistEFT
+  uses it as the coefficient axis. Otherwise it creates a hidden
+  `hist.axis.Integer(start=0, stop=n_quad_terms, name="quadratic_term")`.
+
+Important attributes:
+
+- `_wc_names`: ordered mapping from WC name to WC index.
+- `_wc_count`: number of non-SM WCs.
+- `_quad_count`: number of stored quadratic terms, from
+  `efth.n_quad_terms(n_wc)` at `eft_helper.py:41-46`.
+- `_coeff_axis`: hidden `quadratic_term` axis.
+- `_dense_axis`: user physics dense axis.
+- `_dense_hists`: inherited sparse storage dictionary mapping categorical keys
+  to dense `hist.Hist` blocks.
+- `_init_args_eft`: stores `wc_names` for copy/pickle reconstruction.
+
+Reserved axis names are `quadratic_term`, `sample`, `weight`, and `thread`.
+These are rejected at construction time.
+
+### WC metadata helpers
+
+`wc_names`
+
+Source: `histEFT.py:133-135`.
+
+Returns a list of WC names in the histogram order. The current implementation
+builds this from `_wc_names`; students should treat the returned order as the
+evaluation order for array-style WC values.
+
+`index_of_wc(wc)`
+
+Source: `histEFT.py:137-138`.
+
+Returns the integer index of one WC in `_wc_names`. Unknown names propagate a
+`KeyError`. This is mainly a helper for `quadratic_term_index`.
+
+`quadratic_term_index(*wcs)`
+
+Source: `histEFT.py:140-163`.
+
+Takes exactly two coefficient names and returns the lower-triangle coefficient
+index. `"sm"` maps to 0; non-SM names map to `index_of_wc(name) + 1`. The method
+orders the two factors internally, so `("sm", "ctG")` and `("ctG", "sm")`
+resolve to the same term. This method is public enough that a replacement should
+reproduce it unless all downstream coefficient-axis inspection is migrated.
+
+### Fill API
+
+`fill(eft_coeff=None, **values)`
+
+Source: `histEFT.py:197-249`.
+
+Expected keyword payload in this analysis:
+
+- scalar categorical labels: `process`, `channel`, `systematic`, and `appl`;
+- one dense variable array whose keyword is the physics variable name;
+- `weight`: one event weight per selected event;
+- `eft_coeff`: array shaped like `(n_events, n_quad_terms)`.
+
+If `eft_coeff` is `None`, HistEFT broadcasts SM-only coefficients
+`[1, 0, 0, ...]` for every event. During filling, the dense variable and event
+weight are repeated once per quadratic term, the coefficient array is flattened,
+and `weight` is multiplied into every coefficient. Then the inherited
+`SparseHist.fill` receives the repeated dense values, the repeated
+`quadratic_term` indices, scalar categories, and the flattened weighted
+coefficients as the dense histogram weight.
+
+The method annotation says it returns `Self`, but the implementation delegates
+to `super().fill(...)` without returning that result. Current processor code
+does not rely on a return value. A drop-in replacement should either preserve
+this benign behavior or audit all callers before changing it.
+
+Internal helpers used by `fill`:
+
+- `_fill_flatten(a, n_events)`, source `histEFT.py:172-188`: accepts scalar-like,
+  1D, or `(n_events, 1)` arrays and repeats event values over quadratic terms.
+  It raises `ValueError` for incompatible dimensions.
+- `_fill_indices(n_events)`, source `histEFT.py:190-195`: creates repeated
+  `quadratic_term` indices for all events.
+
+### Evaluation API
+
+`eval(values)`
+
+Source: `histEFT.py:271-284`.
+
+Evaluates every populated categorical block at one WC point and returns a
+dictionary from sparse categorical key tuples to NumPy arrays over the user
+dense axis, including flow bins. Accepted `values` are:
+
+- `None`: all WCs zero;
+- mapping such as `{"ctG": 1.0}`: unspecified WCs are zero;
+- array-like: interpreted in `wc_names` order.
+
+Internally, `eval` calls `self.view(flow=True, as_dict=True)` and passes the
+stored coefficient arrays, excluding the coefficient-axis flow columns with
+`hvs[..., 1:-1]`, to `efth.calc_eft_weights(...)`.
+
+`_wc_for_eval(values)`
+
+Source: `histEFT.py:251-269`.
+
+Normalizes mapping, array, or `None` inputs into a WC-value array. Unknown WC
+names raise `LookupError` with the known coefficient list. Plotting and manual
+inspection rely on this error being clear.
+
+`as_hist(values)`
+
+Source: `histEFT.py:286-305`.
+
+Evaluates the histogram and materializes a regular `hist.Hist` without the
+hidden `quadratic_term` axis. It is useful for plotting or for APIs that need a
+normal histogram after choosing one WC point.
+
+`calc_eft_weights(q_coeffs, wc_values)`
+
+Source: `histEFT.py:358-388`.
+
+Local method equivalent in spirit to `eft_helper.calc_eft_weights`, but adjusted
+for coefficient-axis flow columns. The comment says it should move to
+`eft_helper` once HistEFT is replaced. Current `eval` uses
+`efth.calc_eft_weights(...)`, so treat this method as a compatibility/internal
+helper unless a caller is found.
+
+### Values, variances, and views
+
+`HistEFT` does not define its own `variances(...)` method. The current analysis
+uses base histograms plus `_sumw2` companion histograms for uncertainty
+handling. A manual inspector should evaluate the base HistEFT for yields and use
+the matching `_sumw2` key when it needs the squared-weight convention used by
+the plotter/datacard code.
+
+Inherited from `SparseHist`:
+
+- `values(flow=False)`, source `sparseHist.py:327-350`: recursively returns dense
+  histogram `.values(...)` arrays over populated categorical keys as an awkward
+  structure. For raw HistEFT, this exposes stored coefficient-axis content, not
+  evaluated physics yields.
+- `counts(flow=False)`, source `sparseHist.py:352-353`: delegates to dense
+  histogram counts.
+- `view(flow=False, as_dict=True)`, source `sparseHist.py:362-371`: returns a
+  dictionary from categorical key tuple to dense histogram view. HistEFT
+  evaluation depends on `as_dict=True`.
+
+### Slicing, integration, grouping, and category management
+
+Inherited practical API from `SparseHist`:
+
+- `__getitem__(key)`, source `sparseHist.py:299-325`: supports mapping-style
+  selection such as `h[{"systematic": "nominal"}]`. Depending on what axes
+  collapse, it returns a new sparse histogram, a dense `hist.Hist`, or a scalar.
+- `__setitem__(key, value)`, source `sparseHist.py:273-297`: assigns into one
+  categorical key/dense selection. Plotting code can rely on assignment when
+  constructing derived histograms.
+- `integrate(name, value=None)`, source `sparseHist.py:373-376`: implemented as
+  slicing; `value=None` means sum over that axis.
+- `group(axis_name, groups)`, source `sparseHist.py:378-406`: creates a new
+  sparse histogram where selected categorical bins are merged into named groups.
+  Process grouping in plotting depends on this behavior.
+- `remove(axis_name, bins)` and `prune(axis, to_keep)`, source
+  `sparseHist.py:408-433`: remove categorical labels or keep only a subset.
+- `categorical_axes`, `dense_axes`, and `categorical_keys`, source
+  `sparseHist.py:111-122`: expose sparse/dense axis metadata and populated
+  categorical keys.
+
+### Copy, identity, arithmetic, and merging
+
+Inherited from `SparseHist`:
+
+- `empty_from_axes(...)`, source `histEFT.py:128-131` and `sparseHist.py:60-70`:
+  creates an empty histogram of the same class, preserving `wc_names`.
+- `__copy__` and `__deepcopy__`, source `sparseHist.py:75-83`: copy empty or
+  populated sparse histograms.
+- `reset()` and `empty()`, source `sparseHist.py:355-443`: reset dense blocks and
+  test whether all dense views are zero.
+- `scale(factor)`, source `sparseHist.py:435-437`: in-place scalar
+  multiplication and returns `self`.
+- arithmetic methods, source `sparseHist.py:445-522`: in-place and out-of-place
+  addition/multiplication/division delegate to dense histograms. SparseHist merge
+  requires categorical axis names and order to match.
+- `identity()`, source `sparseHist.py:524-529`: deprecated old-coffea
+  compatibility helper returning an empty copy.
+
+These methods are important for coffea accumulation, pkl merging, and plotting.
+A drop-in replacement must support compatible addition and in-place addition at
+minimum.
+
+### Pickle compatibility
+
+`HistEFT.__reduce__`
+
+Source: `histEFT.py:307-319`.
+
+Pickle state contains categorical axes, the user dense axis, initialization
+arguments including `wc_names`, and `_dense_hists`. `_read_from_reduce` delegates
+to `SparseHist` reconstruction at `histEFT.py:354-356` and
+`sparseHist.py:477-483`.
+
+The plotting script installs a compatibility fast loader for `SparseHist`
+reduce state:
+
+- `analysis/topeft_run2/make_cr_and_sr_plots.py:55-110`.
+
+Future replacements need a documented serialization story: either old HistEFT
+pkls remain readable, or a converter and a compatibility boundary must be
+provided before production outputs are migrated.
+
+### Public API versus implementation detail
+
+Treat these as current public or practically public:
+
+- constructor call pattern;
+- `wc_names`;
+- `quadratic_term_index`;
+- `fill(eft_coeff=..., weight=..., <axis names>=...)`;
+- `eval`, `as_hist`;
+- `.axes`, `.integrate`, `.group`, `.remove`, `.prune`, `.values`, `.view`;
+- arithmetic/add/merge behavior;
+- pickle load/save compatibility.
+
+Treat these as implementation details unless a caller is found:
+
+- `_wc_names`, `_quad_count`, `_coeff_axis`, `_dense_hists`;
+- `_fill_flatten`, `_fill_indices`, `_wc_for_eval`;
+- the local `HistEFT.calc_eft_weights` method;
+- exact internal awkward layout from `SparseHist.values`.
+
+The future replacement can hide or redesign the internal pieces only if the
+processor, plotter, yield tools, datacard tools, and pkl compatibility plan are
+updated together.
+
+## 14. Mapping to a future scikit-hist EFT-aware replacement
 
 A future `scikit-hist` EFT-aware histogram class must reproduce current
 behavior before it can replace `HistEFT` safely.
@@ -772,8 +1196,12 @@ Core histogram behavior:
 - accept named categorical axes and dense axes;
 - preserve sparse categorical behavior or provide an equivalent memory-safe
   representation;
+- preserve the current constructor call shape from `analysis_processor.py:245-292`
+  or provide a small adapter with identical behavior;
 - support fill calls with scalar categorical labels, dense arrays, event
   weights, and optional EFT coefficient arrays;
+- preserve the current "one user dense axis plus hidden EFT coefficient axis"
+  semantics unless the processor fill path is migrated at the same time;
 - support addition and in-place addition for merging pkl outputs;
 - support pruning, removal, grouping, slicing, projection, and integration
   patterns used by the processor and plotter.
@@ -805,7 +1233,10 @@ EFT coefficient storage and evaluation:
 - reproduce `fill(eft_coeff=...)` semantics from `histEFT.py:197-249`,
   including SM-only default coefficients for non-EFT samples;
 - reproduce `eval({})`, `eval({"wc": value})`, and unknown-WC error behavior;
-- support coefficient remapping or define a stricter common WC-list contract.
+- support coefficient remapping or define a stricter common WC-list contract;
+- keep coefficient evaluation independent of process/channel/systematic slicing,
+  because the current plotter first slices/group/integrates and then evaluates
+  the selected HistEFT object at the SM point.
 
 Systematic variation handling:
 
@@ -820,6 +1251,9 @@ Processor API assumptions:
   calls `HistEFT(...)`;
 - `fill` accepts `process=`, `channel=`, `systematic=`, `appl=`, dense variable
   keyword, `weight=`, and `eft_coeff=`;
+- `fill` tolerates `eft_coeff=None` by filling SM-only coefficients;
+- event weights multiply EFT coefficients during fill, not during later
+  evaluation;
 - histograms are pickleable and mergeable after coffea execution;
 - 2D non-EFT histograms can remain separate if the first replacement only
   targets 1D EFT-aware histograms.
@@ -831,7 +1265,10 @@ Plotting API assumptions:
   `.prune(...)`, `.values(...)`, and HistEFT-like `.eval(...)`;
 - process grouping and channel integration work with existing labels;
 - `load_and_merge_histogram_pkls` compatibility checks can validate axes,
-  dense binning, and WC metadata.
+  dense binning, and WC metadata;
+- `eval({})` returns a dictionary of arrays over dense bins, including a
+  flow-bin policy compatible with `_values_with_flow_or_overflow` in
+  `make_cr_and_sr_plots.py:6231-6277`.
 
 Serialization compatibility:
 
@@ -848,7 +1285,10 @@ What can be simplified if plotting migrates too:
 - sumw2 handling can be made explicit as variance storage instead of separate
   top-level keys;
 - WC evaluation can return regular `hist` or `scikit-hist` objects with a
-  documented flow-bin convention.
+  documented flow-bin convention;
+- old pkl support can be isolated in a converter rather than in the new runtime
+  class, if the migration plan includes converting or regenerating existing
+  outputs.
 
 Tests to write before swapping implementation:
 
@@ -862,7 +1302,7 @@ Tests to write before swapping implementation:
 - verify failure messages for unknown WCs, incompatible axes, and missing
   sumw2 companions.
 
-## 13. Glossary
+## 15. Glossary
 
 `HistEFT`
 : EFT-aware histogram class implemented in `topcoffea`. Stores quadratic EFT
@@ -903,7 +1343,7 @@ Tests to write before swapping implementation:
 `CFG`
 : Text file listing sample JSON files and optional redirector prefixes.
 
-## 14. Source map: relevant files and line ranges
+## 16. Source map: relevant files and line ranges
 
 HistEFT and sparse histogram implementation:
 
@@ -911,19 +1351,32 @@ HistEFT and sparse histogram implementation:
 - `topcoffea/topcoffea/modules/histEFT.py:74-126`: constructor restrictions,
   WC metadata, and `quadratic_term` axis.
 - `topcoffea/topcoffea/modules/histEFT.py:140-163`: quadratic-term indexing.
+- `topcoffea/topcoffea/modules/histEFT.py:172-195`: fill-shape helpers.
 - `topcoffea/topcoffea/modules/histEFT.py:197-249`: EFT-aware fill.
+- `topcoffea/topcoffea/modules/histEFT.py:251-269`: WC-value normalization.
 - `topcoffea/topcoffea/modules/histEFT.py:271-305`: `eval` and `as_hist`.
 - `topcoffea/topcoffea/modules/histEFT.py:307-319`: pickle reduce state.
+- `topcoffea/topcoffea/modules/histEFT.py:321-388`: scaling helper and local
+  EFT-weight evaluator.
 - `topcoffea/topcoffea/modules/sparseHist.py:15-39`: sparse/dense axis model.
 - `topcoffea/topcoffea/modules/sparseHist.py:124-139`: fill bookkeeping.
-- `topcoffea/topcoffea/modules/sparseHist.py:299-325`: slicing behavior.
+- `topcoffea/topcoffea/modules/sparseHist.py:273-325`: assignment and slicing
+  behavior.
 - `topcoffea/topcoffea/modules/sparseHist.py:349-406`: values, view,
   integrate, and group.
+- `topcoffea/topcoffea/modules/sparseHist.py:408-529`: remove, prune, scale,
+  arithmetic, pickle reconstruction, and identity.
 
 EFT helpers and pkl helpers:
 
 - `topcoffea/topcoffea/modules/quad_fit_tools.py:203-240`: coefficient
   extraction and ordering.
+- `topcoffea/topcoffea/modules/eft_helper.py:9-46`: EFT polynomial evaluation
+  and quadratic-term count.
+- `topcoffea/topcoffea/modules/eft_helper.py:80-99`: lower-triangle quadratic
+  term/factor mapping.
+- `topcoffea/topcoffea/modules/eft_helper.py:132-206`: quartic/squared-weight
+  coefficient helpers.
 - `topcoffea/topcoffea/modules/eft_helper.py:208-266`: coefficient remapping.
 - `topcoffea/topcoffea/modules/utils.py:399-405`: pkl writing helper.
 - `topcoffea/topcoffea/modules/compat.py:13-39`: HistEFT pickle compatibility
@@ -957,12 +1410,14 @@ Runner:
 - `analysis/topeft_run2/run_cr.sh:72-119`: active CR block.
 - `analysis/topeft_run2/run_cr.sh:125-130`: active main CR loop.
 - `analysis/topeft_run2/run_cr.sh:177-220`: commented SR scaffold.
-- `analysis/topeft_run2/fullR3_run.sh:4-21`: usage and options.
-- `analysis/topeft_run2/fullR3_run.sh:48-116`: option parsing.
-- `analysis/topeft_run2/fullR3_run.sh:129-156`: CR/SR and year resolution.
-- `analysis/topeft_run2/fullR3_run.sh:176-185`: output-name construction.
-- `analysis/topeft_run2/fullR3_run.sh:190-270`: CFG selection.
-- `analysis/topeft_run2/fullR3_run.sh:282-337`: hist-list forwarding,
+- `analysis/topeft_run2/fullR3_run.sh:4-25`: usage and options.
+- `analysis/topeft_run2/fullR3_run.sh:53-138`: option parsing.
+- `analysis/topeft_run2/fullR3_run.sh:151-206`: CR/SR, year, and input-override
+  validation.
+- `analysis/topeft_run2/fullR3_run.sh:213-222`: output-name construction.
+- `analysis/topeft_run2/fullR3_run.sh:226-322`: CFG selection and
+  `--sample-json`/`--cfg-override` handling.
+- `analysis/topeft_run2/fullR3_run.sh:331-385`: hist-list forwarding,
   command construction, and dry-run exit.
 - `analysis/topeft_run2/run_analysis.py:639-860`: CLI arguments.
 - `analysis/topeft_run2/run_analysis.py:1017-1051`: output paths and test

--- a/input_samples/cfgs/mc_background_samples_cr_NDSkim.cfg
+++ b/input_samples/cfgs/mc_background_samples_cr_NDSkim.cfg
@@ -14,33 +14,33 @@ root://cmsxrootd.crc.nd.edu/
 # ../../input_samples/sample_jsons/background_samples/central_UL/UL16APV_WJetsToLNu_NDSkim.json
 ../../input_samples/sample_jsons/background_samples/central_UL/WJetsToLNu_centralUL16APV_NDSkim_2016APV.json
 
-# # Central UL16 background samples
-# root://cmsxrootd.crc.nd.edu/
-# #file:///cms/cephfs/data/
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL16_ZGToLLG_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL16_DY10to50_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL16_DY50_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL16_ST_antitop_t-channel_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL16_ST_top_s-channel_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL16_ST_top_t-channel_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL16_tbarW_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL16_tW_NDSkim.json
-# # ../../input_samples/sample_jsons/background_samples/central_UL/UL16_WJetsToLNu_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/WJetsToLNu_centralUL16_NDSkim_2016.json
+# Central UL16 background samples
+root://cmsxrootd.crc.nd.edu/
+#file:///cms/cephfs/data/
+../../input_samples/sample_jsons/background_samples/central_UL/UL16_ZGToLLG_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/UL16_DY10to50_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/UL16_DY50_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/UL16_ST_antitop_t-channel_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/UL16_ST_top_s-channel_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/UL16_ST_top_t-channel_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/UL16_tbarW_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/UL16_tW_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL/UL16_WJetsToLNu_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/WJetsToLNu_centralUL16_NDSkim_2016.json
 
-# # Central UL17 background samples
-# root://cmsxrootd.crc.nd.edu/
-# #file:///cms/cephfs/data/
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL17_ZGToLLG_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL17_DY10to50_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL17_DY50_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL17_ST_antitop_t-channel_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL17_ST_top_s-channel_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL17_ST_top_t-channel_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL17_tbarW_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL17_tW_NDSkim.json
-# # ../../input_samples/sample_jsons/background_samples/central_UL/UL17_WJetsToLNu_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/WJetsToLNu_centralUL17_NDSkim_2017.json
+# Central UL17 background samples
+root://cmsxrootd.crc.nd.edu/
+#file:///cms/cephfs/data/
+../../input_samples/sample_jsons/background_samples/central_UL/UL17_ZGToLLG_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/UL17_DY10to50_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/UL17_DY50_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/UL17_ST_antitop_t-channel_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/UL17_ST_top_s-channel_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/UL17_ST_top_t-channel_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/UL17_tbarW_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/UL17_tW_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL/UL17_WJetsToLNu_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/WJetsToLNu_centralUL17_NDSkim_2017.json
 
 # # Central UL18 background samples
 root://cmsxrootd.crc.nd.edu/

--- a/input_samples/cfgs/mc_background_samples_cr_NDSkim.cfg
+++ b/input_samples/cfgs/mc_background_samples_cr_NDSkim.cfg
@@ -11,37 +11,38 @@ root://cmsxrootd.crc.nd.edu/
 ../../input_samples/sample_jsons/background_samples/central_UL/UL16APV_ST_top_t-channel_NDSkim.json
 ../../input_samples/sample_jsons/background_samples/central_UL/UL16APV_tbarW_NDSkim.json
 ../../input_samples/sample_jsons/background_samples/central_UL/UL16APV_tW_NDSkim.json
-../../input_samples/sample_jsons/background_samples/central_UL/UL16APV_WJetsToLNu_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL/UL16APV_WJetsToLNu_NDSkim.json
+../../input_samples/sample_jsons/background_samples/central_UL/WJetsToLNu_centralUL16APV_NDSkim_2016APV.json
 
-# Central UL16 background samples
-root://cmsxrootd.crc.nd.edu/
-#file:///cms/cephfs/data/
-../../input_samples/sample_jsons/background_samples/central_UL/UL16_ZGToLLG_NDSkim.json
-../../input_samples/sample_jsons/background_samples/central_UL/UL16_DY10to50_NDSkim.json
-../../input_samples/sample_jsons/background_samples/central_UL/UL16_DY50_NDSkim.json
-../../input_samples/sample_jsons/background_samples/central_UL/UL16_ST_antitop_t-channel_NDSkim.json
-../../input_samples/sample_jsons/background_samples/central_UL/UL16_ST_top_s-channel_NDSkim.json
-../../input_samples/sample_jsons/background_samples/central_UL/UL16_ST_top_t-channel_NDSkim.json
-../../input_samples/sample_jsons/background_samples/central_UL/UL16_tbarW_NDSkim.json
-../../input_samples/sample_jsons/background_samples/central_UL/UL16_tW_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL16_WJetsToLNu_NDSkim.json
-../../input_samples/sample_jsons/background_samples/central_UL/WJetsToLNu_centralUL16_NDSkim_2016.json
+# # Central UL16 background samples
+# root://cmsxrootd.crc.nd.edu/
+# #file:///cms/cephfs/data/
+# ../../input_samples/sample_jsons/background_samples/central_UL/UL16_ZGToLLG_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL/UL16_DY10to50_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL/UL16_DY50_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL/UL16_ST_antitop_t-channel_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL/UL16_ST_top_s-channel_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL/UL16_ST_top_t-channel_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL/UL16_tbarW_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL/UL16_tW_NDSkim.json
+# # ../../input_samples/sample_jsons/background_samples/central_UL/UL16_WJetsToLNu_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL/WJetsToLNu_centralUL16_NDSkim_2016.json
 
-# Central UL17 background samples
-root://cmsxrootd.crc.nd.edu/
-#file:///cms/cephfs/data/
-../../input_samples/sample_jsons/background_samples/central_UL/UL17_ZGToLLG_NDSkim.json
-../../input_samples/sample_jsons/background_samples/central_UL/UL17_DY10to50_NDSkim.json
-../../input_samples/sample_jsons/background_samples/central_UL/UL17_DY50_NDSkim.json
-../../input_samples/sample_jsons/background_samples/central_UL/UL17_ST_antitop_t-channel_NDSkim.json
-../../input_samples/sample_jsons/background_samples/central_UL/UL17_ST_top_s-channel_NDSkim.json
-../../input_samples/sample_jsons/background_samples/central_UL/UL17_ST_top_t-channel_NDSkim.json
-../../input_samples/sample_jsons/background_samples/central_UL/UL17_tbarW_NDSkim.json
-../../input_samples/sample_jsons/background_samples/central_UL/UL17_tW_NDSkim.json
-# ../../input_samples/sample_jsons/background_samples/central_UL/UL17_WJetsToLNu_NDSkim.json
-../../input_samples/sample_jsons/background_samples/central_UL/WJetsToLNu_centralUL17_NDSkim_2017.json
+# # Central UL17 background samples
+# root://cmsxrootd.crc.nd.edu/
+# #file:///cms/cephfs/data/
+# ../../input_samples/sample_jsons/background_samples/central_UL/UL17_ZGToLLG_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL/UL17_DY10to50_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL/UL17_DY50_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL/UL17_ST_antitop_t-channel_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL/UL17_ST_top_s-channel_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL/UL17_ST_top_t-channel_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL/UL17_tbarW_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL/UL17_tW_NDSkim.json
+# # ../../input_samples/sample_jsons/background_samples/central_UL/UL17_WJetsToLNu_NDSkim.json
+# ../../input_samples/sample_jsons/background_samples/central_UL/WJetsToLNu_centralUL17_NDSkim_2017.json
 
-# Central UL18 background samples
+# # Central UL18 background samples
 root://cmsxrootd.crc.nd.edu/
 #file:///cms/cephfs/data/
 ../../input_samples/sample_jsons/background_samples/central_UL/UL18_ZGToLLG_NDSkim.json

--- a/input_samples/sample_jsons/background_samples/central_UL/WJetsToLNu_centralUL18_NDSkim_2018.json
+++ b/input_samples/sample_jsons/background_samples/central_UL/WJetsToLNu_centralUL18_NDSkim_2018.json
@@ -6,8 +6,7 @@
   "options": "",
   "WCnames": [],
   "files": [
-    "/store/user/apiccine/skimmed_CR/background/NAOD_ULv9_lepMVA-run2/2018/v260603/WJetsToLNu_centralUL18_2018/output_55.root",
-    "/store/user/apiccine/skimmed_CR/background/NAOD_ULv9_lepMVA-run2/2018/v260603/WJetsToLNu_centralUL18_2018/output_56.root"
+    "/store/user/apiccine/skimmed_CR/background/NAOD_ULv9_lepMVA-run2/2018/v260605/WJetsToLNu_centralUL18_2018/output_55.root"
   ],
   "nEvents": 29117828,
   "nGenEvents": 29117828,

--- a/tests/test_histeft_api_contract.py
+++ b/tests/test_histeft_api_contract.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import pickle
+
+import pytest
+
+hist = pytest.importorskip("hist")
+np = pytest.importorskip("numpy")
+
+from topcoffea.modules.histEFT import HistEFT
+
+
+def _make_histeft(dense_name: str = "x", wc_names: list[str] | None = None) -> HistEFT:
+    return HistEFT(
+        hist.axis.StrCategory([], name="process", growth=True),
+        hist.axis.StrCategory([], name="channel", growth=True),
+        hist.axis.StrCategory([], name="systematic", growth=True),
+        hist.axis.StrCategory([], name="appl", growth=True),
+        hist.axis.Regular(2, 0.0, 2.0, name=dense_name),
+        wc_names=wc_names or ["ctG", "cpt"],
+        label="Events",
+    )
+
+
+def _only_eval_array(histo: HistEFT, wc_values: dict[str, float] | None = None) -> np.ndarray:
+    evaluated = histo.eval({} if wc_values is None else wc_values)
+    assert len(evaluated) == 1
+    return np.asarray(next(iter(evaluated.values())), dtype=float)
+
+
+def test_quadratic_term_order_matches_current_lower_triangle_contract():
+    histo = _make_histeft()
+
+    assert histo.wc_names == ["ctG", "cpt"]
+    assert histo.quadratic_term_index("sm", "sm") == 0
+    assert histo.quadratic_term_index("ctG", "sm") == 1
+    assert histo.quadratic_term_index("ctG", "ctG") == 2
+    assert histo.quadratic_term_index("cpt", "sm") == 3
+    assert histo.quadratic_term_index("cpt", "ctG") == 4
+    assert histo.quadratic_term_index("cpt", "cpt") == 5
+
+
+def test_fill_weights_and_eval_match_two_wc_polynomial_contract():
+    histo = _make_histeft()
+    coeffs = np.asarray(
+        [
+            [1.0, 2.0, 3.0, 5.0, 7.0, 11.0],
+            [4.0, -1.0, 0.5, 3.0, -2.0, 0.25],
+        ]
+    )
+
+    histo.fill(
+        process="ttH",
+        channel="2lss",
+        systematic="nominal",
+        appl="isSR",
+        x=np.asarray([0.25, 1.25]),
+        weight=np.asarray([2.0, -1.0]),
+        eft_coeff=coeffs,
+    )
+
+    np.testing.assert_allclose(_only_eval_array(histo), [0.0, 2.0, -4.0, 0.0])
+    np.testing.assert_allclose(
+        _only_eval_array(histo, {"ctG": 1.0, "cpt": 2.0}),
+        [0.0, 148.0, -6.5, 0.0],
+    )
+
+
+def test_missing_eft_coeff_fills_sm_only_and_unknown_wc_raises():
+    histo = _make_histeft()
+    histo.fill(
+        process="background",
+        channel="3l",
+        systematic="nominal",
+        appl="isCR",
+        x=np.asarray([0.25]),
+        weight=np.asarray([3.0]),
+    )
+
+    np.testing.assert_allclose(_only_eval_array(histo), [0.0, 3.0, 0.0, 0.0])
+    np.testing.assert_allclose(
+        _only_eval_array(histo, {"ctG": 2.0, "cpt": -4.0}),
+        [0.0, 3.0, 0.0, 0.0],
+    )
+    with pytest.raises(LookupError, match="does not know about"):
+        histo.eval({"unknown_wc": 1.0})
+
+
+def test_integrate_group_copy_add_and_as_hist_cover_consumer_operations():
+    histo = _make_histeft(wc_names=[])
+    for process, x_value, weight in (
+        ("a", 0.25, 1.0),
+        ("b", 1.25, 2.0),
+        ("c", 1.25, 4.0),
+    ):
+        histo.fill(
+            process=process,
+            channel="2lss",
+            systematic="nominal",
+            appl="isSR",
+            x=np.asarray([x_value]),
+            weight=np.asarray([weight]),
+        )
+
+    nominal = histo.integrate("systematic", "nominal")
+    grouped = nominal.group("process", {"combo": ["a", "b"]})
+    grouped_dense = grouped.as_hist({})
+
+    np.testing.assert_allclose(
+        grouped_dense[
+            {"process": "combo", "channel": "2lss", "appl": "isSR"}
+        ].values(flow=True),
+        [0.0, 1.0, 2.0, 0.0],
+    )
+
+    copied = grouped.copy()
+    copied += grouped
+    np.testing.assert_allclose(
+        copied.as_hist({})[
+            {"process": "combo", "channel": "2lss", "appl": "isSR"}
+        ].values(flow=True),
+        [0.0, 2.0, 4.0, 0.0],
+    )
+
+
+def test_pickle_round_trip_preserves_wc_metadata_and_sumw2_companion_shape():
+    histo = _make_histeft()
+    sumw2 = _make_histeft(dense_name="x_sumw2")
+    coeffs = np.asarray([[1.0, 0.5, 0.25, -1.0, 0.0, 2.0]])
+
+    fill_payload = {
+        "process": "ttH",
+        "channel": "2lss",
+        "systematic": "nominal",
+        "appl": "isSR",
+        "x": np.asarray([0.25]),
+        "weight": np.asarray([2.0]),
+        "eft_coeff": coeffs,
+    }
+    histo.fill(**fill_payload)
+
+    sumw2_payload = dict(fill_payload)
+    sumw2_payload.pop("x")
+    sumw2_payload["x_sumw2"] = np.asarray([0.25])
+    sumw2_payload["weight"] = np.square(fill_payload["weight"])
+    sumw2.fill(**sumw2_payload)
+
+    restored = pickle.loads(pickle.dumps({"x": histo, "x_sumw2": sumw2}))
+
+    assert set(restored) == {"x", "x_sumw2"}
+    assert restored["x"].wc_names == ["ctG", "cpt"]
+    assert restored["x_sumw2"].wc_names == ["ctG", "cpt"]
+    np.testing.assert_allclose(_only_eval_array(restored["x"]), [0.0, 2.0, 0.0, 0.0])
+    np.testing.assert_allclose(
+        _only_eval_array(restored["x_sumw2"]),
+        [0.0, 4.0, 0.0, 0.0],
+    )

--- a/tests/test_muon_momentum_correction_order.py
+++ b/tests/test_muon_momentum_correction_order.py
@@ -1,4 +1,3 @@
-import inspect
 from pathlib import Path
 
 import awkward as ak
@@ -481,9 +480,9 @@ def test_processors_build_loop_local_lepton_state(processor_name):
 def test_processors_apply_tau_shifts_before_loop_local_selection(processor_name):
     source = _processor_source(processor_name)
     syst_loop = source.index("for syst_var in syst_var_list:")
-    attach = source.index("tau_energy_views = AttachTauEnergyCorrections(")
+    attach = source.index("taus = AttachTauEnergyCorrections(")
     selector = source.index(
-        "tau = ApplyTauEnergySystematics(tau_energy_views, syst_var)",
+        "tau = ApplyTauEnergySystematics(taus, syst_var)",
         syst_loop,
     )
     tau_pres = source.index('tau["isPres', selector)
@@ -497,19 +496,13 @@ def test_processors_apply_tau_shifts_before_loop_local_selection(processor_name)
     assert attach < syst_loop < selector < tau_pres
     assert tau_pres < tau_clean < tau_good < tau_select
     assert tau_select < jet_cleaning
-    active_tau_block = source[selector:tau_pres]
-    assert "ApplyTES(" not in active_tau_block
-    assert "ApplyTESSystematic(" not in active_tau_block
-    assert "ApplyFESSystematic(" not in active_tau_block
+    assert "ApplyTES" not in source
+    assert "ApplyTESSystematic" not in source
+    assert "ApplyFESSystematic" not in source
+    assert "tau_energy_views" not in source
 
 
-def test_tau_correction_function_signatures_are_unchanged():
-    assert str(inspect.signature(corrections.ApplyTES)) == (
-        "(year, taus, isData, vsJetWP='Loose')"
-    )
-    assert str(inspect.signature(corrections.ApplyTESSystematic)) == (
-        "(year, taus, isData, syst_name, vsJetWP='Loose')"
-    )
-    assert str(inspect.signature(corrections.ApplyFESSystematic)) == (
-        "(year, taus, isData, syst_name, vsJetWP='Loose')"
-    )
+def test_legacy_tau_correction_helpers_are_removed():
+    assert not hasattr(corrections, "ApplyTES")
+    assert not hasattr(corrections, "ApplyTESSystematic")
+    assert not hasattr(corrections, "ApplyFESSystematic")

--- a/tests/test_muon_momentum_correction_order.py
+++ b/tests/test_muon_momentum_correction_order.py
@@ -1,0 +1,112 @@
+from pathlib import Path
+
+import awkward as ak
+import pytest
+
+from topeft.modules import corrections
+from topeft.modules import object_selection
+
+
+class _ThresholdSelection:
+    def coneptMuon(self, muons):
+        return muons.pt
+
+    def isPresMuon(self, muons):
+        return muons.pt > 10.0
+
+
+def _muons(pt=9.5):
+    return ak.Array(
+        [
+            [
+                {
+                    "pt": pt,
+                    "eta": 0.2,
+                    "phi": 0.1,
+                    "charge": 1,
+                    "nTrackerLayers": 12,
+                }
+            ]
+        ]
+    )
+
+
+def _processor_source(name):
+    repo = Path(__file__).resolve().parents[1]
+    return (repo / "analysis" / "topeft_run2" / name).read_text()
+
+
+def test_corrected_pt_is_used_for_conept_and_selection_threshold():
+    muons = _muons()
+    prepared = object_selection.prepare_muons_for_selection(
+        muons,
+        muons.pt + 1.0,
+        _ThresholdSelection(),
+    )
+
+    assert ak.to_list(prepared.pt_raw) == [[9.5]]
+    assert ak.to_list(prepared.pt) == [[10.5]]
+    assert ak.to_list(prepared.conept) == [[10.5]]
+    assert ak.to_list(_ThresholdSelection().isPresMuon(prepared)) == [[True]]
+
+
+def test_run2_dispatch_preserves_rochester_path(monkeypatch):
+    calls = []
+
+    def _fake_rochester(year, muons, is_data):
+        calls.append((year, is_data))
+        return muons.pt + 0.5
+
+    monkeypatch.setattr(
+        corrections, "ApplyRochesterCorrections", _fake_rochester
+    )
+
+    corrected = corrections.apply_muon_momentum_corrections(
+        "2018", _muons(), False
+    )
+
+    assert calls == [("2018", False)]
+    assert ak.to_list(corrected) == [[10.0]]
+
+
+def test_run3_does_not_silently_return_identity_without_payload():
+    with pytest.raises(RuntimeError, match="correction_set or payload_directory"):
+        corrections.apply_muon_momentum_corrections(
+            "2022",
+            _muons(),
+            False,
+            event_numbers=ak.Array([1]),
+            luminosity_blocks=ak.Array([2]),
+        )
+
+
+@pytest.mark.parametrize(
+    "processor_name",
+    ["analysis_processor.py", "analysis_processor_diboson.py"],
+)
+def test_processors_prepare_corrected_muons_before_selection(processor_name):
+    source = _processor_source(processor_name)
+
+    correction = source.index(
+        "corrected_muon_pt = apply_muon_momentum_corrections"
+    )
+    preparation = source.index("mu = te_os.prepare_muons_for_selection")
+    selection = source.index('mu["isPres"] = leptonSelection.isPresMuon(mu)')
+
+    assert correction < preparation < selection
+    assert 'mu["conept"] = leptonSelection.coneptMuon(mu)' not in source
+
+
+@pytest.mark.parametrize(
+    "processor_name",
+    ["analysis_processor.py", "analysis_processor_diboson.py"],
+)
+def test_muon_object_systematics_are_not_activated_without_rebuild(
+    processor_name,
+):
+    source = _processor_source(processor_name)
+
+    assert "MuonScaleUp" not in source
+    assert "MuonScaleDown" not in source
+    assert "MuonResolutionUp" not in source
+    assert "MuonResolutionDown" not in source

--- a/tests/test_muon_momentum_correction_order.py
+++ b/tests/test_muon_momentum_correction_order.py
@@ -4,7 +4,6 @@ import awkward as ak
 import pytest
 
 from topeft.modules import corrections
-from topeft.modules import object_selection
 
 
 class _ThresholdSelection:
@@ -38,10 +37,10 @@ def _processor_source(name):
 
 def test_corrected_pt_is_used_for_conept_and_selection_threshold():
     muons = _muons()
-    prepared = object_selection.prepare_muons_for_selection(
-        muons,
-        muons.pt + 1.0,
-        _ThresholdSelection(),
+    prepared = ak.with_field(muons, muons.pt, "pt_raw")
+    prepared = ak.with_field(prepared, muons.pt + 1.0, "pt")
+    prepared = ak.with_field(
+        prepared, _ThresholdSelection().coneptMuon(prepared), "conept"
     )
 
     assert ak.to_list(prepared.pt_raw) == [[9.5]]
@@ -90,11 +89,17 @@ def test_processors_prepare_corrected_muons_before_selection(processor_name):
     correction = source.index(
         "corrected_muon_pt = apply_muon_momentum_corrections"
     )
-    preparation = source.index("mu = te_os.prepare_muons_for_selection")
+    preserve_raw = source.index('mu["pt_raw"] = mu.pt')
+    install_corrected_pt = source.index('mu["pt"] = corrected_muon_pt')
+    compute_conept = source.index(
+        'mu["conept"] = leptonSelection.coneptMuon(mu)'
+    )
     selection = source.index('mu["isPres"] = leptonSelection.isPresMuon(mu)')
 
-    assert correction < preparation < selection
-    assert 'mu["conept"] = leptonSelection.coneptMuon(mu)' not in source
+    assert correction < preserve_raw < install_corrected_pt
+    assert install_corrected_pt < compute_conept < selection
+    removed_helper = "prepare_" + "muons_for_selection"
+    assert removed_helper not in source
 
 
 @pytest.mark.parametrize(

--- a/tests/test_muon_momentum_correction_order.py
+++ b/tests/test_muon_momentum_correction_order.py
@@ -481,17 +481,12 @@ def test_processors_build_loop_local_lepton_state(processor_name):
 def test_processors_apply_tau_shifts_before_loop_local_selection(processor_name):
     source = _processor_source(processor_name)
     syst_loop = source.index("for syst_var in syst_var_list:")
-    tau_reset = source.index("tau = events.Tau", syst_loop)
-    nominal_tes = source.index(
-        'tau["pt"], tau["mass"] = ApplyTES(', tau_reset
+    attach = source.index("tau_energy_views = AttachTauEnergyCorrections(")
+    selector = source.index(
+        "tau = ApplyTauEnergySystematics(tau_energy_views, syst_var)",
+        syst_loop,
     )
-    tes_syst = source.index(
-        'tau["pt"], tau["mass"] = ApplyTESSystematic(', nominal_tes
-    )
-    fes_syst = source.index(
-        'tau["pt"], tau["mass"] = ApplyFESSystematic(', tes_syst
-    )
-    tau_pres = source.index('tau["isPres', fes_syst)
+    tau_pres = source.index('tau["isPres', selector)
     tau_clean = source.index(
         'tau["isClean"] = te_os.isClean(tau, l_fo', tau_pres
     )
@@ -499,9 +494,13 @@ def test_processors_apply_tau_shifts_before_loop_local_selection(processor_name)
     tau_select = source.index("tau = tau[tau.isGood]", tau_good)
     jet_cleaning = source.index("tmp = ak.cartesian", tau_select)
 
-    assert syst_loop < tau_reset < nominal_tes < tes_syst < fes_syst
-    assert fes_syst < tau_pres < tau_clean < tau_good < tau_select
+    assert attach < syst_loop < selector < tau_pres
+    assert tau_pres < tau_clean < tau_good < tau_select
     assert tau_select < jet_cleaning
+    active_tau_block = source[selector:tau_pres]
+    assert "ApplyTES(" not in active_tau_block
+    assert "ApplyTESSystematic(" not in active_tau_block
+    assert "ApplyFESSystematic(" not in active_tau_block
 
 
 def test_tau_correction_function_signatures_are_unchanged():

--- a/tests/test_muon_momentum_correction_order.py
+++ b/tests/test_muon_momentum_correction_order.py
@@ -6,6 +6,13 @@ import pytest
 
 from topeft.modules import corrections
 
+_RUN3_VARIATIONS = [
+    "MuonScaleUp",
+    "MuonScaleDown",
+    "MuonResolutionUp",
+    "MuonResolutionDown",
+]
+
 
 class _ThresholdSelection:
     def coneptMuon(self, muons):
@@ -142,6 +149,42 @@ def test_run3_nominal_mc_uses_default_backend_and_payload(year):
     )
 
 
+@pytest.mark.parametrize("variation", _RUN3_VARIATIONS)
+def test_run3_mc_variations_use_default_backend_and_payload(variation):
+    corrected = corrections.apply_muon_momentum_corrections(
+        "2022",
+        _run3_muons(),
+        False,
+        event_numbers=ak.Array([1001, 1002, 1003]),
+        luminosity_blocks=ak.Array([11, 12, 13]),
+        variation=variation,
+    )
+
+    _assert_finite_run3_shape(corrected)
+
+
+@pytest.mark.parametrize("variation", _RUN3_VARIATIONS)
+def test_run3_data_rejects_muon_momentum_variations(variation):
+    with pytest.raises(ValueError, match="not applicable to data"):
+        corrections.apply_muon_momentum_corrections(
+            "2022",
+            _run3_muons(),
+            True,
+            variation=variation,
+        )
+
+
+@pytest.mark.parametrize("variation", _RUN3_VARIATIONS)
+def test_run2_variation_requests_remain_unsupported(variation):
+    with pytest.raises(ValueError, match="Run 2 Rochester.*does not support"):
+        corrections.apply_muon_momentum_corrections(
+            "2018",
+            _muons(),
+            False,
+            variation=variation,
+        )
+
+
 def test_run3_mc_requires_event_and_lumi_inputs():
     with pytest.raises(ValueError, match="event_numbers and luminosity_blocks"):
         corrections.apply_muon_momentum_corrections(
@@ -158,6 +201,16 @@ def test_unsupported_year_fails_loudly():
             _run3_muons(),
             True,
         )
+
+
+def test_muon_momentum_systematic_list_is_run3_mc_only():
+    assert corrections.RUN3_MUON_MOMENTUM_SYSTEMATICS == tuple(_RUN3_VARIATIONS)
+    assert (
+        corrections.get_supported_muon_momentum_systematics("2022", isData=False)
+        == _RUN3_VARIATIONS
+    )
+    assert corrections.get_supported_muon_momentum_systematics("2022", isData=True) == []
+    assert corrections.get_supported_muon_momentum_systematics("2018", isData=False) == []
 
 
 @pytest.mark.parametrize(
@@ -187,12 +240,50 @@ def test_processors_prepare_corrected_muons_before_selection(processor_name):
     "processor_name",
     ["analysis_processor.py", "analysis_processor_diboson.py"],
 )
-def test_muon_object_systematics_are_not_activated_without_rebuild(
-    processor_name,
-):
+def test_processors_rebuild_muon_objects_for_muon_systematics(processor_name):
     source = _processor_source(processor_name)
 
-    assert "MuonScaleUp" not in source
-    assert "MuonScaleDown" not in source
-    assert "MuonResolutionUp" not in source
-    assert "MuonResolutionDown" not in source
+    activation = source.index("get_supported_muon_momentum_systematics")
+    syst_loop = source.index("for syst_var in syst_var_list:")
+    rebuild = source.index("if is_muon_momentum_systematic(syst_var):")
+    jet_cleaning = source.index("tmp = ak.cartesian", rebuild)
+    event_leptons = source.index(
+        'events["l_fo_conept_sorted"] = l_fo_conept_sorted_for_syst',
+        rebuild,
+    )
+    event_selection = source.index("te_es.add", event_leptons)
+
+    assert activation < syst_loop < rebuild < jet_cleaning < event_leptons
+    assert event_leptons < event_selection
+
+    for snippet in [
+        'varied_mu = ak.with_field(mu, mu.pt_raw, "pt")',
+        "varied_corrected_muon_pt = apply_muon_momentum_corrections",
+        "variation=syst_var",
+        'varied_mu["pt_raw"] = varied_mu.pt',
+        'varied_mu["pt"] = varied_corrected_muon_pt',
+        'varied_mu["conept"] = leptonSelection.coneptMuon(varied_mu)',
+        'varied_mu["isPres"] = leptonSelection.isPresMuon(varied_mu)',
+        'varied_mu["isLooseM"] = leptonSelection.isLooseMuon(varied_mu)',
+        'varied_mu["isFO"] = leptonSelection.isFOMuon(varied_mu, year)',
+        'varied_mu["isTightLep"]= leptonSelection.tightSelMuon(varied_mu)',
+        "m_loose_for_syst = varied_mu",
+        "l_loose_for_syst = ak.with_name",
+        "min_mll_afas_for_syst = ak.min",
+        "m_fo_for_syst = varied_mu",
+        "AttachMuonSF(m_fo_for_syst",
+        "AttachPerLeptonFR(m_fo_for_syst",
+        "l_fo_for_syst = ak.with_name",
+        "l_fo_conept_sorted_for_syst =",
+    ]:
+        assert source.index(snippet, rebuild) < event_selection
+
+    local_leptons = source.index(
+        "l_fo_conept_sorted_padded = ak.pad_none(l_fo_conept_sorted_for_syst",
+        event_leptons,
+    )
+    assert event_leptons < local_leptons
+
+    rebuild_block = source[rebuild:jet_cleaning]
+    assert "ApplyMETSystematics" not in rebuild_block
+    assert "get_selected_met" not in rebuild_block

--- a/tests/test_muon_momentum_correction_order.py
+++ b/tests/test_muon_momentum_correction_order.py
@@ -1,3 +1,4 @@
+import inspect
 from pathlib import Path
 
 import awkward as ak
@@ -213,77 +214,303 @@ def test_muon_momentum_systematic_list_is_run3_mc_only():
     assert corrections.get_supported_muon_momentum_systematics("2018", isData=False) == []
 
 
+def test_run3_mc_attachment_adds_nominal_and_all_variation_fields(monkeypatch):
+    calls = []
+    offsets = {
+        "nominal": 1.0,
+        "MuonScaleUp": 2.0,
+        "MuonScaleDown": 3.0,
+        "MuonResolutionUp": 4.0,
+        "MuonResolutionDown": 5.0,
+    }
+
+    def _fake_apply(
+        year,
+        muons,
+        is_data,
+        *,
+        event_numbers=None,
+        luminosity_blocks=None,
+        variation="nominal",
+    ):
+        calls.append(
+            (
+                year,
+                is_data,
+                variation,
+                ak.to_list(event_numbers),
+                ak.to_list(luminosity_blocks),
+            )
+        )
+        return muons.pt + offsets[variation]
+
+    monkeypatch.setattr(
+        corrections, "apply_muon_momentum_corrections", _fake_apply
+    )
+    attached = corrections.AttachMuonMomentumCorrections(
+        "2022",
+        _muons(),
+        False,
+        event_numbers=ak.Array([101]),
+        luminosity_blocks=ak.Array([7]),
+    )
+
+    assert [call[2] for call in calls] == [
+        "nominal",
+        *_RUN3_VARIATIONS,
+    ]
+    assert ak.to_list(attached.pt_nom) == [[10.5]]
+    for variation in _RUN3_VARIATIONS:
+        field = corrections.MUON_MOMENTUM_PT_FIELDS[variation]
+        assert field in ak.fields(attached)
+        assert ak.to_list(attached[field]) == [[9.5 + offsets[variation]]]
+
+
+def test_data_attachment_only_adds_nominal_field(monkeypatch):
+    calls = []
+
+    def _fake_apply(year, muons, is_data, **kwargs):
+        calls.append((year, is_data, kwargs["variation"]))
+        return muons.pt + 1.0
+
+    monkeypatch.setattr(
+        corrections, "apply_muon_momentum_corrections", _fake_apply
+    )
+    attached = corrections.AttachMuonMomentumCorrections(
+        "2022", _muons(), True
+    )
+
+    assert calls == [("2022", True, "nominal")]
+    assert "pt_nom" in ak.fields(attached)
+    for variation in _RUN3_VARIATIONS:
+        assert corrections.MUON_MOMENTUM_PT_FIELDS[variation] not in ak.fields(
+            attached
+        )
+
+
+def test_run2_attachment_only_adds_rochester_nominal_field(monkeypatch):
+    calls = []
+
+    def _fake_apply(year, muons, is_data, **kwargs):
+        calls.append((year, is_data, kwargs["variation"]))
+        return muons.pt + 0.5
+
+    monkeypatch.setattr(
+        corrections, "apply_muon_momentum_corrections", _fake_apply
+    )
+    attached = corrections.AttachMuonMomentumCorrections(
+        "2018", _muons(), False
+    )
+
+    assert calls == [("2018", False, "nominal")]
+    assert ak.to_list(attached.pt_nom) == [[10.0]]
+    assert set(ak.fields(attached)).isdisjoint(
+        {
+            corrections.MUON_MOMENTUM_PT_FIELDS[variation]
+            for variation in _RUN3_VARIATIONS
+        }
+    )
+
+
+def _muons_with_attached_pt_fields():
+    muons = ak.with_field(_muons(), ak.Array([[999.0]]), "pt")
+    muons = ak.with_field(muons, ak.Array([[10.0]]), "pt_nom")
+    for idx, variation in enumerate(_RUN3_VARIATIONS, start=1):
+        muons = ak.with_field(
+            muons,
+            ak.Array([[10.0 + idx]]),
+            corrections.MUON_MOMENTUM_PT_FIELDS[variation],
+        )
+    return muons
+
+
+@pytest.mark.parametrize(
+    ("syst_var", "expected"),
+    [
+        ("nominal", 10.0),
+        ("JES_TotalUp", 10.0),
+        ("MuonScaleUp", 11.0),
+        ("MuonScaleDown", 12.0),
+        ("MuonResolutionUp", 13.0),
+        ("MuonResolutionDown", 14.0),
+    ],
+)
+def test_muon_systematic_selector_uses_attached_fields(syst_var, expected):
+    selected = corrections.ApplyMuonMomentumSystematics(
+        "2022", _muons_with_attached_pt_fields(), syst_var
+    )
+
+    assert ak.to_list(selected.pt) == [[expected]]
+
+
+def test_muon_systematic_selector_fails_when_requested_field_is_missing():
+    with pytest.raises(ValueError, match="pt_MuonScaleUp.*not attached"):
+        corrections.ApplyMuonMomentumSystematics(
+            "2022",
+            ak.with_field(_muons(), ak.Array([[10.0]]), "pt_nom"),
+            "MuonScaleUp",
+        )
+
+
+def test_run2_muon_systematic_selector_rejects_variations():
+    with pytest.raises(ValueError, match="Run 2 Rochester.*does not support"):
+        corrections.ApplyMuonMomentumSystematics(
+            "2018",
+            ak.with_field(_muons(), ak.Array([[10.0]]), "pt_nom"),
+            "MuonScaleDown",
+        )
+
+
+def test_nominal_attachment_selector_matches_previous_direct_path():
+    muons = _run3_muons()
+    events = ak.Array([1001, 1002, 1003])
+    lumis = ak.Array([11, 12, 13])
+    direct = corrections.apply_muon_momentum_corrections(
+        "2022",
+        muons,
+        False,
+        event_numbers=events,
+        luminosity_blocks=lumis,
+    )
+    muons = ak.with_field(muons, muons.pt, "pt_raw")
+    attached = corrections.AttachMuonMomentumCorrections(
+        "2022",
+        muons,
+        False,
+        event_numbers=events,
+        luminosity_blocks=lumis,
+    )
+    selected = corrections.ApplyMuonMomentumSystematics(
+        "2022", attached, "nominal"
+    )
+
+    assert ak.to_list(selected.pt_raw) == ak.to_list(muons.pt_raw)
+    assert np.allclose(
+        ak.to_numpy(ak.flatten(selected.pt)),
+        ak.to_numpy(ak.flatten(direct)),
+    )
+
+
+@pytest.mark.parametrize("variation", _RUN3_VARIATIONS)
+def test_muon_systematics_are_jet_noops(variation):
+    jets = object()
+    assert corrections.ApplyJetSystematics("2022", jets, variation) is jets
+
+
 @pytest.mark.parametrize(
     "processor_name",
     ["analysis_processor.py", "analysis_processor_diboson.py"],
 )
-def test_processors_prepare_corrected_muons_before_selection(processor_name):
+def test_processors_attach_muon_variations_before_systematic_loop(processor_name):
     source = _processor_source(processor_name)
 
-    correction = source.index(
-        "corrected_muon_pt = apply_muon_momentum_corrections"
-    )
     preserve_raw = source.index('mu["pt_raw"] = mu.pt')
-    install_corrected_pt = source.index('mu["pt"] = corrected_muon_pt')
-    compute_conept = source.index(
-        'mu["conept"] = leptonSelection.coneptMuon(mu)'
-    )
-    selection = source.index('mu["isPres"] = leptonSelection.isPresMuon(mu)')
+    attachment = source.index("mu = AttachMuonMomentumCorrections(")
+    syst_loop = source.index("for syst_var in syst_var_list:")
 
-    assert correction < preserve_raw < install_corrected_pt
-    assert install_corrected_pt < compute_conept < selection
-    removed_helper = "prepare_" + "muons_for_selection"
-    assert removed_helper not in source
+    assert preserve_raw < attachment < syst_loop
+    assert "mu_base = mu" not in source
+    assert "apply_muon_momentum_corrections" not in source
 
 
 @pytest.mark.parametrize(
     "processor_name",
     ["analysis_processor.py", "analysis_processor_diboson.py"],
 )
-def test_processors_rebuild_muon_objects_for_muon_systematics(processor_name):
+def test_processors_build_loop_local_lepton_state(processor_name):
     source = _processor_source(processor_name)
-
-    activation = source.index("get_supported_muon_momentum_systematics")
     syst_loop = source.index("for syst_var in syst_var_list:")
-    rebuild = source.index("if is_muon_momentum_systematic(syst_var):")
-    jet_cleaning = source.index("tmp = ak.cartesian", rebuild)
+    selector = source.index(
+        "mu = ApplyMuonMomentumSystematics(year, mu, syst_var)", syst_loop
+    )
+    compute_conept = source.index(
+        'mu["conept"] = leptonSelection.coneptMuon(mu)', selector
+    )
+    mu_pres = source.index(
+        'mu["isPres"] = leptonSelection.isPresMuon(mu)', compute_conept
+    )
+    mu_fo = source.index(
+        'mu["isFO"] = leptonSelection.isFOMuon(mu, year)', mu_pres
+    )
+    electron_selection = source.index(
+        'ele["isPres"] = leptonSelection.isPresElec(ele)', mu_fo
+    )
+    m_loose = source.index("m_loose = mu[", electron_selection)
+    l_loose = source.index("l_loose = ak.with_name(", m_loose)
+    min_mll = source.index("min_mll_afas = ak.min(", l_loose)
+    m_fo = source.index("m_fo = mu[", min_mll)
+    l_fo = source.index("l_fo = ak.with_name(", m_fo)
+    l_fo_sorted = source.index("l_fo_conept_sorted = l_fo[", l_fo)
+    jet_cleaning = source.index("tmp = ak.cartesian", l_fo_sorted)
     event_leptons = source.index(
-        'events["l_fo_conept_sorted"] = l_fo_conept_sorted_for_syst',
-        rebuild,
+        'events["l_fo_conept_sorted"] = l_fo_conept_sorted',
+        jet_cleaning,
     )
     event_selection = source.index("te_es.add", event_leptons)
 
-    assert activation < syst_loop < rebuild < jet_cleaning < event_leptons
-    assert event_leptons < event_selection
+    assert syst_loop < selector < compute_conept < mu_pres < mu_fo
+    assert mu_fo < electron_selection < m_loose < l_loose < min_mll
+    assert min_mll < m_fo < l_fo < l_fo_sorted < jet_cleaning
+    assert jet_cleaning < event_leptons < event_selection
+    assert source.index("AttachMuonSF(m_fo", m_fo) < l_fo
+    assert source.index("AttachPerLeptonFR(m_fo", m_fo) < l_fo
 
-    for snippet in [
-        'varied_mu = ak.with_field(mu, mu.pt_raw, "pt")',
-        "varied_corrected_muon_pt = apply_muon_momentum_corrections",
-        "variation=syst_var",
-        'varied_mu["pt_raw"] = varied_mu.pt',
-        'varied_mu["pt"] = varied_corrected_muon_pt',
-        'varied_mu["conept"] = leptonSelection.coneptMuon(varied_mu)',
-        'varied_mu["isPres"] = leptonSelection.isPresMuon(varied_mu)',
-        'varied_mu["isLooseM"] = leptonSelection.isLooseMuon(varied_mu)',
-        'varied_mu["isFO"] = leptonSelection.isFOMuon(varied_mu, year)',
-        'varied_mu["isTightLep"]= leptonSelection.tightSelMuon(varied_mu)',
-        "m_loose_for_syst = varied_mu",
-        "l_loose_for_syst = ak.with_name",
-        "min_mll_afas_for_syst = ak.min",
-        "m_fo_for_syst = varied_mu",
-        "AttachMuonSF(m_fo_for_syst",
-        "AttachPerLeptonFR(m_fo_for_syst",
-        "l_fo_for_syst = ak.with_name",
-        "l_fo_conept_sorted_for_syst =",
-    ]:
-        assert source.index(snippet, rebuild) < event_selection
+    forbidden_names = [
+        "varied_mu",
+        "varied_tau",
+        "m_loose_for_syst",
+        "m_fo_for_syst",
+        "l_loose_for_syst",
+        "l_fo_for_syst",
+        "l_fo_conept_sorted_for_syst",
+        "min_mll_afas_for_syst",
+    ]
+    for name in forbidden_names:
+        assert name not in source
+    assert "if is_muon_momentum_systematic(syst_var):" not in source
 
-    local_leptons = source.index(
-        "l_fo_conept_sorted_padded = ak.pad_none(l_fo_conept_sorted_for_syst",
-        event_leptons,
+    muon_selection_block = source[selector:l_fo_sorted]
+    assert "ApplyMETSystematics" not in muon_selection_block
+    assert "get_selected_met" not in muon_selection_block
+
+
+@pytest.mark.parametrize(
+    "processor_name",
+    ["analysis_processor.py", "analysis_processor_diboson.py"],
+)
+def test_processors_apply_tau_shifts_before_loop_local_selection(processor_name):
+    source = _processor_source(processor_name)
+    syst_loop = source.index("for syst_var in syst_var_list:")
+    tau_reset = source.index("tau = events.Tau", syst_loop)
+    nominal_tes = source.index(
+        'tau["pt"], tau["mass"] = ApplyTES(', tau_reset
     )
-    assert event_leptons < local_leptons
+    tes_syst = source.index(
+        'tau["pt"], tau["mass"] = ApplyTESSystematic(', nominal_tes
+    )
+    fes_syst = source.index(
+        'tau["pt"], tau["mass"] = ApplyFESSystematic(', tes_syst
+    )
+    tau_pres = source.index('tau["isPres', fes_syst)
+    tau_clean = source.index(
+        'tau["isClean"] = te_os.isClean(tau, l_fo', tau_pres
+    )
+    tau_good = source.index('tau["isGood"]', tau_clean)
+    tau_select = source.index("tau = tau[tau.isGood]", tau_good)
+    jet_cleaning = source.index("tmp = ak.cartesian", tau_select)
 
-    rebuild_block = source[rebuild:jet_cleaning]
-    assert "ApplyMETSystematics" not in rebuild_block
-    assert "get_selected_met" not in rebuild_block
+    assert syst_loop < tau_reset < nominal_tes < tes_syst < fes_syst
+    assert fes_syst < tau_pres < tau_clean < tau_good < tau_select
+    assert tau_select < jet_cleaning
+
+
+def test_tau_correction_function_signatures_are_unchanged():
+    assert str(inspect.signature(corrections.ApplyTES)) == (
+        "(year, taus, isData, vsJetWP='Loose')"
+    )
+    assert str(inspect.signature(corrections.ApplyTESSystematic)) == (
+        "(year, taus, isData, syst_name, vsJetWP='Loose')"
+    )
+    assert str(inspect.signature(corrections.ApplyFESSystematic)) == (
+        "(year, taus, isData, syst_name, vsJetWP='Loose')"
+    )

--- a/tests/test_muon_momentum_correction_order.py
+++ b/tests/test_muon_momentum_correction_order.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import awkward as ak
+import numpy as np
 import pytest
 
 from topeft.modules import corrections
@@ -30,6 +31,44 @@ def _muons(pt=9.5):
     )
 
 
+def _run3_muons():
+    return ak.Array(
+        [
+            [
+                {
+                    "pt": 30.0,
+                    "eta": 0.2,
+                    "phi": 0.1,
+                    "charge": 1,
+                    "nTrackerLayers": 12,
+                },
+                {
+                    "pt": 45.0,
+                    "eta": -1.1,
+                    "phi": -0.4,
+                    "charge": -1,
+                    "nTrackerLayers": 14,
+                },
+            ],
+            [],
+            [
+                {
+                    "pt": 60.0,
+                    "eta": 1.3,
+                    "phi": 2.0,
+                    "charge": 1,
+                    "nTrackerLayers": 10,
+                }
+            ],
+        ]
+    )
+
+
+def _assert_finite_run3_shape(corrected):
+    assert ak.to_list(ak.num(corrected)) == [2, 0, 1]
+    assert np.all(np.isfinite(ak.to_numpy(ak.flatten(corrected))))
+
+
 def _processor_source(name):
     repo = Path(__file__).resolve().parents[1]
     return (repo / "analysis" / "topeft_run2" / name).read_text()
@@ -49,7 +88,8 @@ def test_corrected_pt_is_used_for_conept_and_selection_threshold():
     assert ak.to_list(_ThresholdSelection().isPresMuon(prepared)) == [[True]]
 
 
-def test_run2_dispatch_preserves_rochester_path(monkeypatch):
+@pytest.mark.parametrize("year", ["2016APV", "2016", "2017", "2018"])
+def test_run2_dispatch_preserves_rochester_path(monkeypatch, year):
     calls = []
 
     def _fake_rochester(year, muons, is_data):
@@ -61,21 +101,62 @@ def test_run2_dispatch_preserves_rochester_path(monkeypatch):
     )
 
     corrected = corrections.apply_muon_momentum_corrections(
-        "2018", _muons(), False
+        year, _muons(), False
     )
 
-    assert calls == [("2018", False)]
+    assert calls == [(year, False)]
     assert ak.to_list(corrected) == [[10.0]]
 
 
-def test_run3_does_not_silently_return_identity_without_payload():
-    with pytest.raises(RuntimeError, match="correction_set or payload_directory"):
+@pytest.mark.parametrize("year", ["2022", "2022EE", "2023", "2023BPix"])
+def test_run3_nominal_data_uses_default_backend_and_payload(year):
+    corrected = corrections.apply_muon_momentum_corrections(
+        year,
+        _run3_muons(),
+        True,
+    )
+
+    _assert_finite_run3_shape(corrected)
+
+
+@pytest.mark.parametrize("year", ["2022", "2022EE", "2023", "2023BPix"])
+def test_run3_nominal_mc_uses_default_backend_and_payload(year):
+    muons = _run3_muons()
+    data_corrected = corrections.apply_muon_momentum_corrections(
+        year,
+        muons,
+        True,
+    )
+    corrected = corrections.apply_muon_momentum_corrections(
+        year,
+        muons,
+        False,
+        event_numbers=ak.Array([1001, 1002, 1003]),
+        luminosity_blocks=ak.Array([11, 12, 13]),
+    )
+
+    _assert_finite_run3_shape(corrected)
+    assert not np.allclose(
+        ak.to_numpy(ak.flatten(data_corrected)),
+        ak.to_numpy(ak.flatten(corrected)),
+    )
+
+
+def test_run3_mc_requires_event_and_lumi_inputs():
+    with pytest.raises(ValueError, match="event_numbers and luminosity_blocks"):
         corrections.apply_muon_momentum_corrections(
             "2022",
-            _muons(),
+            _run3_muons(),
             False,
-            event_numbers=ak.Array([1]),
-            luminosity_blocks=ak.Array([2]),
+        )
+
+
+def test_unsupported_year_fails_loudly():
+    with pytest.raises(ValueError, match="Unsupported Run 3.*2024"):
+        corrections.apply_muon_momentum_corrections(
+            "2024",
+            _run3_muons(),
+            True,
         )
 
 

--- a/tests/test_tau_energy_corrections.py
+++ b/tests/test_tau_energy_corrections.py
@@ -5,10 +5,8 @@ import awkward as ak
 import numpy as np
 import pytest
 
+import topeft.modules.corrections as corrections
 from topeft.modules.corrections import (
-    ApplyFESSystematic,
-    ApplyTES,
-    ApplyTESSystematic,
     ApplyTauEnergySystematics,
     AttachTauEnergyCorrections,
     TAU_ENERGY_FIELDS,
@@ -61,7 +59,7 @@ def _base_records():
     ]
 
 
-def test_attaches_all_complete_tau_energy_views_and_preserves_raw_fields():
+def test_attaches_all_complete_tau_energy_fields_and_preserves_raw_fields():
     tau = _taus(_base_records())
     attached = AttachTauEnergyCorrections(
         "2022", tau, False, vsJetWP="Medium"
@@ -75,33 +73,34 @@ def test_attaches_all_complete_tau_energy_views_and_preserves_raw_fields():
     _assert_close(attached.mass_raw, tau.mass)
 
 
-def test_complete_views_preserve_nominal_correction_for_untargeted_category():
+def test_complete_views_apply_only_the_targeted_category_variation():
     tau = _taus(_base_records())
     attached = AttachTauEnergyCorrections(
         "2022", tau, False, vsJetWP="Medium"
     )
-    nominal_pt, nominal_mass = ApplyTES(
-        "2022", tau, False, vsJetWP="Medium"
-    )
-    direct_tes_up_pt, _ = ApplyTESSystematic(
-        "2022", tau, False, "TESUp", vsJetWP="Medium"
-    )
-    direct_fes_up_pt, _ = ApplyFESSystematic(
-        "2022", tau, False, "FESUp", vsJetWP="Medium"
-    )
-
-    _assert_close(attached.pt_nom, nominal_pt)
-    _assert_close(attached.mass_nom, nominal_mass)
 
     # Genuine tau: varied TES; fake tau: nominal FES; unmatched: raw.
-    _assert_close(attached.pt_TESUp[:, 0], direct_tes_up_pt[:, 0])
+    assert attached.pt_TESUp[0, 0] != pytest.approx(attached.pt_nom[0, 0])
     _assert_close(attached.pt_TESUp[:, 1], attached.pt_nom[:, 1])
     _assert_close(attached.pt_TESUp[:, 2], attached.pt_raw[:, 2])
 
     # Genuine tau: nominal TES; fake tau: varied FES; unmatched: raw.
     _assert_close(attached.pt_FESUp[:, 0], attached.pt_nom[:, 0])
-    _assert_close(attached.pt_FESUp[:, 1], direct_fes_up_pt[:, 1])
+    assert attached.pt_FESUp[0, 1] != pytest.approx(attached.pt_nom[0, 1])
     _assert_close(attached.pt_FESUp[:, 2], attached.pt_raw[:, 2])
+
+    for variation in ("nominal",) + TAU_ENERGY_SYSTEMATICS:
+        pt_field, mass_field = TAU_ENERGY_FIELDS[variation]
+        _assert_close(
+            attached[mass_field] / attached.mass_raw,
+            attached[pt_field] / attached.pt_raw,
+        )
+
+
+def test_legacy_tau_energy_helpers_are_not_public():
+    assert not hasattr(corrections, "ApplyTES")
+    assert not hasattr(corrections, "ApplyTESSystematic")
+    assert not hasattr(corrections, "ApplyFESSystematic")
 
 
 def test_selector_uses_attached_views_and_resets_from_nominal():
@@ -228,7 +227,7 @@ def test_run3_fes_variations_cover_all_payload_supported_decay_modes(year):
         )
 
 
-def test_raw_based_threshold_case_avoids_sequential_composition():
+def test_raw_based_threshold_case_keeps_tes_up_independent_of_nominal():
     tau = _taus(
         [
             {
@@ -243,19 +242,11 @@ def test_raw_based_threshold_case_avoids_sequential_composition():
     attached = AttachTauEnergyCorrections(
         "2022", tau, False, vsJetWP="Medium"
     )
-    nominal_pt, nominal_mass = ApplyTES(
-        "2022", tau, False, vsJetWP="Medium"
-    )
-    nominal_tau = ak.with_field(tau, nominal_pt, "pt")
-    nominal_tau = ak.with_field(nominal_tau, nominal_mass, "mass")
-    sequential_pt, _ = ApplyTESSystematic(
-        "2022", nominal_tau, False, "TESUp", vsJetWP="Medium"
-    )
 
     assert attached.pt_nom[0, 0] < 20
     assert attached.pt_TESUp[0, 0] > 20
-    assert sequential_pt[0, 0] < 20
-    assert attached.pt_TESUp[0, 0] != pytest.approx(sequential_pt[0, 0])
+    assert attached.pt_nom[0, 0] == pytest.approx(19.869549933075906)
+    assert attached.pt_TESUp[0, 0] == pytest.approx(20.170300841331482)
 
 
 def test_correction_applicability_uses_strict_raw_pt_range():
@@ -351,10 +342,10 @@ def test_processors_attach_once_and_select_before_tau_acceptance():
         source = (PROCESSOR_DIR / processor_name).read_text()
         syst_loop = source.index("for syst_var in syst_var_list:")
         attach = source.index(
-            "tau_energy_views = AttachTauEnergyCorrections("
+            "taus = AttachTauEnergyCorrections("
         )
         selector = source.index(
-            "tau = ApplyTauEnergySystematics(tau_energy_views, syst_var)",
+            "tau = ApplyTauEnergySystematics(taus, syst_var)",
             syst_loop,
         )
         tau_pres = source.index('tau["isPres', selector)
@@ -369,7 +360,8 @@ def test_processors_attach_once_and_select_before_tau_acceptance():
         assert attach < syst_loop < selector < tau_pres
         assert selector < tau_pres < tau_clean < tau_good < tau_select
         assert tau_select < dm_flag < dm_select < tau_sf < jet_cleaning
-        assert "ApplyTES(" not in source
-        assert "ApplyTESSystematic(" not in source
-        assert "ApplyFESSystematic(" not in source
+        assert "ApplyTES" not in source
+        assert "ApplyTESSystematic" not in source
+        assert "ApplyFESSystematic" not in source
+        assert "tau_energy_views" not in source
         assert "ApplyMETSystematics" not in source[selector:tau_pres]

--- a/tests/test_tau_energy_corrections.py
+++ b/tests/test_tau_energy_corrections.py
@@ -1,0 +1,375 @@
+from itertools import product
+from pathlib import Path
+
+import awkward as ak
+import numpy as np
+import pytest
+
+from topeft.modules.corrections import (
+    ApplyFESSystematic,
+    ApplyTES,
+    ApplyTESSystematic,
+    ApplyTauEnergySystematics,
+    AttachTauEnergyCorrections,
+    TAU_ENERGY_FIELDS,
+    TAU_ENERGY_SYSTEMATICS,
+    get_supported_tau_energy_systematics,
+)
+
+
+PROCESSOR_DIR = (
+    Path(__file__).resolve().parents[1] / "analysis" / "topeft_run2"
+)
+
+
+def _taus(records):
+    return ak.Array([records])
+
+
+def _assert_close(actual, expected):
+    np.testing.assert_allclose(
+        ak.to_numpy(ak.flatten(actual, axis=None)),
+        ak.to_numpy(ak.flatten(expected, axis=None)),
+        rtol=1e-6,
+        atol=1e-7,
+    )
+
+
+def _base_records():
+    return [
+        {
+            "pt": 30.0,
+            "mass": 1.2,
+            "eta": 0.7,
+            "decayMode": 0,
+            "genPartFlav": 5,
+        },
+        {
+            "pt": 30.0,
+            "mass": 1.3,
+            "eta": -1.8,
+            "decayMode": 10,
+            "genPartFlav": 1,
+        },
+        {
+            "pt": 30.0,
+            "mass": 1.4,
+            "eta": 0.7,
+            "decayMode": 0,
+            "genPartFlav": 0,
+        },
+    ]
+
+
+def test_attaches_all_complete_tau_energy_views_and_preserves_raw_fields():
+    tau = _taus(_base_records())
+    attached = AttachTauEnergyCorrections(
+        "2022", tau, False, vsJetWP="Medium"
+    )
+
+    expected_fields = {"pt_raw", "mass_raw"}
+    for pt_field, mass_field in TAU_ENERGY_FIELDS.values():
+        expected_fields.update((pt_field, mass_field))
+    assert expected_fields <= set(ak.fields(attached))
+    _assert_close(attached.pt_raw, tau.pt)
+    _assert_close(attached.mass_raw, tau.mass)
+
+
+def test_complete_views_preserve_nominal_correction_for_untargeted_category():
+    tau = _taus(_base_records())
+    attached = AttachTauEnergyCorrections(
+        "2022", tau, False, vsJetWP="Medium"
+    )
+    nominal_pt, nominal_mass = ApplyTES(
+        "2022", tau, False, vsJetWP="Medium"
+    )
+    direct_tes_up_pt, _ = ApplyTESSystematic(
+        "2022", tau, False, "TESUp", vsJetWP="Medium"
+    )
+    direct_fes_up_pt, _ = ApplyFESSystematic(
+        "2022", tau, False, "FESUp", vsJetWP="Medium"
+    )
+
+    _assert_close(attached.pt_nom, nominal_pt)
+    _assert_close(attached.mass_nom, nominal_mass)
+
+    # Genuine tau: varied TES; fake tau: nominal FES; unmatched: raw.
+    _assert_close(attached.pt_TESUp[:, 0], direct_tes_up_pt[:, 0])
+    _assert_close(attached.pt_TESUp[:, 1], attached.pt_nom[:, 1])
+    _assert_close(attached.pt_TESUp[:, 2], attached.pt_raw[:, 2])
+
+    # Genuine tau: nominal TES; fake tau: varied FES; unmatched: raw.
+    _assert_close(attached.pt_FESUp[:, 0], attached.pt_nom[:, 0])
+    _assert_close(attached.pt_FESUp[:, 1], direct_fes_up_pt[:, 1])
+    _assert_close(attached.pt_FESUp[:, 2], attached.pt_raw[:, 2])
+
+
+def test_selector_uses_attached_views_and_resets_from_nominal():
+    attached = AttachTauEnergyCorrections(
+        "2022", _taus(_base_records()), False, vsJetWP="Medium"
+    )
+    nominal = ApplyTauEnergySystematics(attached, "nominal")
+    varied_after_nominal = ApplyTauEnergySystematics(nominal, "TESUp")
+
+    _assert_close(nominal.pt, attached.pt_nom)
+    _assert_close(nominal.mass, attached.mass_nom)
+    _assert_close(varied_after_nominal.pt, attached.pt_TESUp)
+    _assert_close(varied_after_nominal.mass, attached.mass_TESUp)
+    _assert_close(varied_after_nominal.pt_raw, attached.pt_raw)
+    _assert_close(varied_after_nominal.mass_raw, attached.mass_raw)
+
+    non_tau = ApplyTauEnergySystematics(varied_after_nominal, "JESUp")
+    _assert_close(non_tau.pt, attached.pt_nom)
+    _assert_close(non_tau.mass, attached.mass_nom)
+
+
+def test_selector_fails_loudly_when_requested_view_is_missing():
+    tau = _taus(
+        [
+            {
+                "pt": 30.0,
+                "mass": 1.2,
+                "pt_nom": 29.0,
+                "mass_nom": 1.16,
+            }
+        ]
+    )
+    with pytest.raises(ValueError, match="pt_TESUp.*mass_TESUp"):
+        ApplyTauEnergySystematics(tau, "TESUp")
+
+
+def test_data_is_nominal_only_and_all_attached_views_are_raw():
+    tau = _taus(
+        [
+            {
+                "pt": 30.0,
+                "mass": 1.2,
+                "eta": 0.7,
+                "decayMode": 0,
+            }
+        ]
+    )
+    attached = AttachTauEnergyCorrections("2022", tau, True)
+
+    assert get_supported_tau_energy_systematics("2022", isData=True) == []
+    for variation in ("nominal",) + TAU_ENERGY_SYSTEMATICS:
+        pt_field, mass_field = TAU_ENERGY_FIELDS[variation]
+        _assert_close(attached[pt_field], tau.pt)
+        _assert_close(attached[mass_field], tau.mass)
+        active = ApplyTauEnergySystematics(attached, variation)
+        _assert_close(active.pt, tau.pt)
+        _assert_close(active.mass, tau.mass)
+
+
+def test_mc_tau_energy_systematics_are_advertised_for_run2_and_run3():
+    assert get_supported_tau_energy_systematics("2018", isData=False) == list(
+        TAU_ENERGY_SYSTEMATICS
+    )
+    assert get_supported_tau_energy_systematics("2022", isData=False) == list(
+        TAU_ENERGY_SYSTEMATICS
+    )
+
+
+def test_run2_fes_uses_absolute_eta_for_nominal_and_variations():
+    tau = _taus(
+        [
+            {
+                "pt": 30.0,
+                "mass": 1.2,
+                "eta": 1.8,
+                "decayMode": 0,
+                "genPartFlav": 1,
+            },
+            {
+                "pt": 30.0,
+                "mass": 1.2,
+                "eta": -1.8,
+                "decayMode": 0,
+                "genPartFlav": 1,
+            },
+        ]
+    )
+    attached = AttachTauEnergyCorrections(
+        "2018", tau, False, vsJetWP="Loose"
+    )
+
+    for variation in ("nominal", "FESUp", "FESDown"):
+        pt_field, mass_field = TAU_ENERGY_FIELDS[variation]
+        _assert_close(attached[pt_field][:, 0], attached[pt_field][:, 1])
+        _assert_close(
+            attached[mass_field][:, 0], attached[mass_field][:, 1]
+        )
+
+
+@pytest.mark.parametrize("year", ["2022", "2022EE", "2023", "2023BPix"])
+def test_run3_fes_variations_cover_all_payload_supported_decay_modes(year):
+    tau = _taus(
+        [
+            {
+                "pt": 30.0,
+                "mass": 1.2,
+                "eta": 0.7,
+                "decayMode": dm,
+                "genPartFlav": 1,
+            }
+            for dm in (0, 1, 2, 10, 11)
+        ]
+    )
+    attached = AttachTauEnergyCorrections(
+        year, tau, False, vsJetWP="Medium"
+    )
+
+    for index in range(5):
+        assert attached.pt_FESUp[0, index] != pytest.approx(
+            attached.pt_nom[0, index]
+        )
+        assert attached.pt_FESDown[0, index] != pytest.approx(
+            attached.pt_nom[0, index]
+        )
+
+
+def test_raw_based_threshold_case_avoids_sequential_composition():
+    tau = _taus(
+        [
+            {
+                "pt": 20.05,
+                "mass": 1.2,
+                "eta": 0.7,
+                "decayMode": 0,
+                "genPartFlav": 5,
+            }
+        ]
+    )
+    attached = AttachTauEnergyCorrections(
+        "2022", tau, False, vsJetWP="Medium"
+    )
+    nominal_pt, nominal_mass = ApplyTES(
+        "2022", tau, False, vsJetWP="Medium"
+    )
+    nominal_tau = ak.with_field(tau, nominal_pt, "pt")
+    nominal_tau = ak.with_field(nominal_tau, nominal_mass, "mass")
+    sequential_pt, _ = ApplyTESSystematic(
+        "2022", nominal_tau, False, "TESUp", vsJetWP="Medium"
+    )
+
+    assert attached.pt_nom[0, 0] < 20
+    assert attached.pt_TESUp[0, 0] > 20
+    assert sequential_pt[0, 0] < 20
+    assert attached.pt_TESUp[0, 0] != pytest.approx(sequential_pt[0, 0])
+
+
+def test_correction_applicability_uses_strict_raw_pt_range():
+    tau = _taus(
+        [
+            {
+                "pt": pt,
+                "mass": 1.2,
+                "eta": 0.7,
+                "decayMode": 0,
+                "genPartFlav": 5,
+            }
+            for pt in (19.95, 20.0, 20.01, 204.99, 205.0, 205.01)
+        ]
+    )
+    attached = AttachTauEnergyCorrections(
+        "2022", tau, False, vsJetWP="Medium"
+    )
+
+    for index in (0, 1, 4, 5):
+        assert attached.pt_nom[0, index] == pytest.approx(
+            attached.pt_raw[0, index]
+        )
+    assert attached.pt_nom[0, 2] != pytest.approx(attached.pt_raw[0, 2])
+
+
+@pytest.mark.parametrize("year,wp", [("2018", "Loose"), ("2022", "Medium")])
+def test_pt_and_mass_receive_identical_scale_for_every_view(year, wp):
+    attached = AttachTauEnergyCorrections(
+        year, _taus(_base_records()), False, vsJetWP=wp
+    )
+    for variation in ("nominal",) + TAU_ENERGY_SYSTEMATICS:
+        pt_field, mass_field = TAU_ENERGY_FIELDS[variation]
+        pt_scale = attached[pt_field] / attached.pt_raw
+        mass_scale = attached[mass_field] / attached.mass_raw
+        _assert_close(pt_scale, mass_scale)
+
+
+@pytest.mark.parametrize("year,wp", [("2018", "Loose"), ("2022", "Medium")])
+def test_synthetic_distribution_grid_is_finite_and_category_complete(year, wp):
+    records = [
+        {
+            "pt": pt,
+            "mass": 1.2,
+            "eta": eta,
+            "decayMode": dm,
+            "genPartFlav": gen,
+        }
+        for pt, eta, dm, gen in product(
+            (19.95, 20.0, 20.01, 20.05, 30.0, 204.99, 205.0, 205.01),
+            (0.7, -0.7, 1.8, -1.8),
+            (0, 1, 2, 10, 11),
+            (0, 1, 2, 3, 4, 5),
+        )
+    ]
+    attached = AttachTauEnergyCorrections(
+        year, _taus(records), False, vsJetWP=wp
+    )
+
+    assert len(records) == 960
+    for variation in ("nominal",) + TAU_ENERGY_SYSTEMATICS:
+        pt_field, mass_field = TAU_ENERGY_FIELDS[variation]
+        pt = ak.to_numpy(ak.flatten(attached[pt_field]))
+        mass = ak.to_numpy(ak.flatten(attached[mass_field]))
+        assert np.all(np.isfinite(pt))
+        assert np.all(np.isfinite(mass))
+        assert np.count_nonzero(pt > 20) > 0
+        assert np.count_nonzero(pt < 205) > 0
+
+    gen = ak.to_numpy(ak.flatten(attached.genPartFlav))
+    dm = ak.to_numpy(ak.flatten(attached.decayMode))
+    raw = ak.to_numpy(ak.flatten(attached.pt_raw))
+    nominal = ak.to_numpy(ak.flatten(attached.pt_nom))
+    untargeted = gen == 0
+    np.testing.assert_allclose(nominal[untargeted], raw[untargeted])
+
+    if year == "2018":
+        fake_unsupported_dm = (
+            (gen >= 1)
+            & (gen <= 4)
+            & ((dm == 2) | (dm == 10) | (dm == 11))
+        )
+        np.testing.assert_allclose(
+            nominal[fake_unsupported_dm], raw[fake_unsupported_dm]
+        )
+
+
+def test_processors_attach_once_and_select_before_tau_acceptance():
+    for processor_name in (
+        "analysis_processor.py",
+        "analysis_processor_diboson.py",
+    ):
+        source = (PROCESSOR_DIR / processor_name).read_text()
+        syst_loop = source.index("for syst_var in syst_var_list:")
+        attach = source.index(
+            "tau_energy_views = AttachTauEnergyCorrections("
+        )
+        selector = source.index(
+            "tau = ApplyTauEnergySystematics(tau_energy_views, syst_var)",
+            syst_loop,
+        )
+        tau_pres = source.index('tau["isPres', selector)
+        tau_clean = source.index('tau["isClean"]', tau_pres)
+        tau_good = source.index('tau["isGood"]', tau_clean)
+        tau_select = source.index("tau = tau[tau.isGood]", tau_good)
+        dm_flag = source.index('tau["DMflag"]', tau_select)
+        dm_select = source.index("tau = tau[tau.DMflag]", dm_flag)
+        tau_sf = source.index("AttachTauSF(", dm_select)
+        jet_cleaning = source.index("tmp = ak.cartesian", tau_select)
+
+        assert attach < syst_loop < selector < tau_pres
+        assert selector < tau_pres < tau_clean < tau_good < tau_select
+        assert tau_select < dm_flag < dm_select < tau_sf < jet_cleaning
+        assert "ApplyTES(" not in source
+        assert "ApplyTESSystematic(" not in source
+        assert "ApplyFESSystematic(" not in source
+        assert "ApplyMETSystematics" not in source[selector:tau_pres]

--- a/topeft/modules/corrections.py
+++ b/topeft/modules/corrections.py
@@ -6,6 +6,7 @@
 from coffea import lookup_tools
 from topcoffea.modules.paths import topcoffea_path
 from topcoffea.modules.muon_momentum_corrections import (
+    MUON_MOMENTUM_VARIATIONS,
     apply_muon_momentum_corrections as apply_run3_muon_momentum_corrections,
 )
 from topeft.modules.paths import topeft_path
@@ -37,6 +38,21 @@ get_te_param = GetParam(topeft_path("params/params.json"))
 from collections import OrderedDict
 
 basepathFromTTH = 'data/fromTTH/'
+
+RUN3_MUON_MOMENTUM_SYSTEMATICS = tuple(
+    variation for variation in MUON_MOMENTUM_VARIATIONS
+    if variation != "nominal"
+)
+
+
+def is_muon_momentum_systematic(syst_var):
+    return syst_var in RUN3_MUON_MOMENTUM_SYSTEMATICS
+
+
+def get_supported_muon_momentum_systematics(year, isData=False):
+    if isData or str(year).startswith("201"):
+        return []
+    return list(RUN3_MUON_MOMENTUM_SYSTEMATICS)
 
 ###### Lepton scale factors
 ################################################################

--- a/topeft/modules/corrections.py
+++ b/topeft/modules/corrections.py
@@ -50,6 +50,14 @@ MUON_MOMENTUM_PT_FIELDS = {
         for variation in RUN3_MUON_MOMENTUM_SYSTEMATICS
     },
 }
+TAU_ENERGY_SYSTEMATICS = ("TESUp", "TESDown", "FESUp", "FESDown")
+TAU_ENERGY_FIELDS = {
+    "nominal": ("pt_nom", "mass_nom"),
+    **{
+        variation: (f"pt_{variation}", f"mass_{variation}")
+        for variation in TAU_ENERGY_SYSTEMATICS
+    },
+}
 
 
 def is_muon_momentum_systematic(syst_var):
@@ -60,6 +68,16 @@ def get_supported_muon_momentum_systematics(year, isData=False):
     if isData or str(year).startswith("201"):
         return []
     return list(RUN3_MUON_MOMENTUM_SYSTEMATICS)
+
+
+def is_tau_energy_systematic(syst_var):
+    return syst_var in TAU_ENERGY_SYSTEMATICS
+
+
+def get_supported_tau_energy_systematics(year, isData=False):
+    if isData:
+        return []
+    return list(TAU_ENERGY_SYSTEMATICS)
 
 ###### Lepton scale factors
 ################################################################
@@ -611,236 +629,224 @@ SFevaluator = extLepSF.make_evaluator()
 
 ffSysts=['','_up','_down','_be1','_be2','_pt1','_pt2']
 
+
+def _evaluate_tau_energy_components(
+    year,
+    pt,
+    eta,
+    dm,
+    gen,
+    isData,
+    vsJetWP,
+):
+    """Return raw-kinematics TES/FES component factors."""
+    ones = ak.ones_like(pt, dtype=np.float32)
+    if isData:
+        return {
+            "tes_nom": ones,
+            "tes_up": ones,
+            "tes_down": ones,
+            "fes_nom": ones,
+            "fes_up": ones,
+            "fes_down": ones,
+        }
+
+    if year.startswith("201"):
+        tes_where = (
+            (pt > 20)
+            & (pt < 205)
+            & (gen == 5)
+            & ((dm == 0) | (dm == 1) | (dm == 10) | (dm == 11))
+        )
+        fes_where = (
+            (pt > 20)
+            & (pt < 205)
+            & (gen >= 1)
+            & (gen <= 4)
+            & ((dm == 0) | (dm == 1))
+        )
+        abs_eta = abs(eta)
+        return {
+            "tes_nom": ak.where(
+                tes_where, SFevaluator[f"TauTES_{year}"](dm, pt), 1.0
+            ),
+            "tes_up": ak.where(
+                tes_where, SFevaluator[f"TauTES_{year}_up"](dm, pt), 1.0
+            ),
+            "tes_down": ak.where(
+                tes_where, SFevaluator[f"TauTES_{year}_down"](dm, pt), 1.0
+            ),
+            "fes_nom": ak.where(
+                fes_where, SFevaluator[f"TauFES_{year}"](abs_eta, dm), 1.0
+            ),
+            "fes_up": ak.where(
+                fes_where, SFevaluator[f"TauFES_{year}_up"](abs_eta, dm), 1.0
+            ),
+            "fes_down": ak.where(
+                fes_where, SFevaluator[f"TauFES_{year}_down"](abs_eta, dm), 1.0
+            ),
+        }
+
+    clib_year = clib_year_map[year]
+    json_path = topcoffea_path(f"data/POG/TAU/{clib_year}/tau.json.gz")
+    corr = correctionlib.CorrectionSet.from_file(json_path)["tau_energy_scale"]
+
+    flat_pt = ak.flatten(ak.fill_none(pt, 0.0), axis=1)
+    flat_eta = ak.flatten(ak.fill_none(eta, 0.0), axis=1)
+    flat_dm = ak.flatten(ak.fill_none(dm, -1), axis=1)
+    flat_gen = ak.flatten(ak.fill_none(gen, 0), axis=1)
+    flat_pt_np = ak.to_numpy(flat_pt)
+    counts = ak.num(pt, axis=1)
+
+    in_range = (flat_pt > 20) & (flat_pt < 205)
+    tes_dm = (
+        (flat_dm == 0)
+        | (flat_dm == 1)
+        | (flat_dm == 10)
+        | (flat_dm == 11)
+    )
+    # The POG fake-tau branch defines DM2, while genuine TES does not.
+    fes_dm = tes_dm | (flat_dm == 2)
+    tes_where = in_range & tes_dm & (flat_gen == 5)
+    fes_where = (
+        in_range
+        & fes_dm
+        & (flat_gen >= 1)
+        & (flat_gen <= 4)
+    )
+
+    def evaluate(where, syst):
+        full = np.ones_like(flat_pt_np, dtype=np.float32)
+        indices = np.nonzero(ak.to_numpy(where))[0]
+        if len(indices) > 0:
+            full[indices] = corr.evaluate(
+                ak.to_numpy(flat_pt[where]),
+                ak.to_numpy(flat_eta[where]),
+                ak.to_numpy(flat_dm[where]),
+                ak.to_numpy(flat_gen[where]),
+                "DeepTau2018v2p5",
+                vsJetWP,
+                "VVLoose",
+                syst,
+            )
+        return ak.unflatten(full, counts)
+
+    return {
+        "tes_nom": evaluate(tes_where, "nom"),
+        "tes_up": evaluate(tes_where, "up"),
+        "tes_down": evaluate(tes_where, "down"),
+        "fes_nom": evaluate(fes_where, "nom"),
+        "fes_up": evaluate(fes_where, "up"),
+        "fes_down": evaluate(fes_where, "down"),
+    }
+
+
 def ApplyTES(year, taus, isData, vsJetWP="Loose"):
     if isData:
         return (taus.pt, taus.mass)
-
-    pt  = taus.pt
-    dm  = taus.decayMode
-    gen = taus.genPartFlav
-    eta = taus.eta
-
-    clib_year = clib_year_map[year]
-    is_run2 = False
-    if year.startswith("201"):
-        is_run2 = True
-
-    is_run3 = not is_run2
-
-    if is_run2:
-
-        kinFlag = (pt>20) & (pt<205) & (gen==5)
-        dmFlag = ((dm==0) | (dm==1) | (dm==10) | (dm==11))
-        whereFlag = kinFlag & dmFlag #((pt>20) & (pt<205) & (gen==5) & (dm==0 | dm==1 | dm==10 | dm==11))
-        tes = np.where(whereFlag, SFevaluator['TauTES_{year}'.format(year=year)](dm,pt), 1)
-
-        kinFlag = (pt>20) & (pt<205) & (gen>=1) & (gen<=4)
-        dmFlag = ((dm==0) | (dm==1))
-        whereFlag = kinFlag & dmFlag
-        fes = np.where(whereFlag, SFevaluator['TauFES_{year}'.format(year=year)](eta,dm), 1)
-
-    if is_run3:
-
-        json_path = topcoffea_path(f"data/POG/TAU/{clib_year}/tau.json.gz")
-        ceval = correctionlib.CorrectionSet.from_file(json_path)
-        corr = ceval["tau_energy_scale"]
-
-        flat_pt  = ak.flatten(ak.fill_none(pt, 0.0), axis=1)
-        flat_eta = ak.flatten(ak.fill_none(eta, 0.0), axis=1)
-        flat_dm  = ak.flatten(ak.fill_none(dm, -1), axis=1)
-        flat_gen = ak.flatten(ak.fill_none(gen, 0), axis=1)
-
-        flat_all_pt = ak.flatten(ak.fill_none(pt, 0.0), axis=1)
-        flat_all_pt_np = ak.to_numpy(flat_all_pt)
-        counts = ak.num(pt, axis=1)
-
-        # Genuine taus (genmatch==5) receive the TES weights
-        tes_kin = (flat_pt > 20) & (flat_pt < 205)
-        tes_dm  = (flat_dm == 0) | (flat_dm == 1) | (flat_dm == 10) | (flat_dm == 11)
-        tes_where = tes_kin & tes_dm & (flat_gen == 5)
-
-        full_tes = np.ones_like(flat_all_pt_np, dtype=np.float32)
-        tes_indices = np.nonzero(ak.to_numpy(tes_where))[0]
-        if len(tes_indices) > 0:
-            tes_values = corr.evaluate(
-                ak.to_numpy(flat_pt[tes_where]),
-                ak.to_numpy(flat_eta[tes_where]),
-                ak.to_numpy(flat_dm[tes_where]),
-                ak.to_numpy(flat_gen[tes_where]),
-                "DeepTau2018v2p5",
-                vsJetWP,
-                "VVLoose",
-                "nom",
-            )
-            full_tes = ak.to_numpy(full_tes)
-            full_tes[tes_indices] = tes_values
-        tes = ak.unflatten(full_tes, counts)
-
-        # Electron/muon fakes (genmatch 1-4) receive the FES weights
-        fes_kin = (flat_pt > 20) & (flat_pt < 205)
-        fes_dm  = (flat_dm == 0) | (flat_dm == 1) | (flat_dm == 10) | (flat_dm == 11)
-        fes_where = fes_kin & fes_dm & (flat_gen >= 1) & (flat_gen <= 4)
-
-        full_fes = np.ones_like(flat_all_pt_np, dtype=np.float32)
-        fes_indices = np.nonzero(ak.to_numpy(fes_where))[0]
-        if len(fes_indices) > 0:
-            fes_values = corr.evaluate(
-                ak.to_numpy(flat_pt[fes_where]),
-                ak.to_numpy(flat_eta[fes_where]),
-                ak.to_numpy(flat_dm[fes_where]),
-                ak.to_numpy(flat_gen[fes_where]),
-                "DeepTau2018v2p5",
-                vsJetWP,
-                "VVLoose",
-                "nom",
-            )
-            full_fes = ak.to_numpy(full_fes)
-            full_fes[fes_indices] = fes_values
-        fes = ak.unflatten(full_fes, counts)
-
-    return (taus.pt*tes*fes, taus.mass*tes*fes)
+    components = _evaluate_tau_energy_components(
+        year,
+        taus.pt,
+        taus.eta,
+        taus.decayMode,
+        taus.genPartFlav,
+        isData,
+        vsJetWP,
+    )
+    factor = components["tes_nom"] * components["fes_nom"]
+    return (taus.pt * factor, taus.mass * factor)
 
 def ApplyTESSystematic(year, taus, isData, syst_name, vsJetWP="Loose"):
     if not syst_name.startswith('TES') or isData:
         return (taus.pt, taus.mass)
-
-    pt  = taus.pt
-    dm  = taus.decayMode
-    gen = taus.genPartFlav
-    eta = taus.eta
-
-    clib_year = clib_year_map[year]
-    is_run2 = False
-    if year.startswith("201"):
-        is_run2 = True
-
-    is_run3 = not is_run2
-
-    syst_lab = f'TauTES_{year}'
-    syst = "nom"
+    components = _evaluate_tau_energy_components(
+        year,
+        taus.pt,
+        taus.eta,
+        taus.decayMode,
+        taus.genPartFlav,
+        isData,
+        vsJetWP,
+    )
+    component = "tes_nom"
     if syst_name.endswith("Up"):
-        syst = "up"
-        syst_lab += '_up'
+        component = "tes_up"
     elif syst_name.endswith("Down"):
-        syst = "down"
-        syst_lab += '_down'
-
-    if is_run2:
-
-        kinFlag = (pt>20) & (pt<205) & (gen==5)
-        dmFlag = ((dm==0) | (dm==1) | (dm==10) | (dm==11))
-        whereFlag = kinFlag & dmFlag
-
-        tes_syst = np.where(whereFlag, SFevaluator[syst_lab](dm,pt), 1)
-
-    if is_run3:
-        json_path = topcoffea_path(f"data/POG/TAU/{clib_year}/tau.json.gz")
-        ceval = correctionlib.CorrectionSet.from_file(json_path)
-        corr   = ceval['tau_energy_scale']
-
-        flat_pt  = ak.flatten(ak.fill_none(pt, 0.0), axis=1)
-        flat_eta = ak.flatten(ak.fill_none(eta, 0.0), axis=1)
-        flat_dm  = ak.flatten(ak.fill_none(dm, -1), axis=1)
-        flat_gen = ak.flatten(ak.fill_none(gen, 0), axis=1)
-
-        kinFlag = (flat_pt>20) & (flat_pt<205) & (flat_gen==5)
-        dmFlag = ((flat_dm==0) | (flat_dm==1) | (flat_dm==10) | (flat_dm==11))
-        whereFlag = kinFlag & dmFlag
-
-        flat_all_pt = ak.flatten(ak.fill_none(pt, 0.0), axis=1)
-        full_tes_syst = np.ones_like(flat_all_pt, dtype=np.float32)
-        indices = np.nonzero(ak.to_numpy(whereFlag))[0]
-
-        if len(indices) > 0:
-            tes_syst_values = corr.evaluate(
-                ak.to_numpy((flat_pt[whereFlag])),
-                ak.to_numpy((flat_eta[whereFlag])),
-                ak.to_numpy((flat_dm[whereFlag])),
-                ak.to_numpy((flat_gen[whereFlag])),
-                "DeepTau2018v2p5",
-                vsJetWP,
-                "VVLoose",
-                syst
-            )
-
-            full_tes_syst = ak.to_numpy(full_tes_syst)
-            full_tes_syst[indices] = tes_syst_values
-
-        counts = ak.num(pt,axis=1)
-        tes_syst = ak.unflatten(full_tes_syst, counts)
-
-    return (taus.pt*tes_syst, taus.mass*tes_syst)
+        component = "tes_down"
+    factor = components[component]
+    return (taus.pt * factor, taus.mass * factor)
 
 def ApplyFESSystematic(year, taus, isData, syst_name, vsJetWP="Loose"):
     if not syst_name.startswith('FES') or isData:
         return (taus.pt, taus.mass)
-
-    pt  = taus.pt
-    eta  = taus.eta
-    dm  = taus.decayMode
-    gen = taus.genPartFlav
-
-    clib_year = clib_year_map[year]
-    is_run2 = False
-    if year.startswith("201"):
-        is_run2 = True
-
-    is_run3 = not is_run2
-
-    syst_lab = f'TauFES_{year}'
-    syst = "nom"
-
+    components = _evaluate_tau_energy_components(
+        year,
+        taus.pt,
+        taus.eta,
+        taus.decayMode,
+        taus.genPartFlav,
+        isData,
+        vsJetWP,
+    )
+    component = "fes_nom"
     if syst_name.endswith("Up"):
-        syst = "up"
-        syst_lab += '_up'
+        component = "fes_up"
     elif syst_name.endswith("Down"):
-        syst = "down"
-        syst_lab += '_down'
+        component = "fes_down"
+    factor = components[component]
+    return (taus.pt * factor, taus.mass * factor)
 
-    if is_run2:
-        kinFlag = (pt>20) & (pt<205) & (gen>=1) & (gen<=4)
-        dmFlag = ((taus.decayMode==0) | (taus.decayMode==1))
-        whereFlag = kinFlag & dmFlag
 
-        fes_syst = np.where(whereFlag, SFevaluator[syst_lab](eta,dm), 1)
+def AttachTauEnergyCorrections(year, taus, isData, vsJetWP="Medium"):
+    """Attach complete nominal and varied tau pt/mass views from raw kinematics."""
+    if "pt_raw" not in ak.fields(taus):
+        taus = ak.with_field(taus, taus.pt, "pt_raw")
+    if "mass_raw" not in ak.fields(taus):
+        taus = ak.with_field(taus, taus.mass, "mass_raw")
 
-    if is_run3:
-        json_path = topcoffea_path(f"data/POG/TAU/{clib_year}/tau.json.gz")
-        ceval = correctionlib.CorrectionSet.from_file(json_path)
-        corr   = ceval['tau_energy_scale']
+    if isData:
+        components = _evaluate_tau_energy_components(
+            year, taus.pt_raw, None, None, None, True, vsJetWP
+        )
+    else:
+        components = _evaluate_tau_energy_components(
+            year,
+            taus.pt_raw,
+            taus.eta,
+            taus.decayMode,
+            taus.genPartFlav,
+            False,
+            vsJetWP,
+        )
+    complete_factors = {
+        "nominal": components["tes_nom"] * components["fes_nom"],
+        "TESUp": components["tes_up"] * components["fes_nom"],
+        "TESDown": components["tes_down"] * components["fes_nom"],
+        "FESUp": components["tes_nom"] * components["fes_up"],
+        "FESDown": components["tes_nom"] * components["fes_down"],
+    }
+    for variation, factor in complete_factors.items():
+        pt_field, mass_field = TAU_ENERGY_FIELDS[variation]
+        taus = ak.with_field(taus, taus.pt_raw * factor, pt_field)
+        taus = ak.with_field(taus, taus.mass_raw * factor, mass_field)
+    return taus
 
-        flat_pt  = ak.flatten(ak.fill_none(pt, 0.0), axis=1)
-        flat_eta = ak.flatten(ak.fill_none(eta, 0.0), axis=1)
-        flat_dm  = ak.flatten(ak.fill_none(dm, -1), axis=1)
-        flat_gen = ak.flatten(ak.fill_none(gen, 0), axis=1)
 
-        kinFlag = (flat_pt>20) & (flat_pt<205) & (flat_gen>=1) & (flat_gen<=4)
-        dmFlag = ((flat_dm==0) | (flat_dm==1))
-        whereFlag = kinFlag & dmFlag
-
-        flat_all_pt = ak.flatten(ak.fill_none(pt, 0.0), axis=1)
-        full_fes_syst = np.ones_like(flat_all_pt, dtype=np.float32)
-        indices = np.nonzero(ak.to_numpy(whereFlag))[0]
-
-        if len(indices) > 0:
-            fes_syst_values = corr.evaluate(
-                ak.to_numpy((flat_pt[whereFlag])),
-                ak.to_numpy((flat_eta[whereFlag])),
-                ak.to_numpy((flat_dm[whereFlag])),
-                ak.to_numpy((flat_gen[whereFlag])),
-                "DeepTau2018v2p5",
-                vsJetWP,
-                "VVLoose",
-                syst
-            )
-
-            full_fes_syst = ak.to_numpy(full_fes_syst)
-            full_fes_syst[indices] = fes_syst_values
-
-        counts = ak.num(pt,axis=1)
-        fes_syst = ak.unflatten(full_fes_syst, counts)
-
-    return (taus.pt*fes_syst, taus.mass*fes_syst)
+def ApplyTauEnergySystematics(taus, syst_var):
+    """Select active tau pt/mass from fields attached before the systematic loop."""
+    variation = syst_var if is_tau_energy_systematic(syst_var) else "nominal"
+    pt_field, mass_field = TAU_ENERGY_FIELDS[variation]
+    missing = [
+        field for field in (pt_field, mass_field)
+        if field not in ak.fields(taus)
+    ]
+    if missing:
+        raise ValueError(
+            "Tau energy field(s) required for variation "
+            f'"{variation}" are not attached: {", ".join(missing)}.'
+        )
+    taus = ak.with_field(taus, taus[pt_field], "pt")
+    return ak.with_field(taus, taus[mass_field], "mass")
 
 def AttachTauSF(events, taus, year, vsJetWP="Loose", run3_fake_split=False):
     pt   = taus.pt

--- a/topeft/modules/corrections.py
+++ b/topeft/modules/corrections.py
@@ -43,6 +43,13 @@ RUN3_MUON_MOMENTUM_SYSTEMATICS = tuple(
     variation for variation in MUON_MOMENTUM_VARIATIONS
     if variation != "nominal"
 )
+MUON_MOMENTUM_PT_FIELDS = {
+    "nominal": "pt_nom",
+    **{
+        variation: f"pt_{variation}"
+        for variation in RUN3_MUON_MOMENTUM_SYSTEMATICS
+    },
+}
 
 
 def is_muon_momentum_systematic(syst_var):
@@ -2009,7 +2016,19 @@ def ApplyJetSystematics(year,cleanedJets,syst_var):
         return cleanedJets.JES_jes.down
     elif (syst_var == 'nominal'):
         return cleanedJets
-    elif (syst_var in ['nominal','MuonESUp','MuonESDown', 'TESUp', 'TESDown', 'FESUp', 'FESDown']) or is_met_unclustered_systematic(syst_var):
+    elif (
+        syst_var in [
+            'nominal',
+            'MuonESUp',
+            'MuonESDown',
+            'TESUp',
+            'TESDown',
+            'FESUp',
+            'FESDown',
+        ]
+        or is_muon_momentum_systematic(syst_var)
+        or is_met_unclustered_systematic(syst_var)
+    ):
         return cleanedJets
     elif ('JES_FlavorQCD' in syst_var):
         # Overwrite FlavorQCD with the proper jet flavor uncertainty
@@ -2121,6 +2140,54 @@ def apply_muon_momentum_corrections(
         event_numbers=event_numbers,
         luminosity_blocks=luminosity_blocks,
     )
+
+
+def AttachMuonMomentumCorrections(
+    year,
+    mu,
+    is_data,
+    *,
+    event_numbers=None,
+    luminosity_blocks=None,
+):
+    """Attach nominal and available varied muon pt fields once per event chunk."""
+    variations = ["nominal"]
+    if not is_data and not str(year).startswith("201"):
+        variations.extend(RUN3_MUON_MOMENTUM_SYSTEMATICS)
+
+    for variation in variations:
+        corrected_pt = apply_muon_momentum_corrections(
+            year,
+            mu,
+            is_data,
+            event_numbers=event_numbers,
+            luminosity_blocks=luminosity_blocks,
+            variation=variation,
+        )
+        mu = ak.with_field(
+            mu,
+            corrected_pt,
+            MUON_MOMENTUM_PT_FIELDS[variation],
+        )
+    return mu
+
+
+def ApplyMuonMomentumSystematics(year, mu, syst_var):
+    """Select active muon pt from fields attached before the systematic loop."""
+    variation = syst_var if is_muon_momentum_systematic(syst_var) else "nominal"
+    if str(year).startswith("201") and variation != "nominal":
+        raise ValueError(
+            "Run 2 Rochester uncertainty handling does not support object "
+            f'variation "{variation}" here.'
+        )
+
+    field = MUON_MOMENTUM_PT_FIELDS[variation]
+    if field not in ak.fields(mu):
+        raise ValueError(
+            f'Muon momentum field "{field}" required for variation '
+            f'"{variation}" is not attached.'
+        )
+    return ak.with_field(mu, mu[field], "pt")
 
 ###### Trigger SFs
 ################################################################

--- a/topeft/modules/corrections.py
+++ b/topeft/modules/corrections.py
@@ -5,6 +5,9 @@
 
 from coffea import lookup_tools
 from topcoffea.modules.paths import topcoffea_path
+from topcoffea.modules.muon_momentum_corrections import (
+    apply_muon_momentum_corrections as apply_run3_muon_momentum_corrections,
+)
 from topeft.modules.paths import topeft_path
 from topeft.modules.object_selection import RUN2_VSMU_TIGHT_BIT, RUN3_VSMU_TIGHT_THRESHOLD
 import numpy as np
@@ -2031,46 +2034,77 @@ def ApplyJetSystematics(year,cleanedJets,syst_var):
 # https://gitlab.cern.ch/akhukhun/roccor
 # https://github.com/CoffeaTeam/coffea/blob/master/coffea/lookup_tools/rochester_lookup.py
 def ApplyRochesterCorrections(year, mu, is_data):
-    if year.startswith('201'): #Run2 scenario
-        rocco_tag = None
-        if year == '2016':
-            rocco_tag = "2016bUL"
-        elif year == '2016APV':
-            rocco_tag = "2016aUL"
-        elif year == '2017':
-            rocco_tag = "2017UL"
-        elif year == '2018':
-            rocco_tag = "2018UL"
-        rochester_data = txt_converters.convert_rochester_file(topcoffea_path(f"data/MuonScale/RoccoR{rocco_tag}.txt"), loaduncs=True)
-        rochester = rochester_lookup.rochester_lookup(rochester_data)
-        if not is_data:
-            hasgen = ~np.isnan(ak.fill_none(mu.matched_gen.pt, np.nan))
-            mc_rand = np.random.rand(*ak.to_numpy(ak.flatten(mu.pt)).shape)
-            mc_rand = ak.unflatten(mc_rand, ak.num(mu.pt, axis=1))
-            corrections = np.array(ak.flatten(ak.ones_like(mu.pt)))
-            mc_kspread = rochester.kSpreadMC(
-                mu.charge[hasgen],mu.pt[hasgen],
-                mu.eta[hasgen],
-                mu.phi[hasgen],
-                mu.matched_gen.pt[hasgen]
-            )
-            mc_ksmear = rochester.kSmearMC(
-                mu.charge[~hasgen],
-                mu.pt[~hasgen],
-                mu.eta[~hasgen],
-                mu.phi[~hasgen],
-                mu.nTrackerLayers[~hasgen],
-                mc_rand[~hasgen]
-            )
-            hasgen_flat = np.array(ak.flatten(hasgen))
-            corrections[hasgen_flat] = np.array(ak.flatten(mc_kspread))
-            corrections[~hasgen_flat] = np.array(ak.flatten(mc_ksmear))
-            corrections = ak.unflatten(corrections, ak.num(mu.pt, axis=1))
-        else:
-            corrections = rochester.kScaleDT(mu.charge, mu.pt, mu.eta, mu.phi)
+    if not year.startswith('201'):
+        raise ValueError(
+            "ApplyRochesterCorrections is Run 2 only; use "
+            "apply_muon_momentum_corrections for Run 3."
+        )
+
+    rocco_tag = None
+    if year == '2016':
+        rocco_tag = "2016bUL"
+    elif year == '2016APV':
+        rocco_tag = "2016aUL"
+    elif year == '2017':
+        rocco_tag = "2017UL"
+    elif year == '2018':
+        rocco_tag = "2018UL"
+    rochester_data = txt_converters.convert_rochester_file(topcoffea_path(f"data/MuonScale/RoccoR{rocco_tag}.txt"), loaduncs=True)
+    rochester = rochester_lookup.rochester_lookup(rochester_data)
+    if not is_data:
+        hasgen = ~np.isnan(ak.fill_none(mu.matched_gen.pt, np.nan))
+        mc_rand = np.random.rand(*ak.to_numpy(ak.flatten(mu.pt)).shape)
+        mc_rand = ak.unflatten(mc_rand, ak.num(mu.pt, axis=1))
+        corrections = np.array(ak.flatten(ak.ones_like(mu.pt)))
+        mc_kspread = rochester.kSpreadMC(
+            mu.charge[hasgen],mu.pt[hasgen],
+            mu.eta[hasgen],
+            mu.phi[hasgen],
+            mu.matched_gen.pt[hasgen]
+        )
+        mc_ksmear = rochester.kSmearMC(
+            mu.charge[~hasgen],
+            mu.pt[~hasgen],
+            mu.eta[~hasgen],
+            mu.phi[~hasgen],
+            mu.nTrackerLayers[~hasgen],
+            mc_rand[~hasgen]
+        )
+        hasgen_flat = np.array(ak.flatten(hasgen))
+        corrections[hasgen_flat] = np.array(ak.flatten(mc_kspread))
+        corrections[~hasgen_flat] = np.array(ak.flatten(mc_ksmear))
+        corrections = ak.unflatten(corrections, ak.num(mu.pt, axis=1))
     else:
-        corrections = ak.ones_like(mu.pt)
+        corrections = rochester.kScaleDT(mu.charge, mu.pt, mu.eta, mu.phi)
     return (mu.pt * corrections)
+
+
+def apply_muon_momentum_corrections(
+    year,
+    mu,
+    is_data,
+    *,
+    event_numbers=None,
+    luminosity_blocks=None,
+    variation="nominal",
+):
+    """Dispatch Run 2 Rochester or Run 3 ScaReKit muon corrections."""
+    if year.startswith("201"):
+        if variation != "nominal":
+            raise ValueError(
+                "Run 2 Rochester uncertainty handling is unchanged and does "
+                f'not support object variation "{variation}" here.'
+            )
+        return ApplyRochesterCorrections(year, mu, is_data)
+
+    return apply_run3_muon_momentum_corrections(
+        mu,
+        year,
+        is_data,
+        variation,
+        event_numbers=event_numbers,
+        luminosity_blocks=luminosity_blocks,
+    )
 
 ###### Trigger SFs
 ################################################################

--- a/topeft/modules/corrections.py
+++ b/topeft/modules/corrections.py
@@ -741,62 +741,6 @@ def _evaluate_tau_energy_components(
     }
 
 
-def ApplyTES(year, taus, isData, vsJetWP="Loose"):
-    if isData:
-        return (taus.pt, taus.mass)
-    components = _evaluate_tau_energy_components(
-        year,
-        taus.pt,
-        taus.eta,
-        taus.decayMode,
-        taus.genPartFlav,
-        isData,
-        vsJetWP,
-    )
-    factor = components["tes_nom"] * components["fes_nom"]
-    return (taus.pt * factor, taus.mass * factor)
-
-def ApplyTESSystematic(year, taus, isData, syst_name, vsJetWP="Loose"):
-    if not syst_name.startswith('TES') or isData:
-        return (taus.pt, taus.mass)
-    components = _evaluate_tau_energy_components(
-        year,
-        taus.pt,
-        taus.eta,
-        taus.decayMode,
-        taus.genPartFlav,
-        isData,
-        vsJetWP,
-    )
-    component = "tes_nom"
-    if syst_name.endswith("Up"):
-        component = "tes_up"
-    elif syst_name.endswith("Down"):
-        component = "tes_down"
-    factor = components[component]
-    return (taus.pt * factor, taus.mass * factor)
-
-def ApplyFESSystematic(year, taus, isData, syst_name, vsJetWP="Loose"):
-    if not syst_name.startswith('FES') or isData:
-        return (taus.pt, taus.mass)
-    components = _evaluate_tau_energy_components(
-        year,
-        taus.pt,
-        taus.eta,
-        taus.decayMode,
-        taus.genPartFlav,
-        isData,
-        vsJetWP,
-    )
-    component = "fes_nom"
-    if syst_name.endswith("Up"):
-        component = "fes_up"
-    elif syst_name.endswith("Down"):
-        component = "fes_down"
-    factor = components[component]
-    return (taus.pt * factor, taus.mass * factor)
-
-
 def AttachTauEnergyCorrections(year, taus, isData, vsJetWP="Medium"):
     """Attach complete nominal and varied tau pt/mass views from raw kinematics."""
     if "pt_raw" not in ak.fields(taus):

--- a/topeft/modules/object_selection.py
+++ b/topeft/modules/object_selection.py
@@ -257,15 +257,6 @@ def get_medium_btag_foryear(year,btagger="btagDeepFlavB"):
         raise Exception(f"Error: Unknown year \"{year}\". Exiting...")
 
 
-def prepare_muons_for_selection(muons, corrected_pt, lepton_selection):
-    """Preserve raw pt and compute cone pt from corrected muon momentum."""
-    muons = ak.with_field(muons, muons.pt, "pt_raw")
-    muons = ak.with_field(muons, corrected_pt, "pt")
-    return ak.with_field(
-        muons, lepton_selection.coneptMuon(muons), "conept"
-    )
-
-
 class run2leptonselection:
 
     def __init__(self, btagger="btagDeepFlavB"):

--- a/topeft/modules/object_selection.py
+++ b/topeft/modules/object_selection.py
@@ -256,6 +256,16 @@ def get_medium_btag_foryear(year,btagger="btagDeepFlavB"):
     else:
         raise Exception(f"Error: Unknown year \"{year}\". Exiting...")
 
+
+def prepare_muons_for_selection(muons, corrected_pt, lepton_selection):
+    """Preserve raw pt and compute cone pt from corrected muon momentum."""
+    muons = ak.with_field(muons, muons.pt, "pt_raw")
+    muons = ak.with_field(muons, corrected_pt, "pt")
+    return ak.with_field(
+        muons, lepton_selection.coneptMuon(muons), "conept"
+    )
+
+
 class run2leptonselection:
 
     def __init__(self, btagger="btagDeepFlavB"):


### PR DESCRIPTION
### Summary

* Integrate Run 3 muon momentum corrections and systematics into the TOP EFT processors.
* Refactor tau energy corrections so nominal and TES/FES variations are attached once and applied consistently inside the kinematic systematic loop.
* Add focused tests for muon momentum correction ordering, tau energy correction behavior, and processor source-order guarantees.
* Add HistEFT onboarding documentation, a read-only pkl inspection helper, a formal HistEFT API contract, and lightweight HistEFT contract tests.
* Extend the Run 3 wrapper tutorial path with one-json input support and cleaner dry-run command construction.

### Motivation

Run 3 object corrections need to propagate through the same reconstruction-dependent analysis logic that uses the corrected object kinematics: lepton selections, cone pt ordering, tau acceptance, jet cleaning, event selections, and histogram filling.

Before this change, the processor applied muon and tau kinematic corrections in a more limited way: muon Rochester corrections were applied outside the systematic loop, while tau TES/FES shifts were applied later in the loop after parts of the tau selection had already been built. That made it harder to guarantee that object-level kinematic variations were propagated through all downstream selections and event variables.

This PR moves the relevant muon and tau kinematic shifts into the systematic loop so that each variation rebuilds the corresponding local muon/tau selections before jet cleaning and event selection.

The PR also adds student-facing HistEFT documentation and contract tests so future maintainers can inspect processor outputs, understand HistEFT pkl structure, and reason about any future histogram-backend work without reverse-engineering the analysis code.

### Implementation details

#### A. Muon momentum correction integration

The processors now import and use the new correction helpers from `topeft.modules.corrections`:

```python
AttachMuonMomentumCorrections
ApplyMuonMomentumSystematics
get_supported_muon_momentum_systematics
```

The main processor and diboson processor now attach nominal muon momentum correction views before the systematic loop, preserving the raw pt as `mu["pt_raw"]`.

Inside the kinematic systematic loop, the processors apply the active muon momentum systematic with:

```python
mu = ApplyMuonMomentumSystematics(year, mu, syst_var)
```

and then rebuild the muon-dependent selection quantities:

```python
mu["conept"]
mu["isPres"]
mu["isLooseM"]
mu["isFO"]
mu["isTightLep"]
m_loose
m_fo
l_loose
l_fo
l_fo_conept_sorted
minMllAFAS
```

This ensures muon momentum variations affect object selection and downstream event variables consistently.

Run 3 muon momentum systematics are exposed as object correction systematics for MC only. Data and Run 2 are excluded from the Run 3 ScaReKit variation list.

#### B. Tau energy correction refactor

Legacy tau helpers are replaced by an attach/apply model:

```python
AttachTauEnergyCorrections
ApplyTauEnergySystematics
get_supported_tau_energy_systematics
```

The processors now attach nominal tau energy correction views once, before the systematic loop. Inside the loop, the active tau energy systematic is applied before tau preselection, cleaning, decay-mode filtering, tau scale factors, and jet cleaning.

This changes the ordering from “select taus, then apply TES/FES shifts later” to “apply the tau energy view for this systematic, then rebuild tau acceptance and derived quantities.”

The old helper names are removed from the processor flow:

```python
ApplyTES
ApplyTESSystematic
ApplyFESSystematic
```

and the new tests explicitly assert that these legacy helpers are no longer used in the processors.

#### C. Processor ordering and event-variable behavior

The muon/tau selection blocks are now local to each kinematic systematic iteration. This avoids separate ad hoc `*_for_syst` object branches and ensures that each variation uses a coherent object collection.

The main processor also restores `events["minMllAFAS"]` from the loop-local value after rebuilding loose leptons for the active systematic.

Jet cleaning continues to use the rebuilt lepton/tau objects for the active systematic before jet selection and downstream event selection.

#### D. Correction helper API

`topeft/modules/corrections.py` now defines correction metadata and helpers for:

```python
RUN3_MUON_MOMENTUM_SYSTEMATICS
MUON_MOMENTUM_PT_FIELDS
TAU_ENERGY_SYSTEMATICS
TAU_ENERGY_FIELDS

is_muon_momentum_systematic(...)
get_supported_muon_momentum_systematics(...)

is_tau_energy_systematic(...)
get_supported_tau_energy_systematics(...)
```

Muon correction application delegates to the topcoffea-side ScaReKit adapter:

```python
topcoffea.modules.muon_momentum_corrections.apply_muon_momentum_corrections
```

Tau correction helpers now expose nominal and systematic pt/mass views consistently through named fields.

#### E. Runner and tutorial ergonomics

`analysis/topeft_run2/fullR3_run.sh` gains a safer tutorial/single-input path:

```bash
--sample-json JSON
--cfg-override CFG
```

It also detects user-provided `-p`/`--outpath` arguments and avoids printing duplicate output-path options in dry-run reconstructed commands.

`run_analysis.py` now prints the resolved histogram list, which makes dry-runs and debugging easier.

`analysis/topeft_run2/inspect_histeft_pkl.py` adds a read-only pkl inspection tool for TOP EFT histogram outputs. It can list top-level keys, histogram-like objects, axes, category labels, WC metadata, and optional nominal yield summaries.

#### F. HistEFT documentation and contract tests

This PR adds:

```text
docs/histeft_pkl_tutorial.md
docs/histeft_api_contract.md
tests/test_histeft_api_contract.py
```

The tutorial explains:

* what HistEFT is;
* how the processor fills it;
* how pkl outputs are structured;
* how plotting consumes pkl files;
* how to inspect pkls manually or with the helper;
* how to run a bounded one-json Run 3 EFT signal tutorial path.

The API contract documents:

* implemented versus actually used HistEFT/SparseHist features;
* EFT coefficient ordering and evaluation semantics;
* pkl compatibility expectations;
* current processor/plotter/datacard/yield consumers;
* replacement requirements and parity-test design.

The contract tests provide lightweight anchors for current HistEFT behavior, including coefficient ordering, fill/eval behavior, pickle round trip, `_sumw2` companion shape, grouping, copying, and addition.

#### G. CR configuration and local runner defaults

The diff also updates `analysis/topeft_run2/run_cr.sh` and `input_samples/cfgs/mc_background_samples_cr_NDSkim.cfg`.

The runner changes appear targeted at a muon-resolution CR validation setup, including:

* changing the base tag to `CR_muonres`;
* changing the default variables to muon-related observables;
* including 2023/2023BPix/2018 in the local year list;
* using CRZ/flip category groups;
* forwarding `--hist-vars`.

The CR sample CFG change re-enables the Central UL16 background sample block.

These are operational analysis-driver changes, not just documentation changes. Reviewers should check whether these defaults are intended to land in the shared branch or whether they should remain local validation settings.

### Testing

Targeted tests added or updated by this PR include:

```bash
pytest tests/test_muon_momentum_correction_order.py -q
pytest tests/test_tau_energy_corrections.py -q
pytest tests/test_histeft_api_contract.py -q
```

Runner/tutorial validation expected for the new `fullR3_run.sh` behavior:

```bash
cd analysis/topeft_run2

./fullR3_run.sh \
  -y 2023 \
  -t CL007AC_default_dryrun \
  -s 1000 \
  --sr \
  --hist-vars njets \
  --dry-run \
  --category-groups 2l \
  --all-analysis \
  -p /tmp/cl007ac_default \
  -x futures \
  --nworkers 1 \
  --nchunks 1 \
  --pretend \
  --np-postprocess=skip
```

and the one-json tutorial dry-run:

```bash
cd analysis/topeft_run2

./fullR3_run.sh \
  -y 2023 \
  -t CL007AC_single_ttH_2023_njets \
  -s 1000 \
  --sr \
  --hist-vars njets \
  --sample-json ../../input_samples/sample_jsons/signal_samples/ND_SRskim2023/ttH_NDSkim_2023.json \
  --dry-run \
  --category-groups 2l \
  --all-analysis \
  -p /tmp/cl007ac_histeft_demo \
  -x futures \
  --nworkers 1 \
  --nchunks 1 \
  --pretend \
  --np-postprocess=skip \
  --prefix root://cmsxrootd.crc.nd.edu/
```

The dry-runs should show the resolved years, CFG/JSON inputs, region, histogram list, output path, and exactly one output-path option in the reconstructed `run_analysis.py` command.

Limitations:

* This PR adds targeted unit/source-order tests and dry-run validation.
* It does not include a full production processing campaign.
* The topcoffea ScaReKit adapter and MUO payload support are expected from the companion topcoffea PR.

### Review notes

* This PR depends on the companion topcoffea PR that adds `topcoffea.modules.muon_momentum_corrections` and the local ScaReKit backend.
* Please review the processor ordering carefully: muon and tau kinematic variations are now applied before rebuilding local lepton/tau selections and before jet cleaning.
* Please review whether the `run_cr.sh` default changes and `mc_background_samples_cr_NDSkim.cfg` UL16 sample activation are intended to land in the shared branch. These are the most likely pieces to be mistaken for local validation edits.
* The tau correction refactor intentionally removes the legacy `ApplyTES`, `ApplyTESSystematic`, and `ApplyFESSystematic` flow.
* The HistEFT additions are documentation, inspection tooling, and lightweight contract tests; they do not replace HistEFT or change the production histogram backend.
