### PR TITLE
Harmonize Run 2/Run 3 workflow wrappers and default forward-JER mitigation

### DIFF
--- a/analysis/topeft_run2/fullR3_run.sh
+++ b/analysis/topeft_run2/fullR3_run.sh
@@ -309,6 +309,19 @@ main() {
     [UL18]=2018
   )
 
+  local -a RUN2_CFGS_SR=(
+    "${CFGS_PATH}/mc_signal_samples_NDSkim.cfg"
+    "${CFGS_PATH}/mc_background_samples_NDSkim.cfg"
+    "${CFGS_PATH}/data_samples_NDSkim.cfg"
+  )
+
+  local -a RUN2_CFGS_CR=(
+    "${CFGS_PATH}/mc_signal_samples_NDSkim.cfg"
+    "${CFGS_PATH}/mc_background_samples_NDSkim.cfg"
+    "${CFGS_PATH}/mc_background_samples_cr_NDSkim.cfg"
+    "${CFGS_PATH}/data_samples_NDSkim.cfg"
+  )
+
   declare -A SEEN_CFGS=()
   local RUN2_BUNDLE_ADDED=false
 
@@ -333,21 +346,12 @@ main() {
 
   get_run2_cfgs_for_region() {
     local region="$1"
-    local -n cfgs_ref="$2"
     case "$region" in
       CR)
-        cfgs_ref=(
-          "${CFGS_PATH}/mc_signal_samples_cr_NDSkim.cfg"
-          "${CFGS_PATH}/mc_background_samples_cr_NDSkim.cfg"
-          "${CFGS_PATH}/data_samples_cr_NDSkim.cfg"
-        )
+        printf '%s\n' "${RUN2_CFGS_CR[@]}"
         ;;
       SR)
-        cfgs_ref=(
-          "${CFGS_PATH}/mc_signal_samples_NDSkim.cfg"
-          "${CFGS_PATH}/mc_background_samples_NDSkim.cfg"
-          "${CFGS_PATH}/data_samples_NDSkim.cfg"
-        )
+        printf '%s\n' "${RUN2_CFGS_SR[@]}"
         ;;
       *)
         echo "Error: Unsupported region for Run 2 cfg resolution: $region" >&2
@@ -359,21 +363,18 @@ main() {
   get_run3_cfgs_for_region_and_year() {
     local region="$1"
     local year="$2"
-    local -n cfgs_ref="$3"
     case "$region" in
       CR)
-        cfgs_ref=(
-          "${CFGS_PATH}/NDSkim_${year}_background_samples_cr.cfg"
-          "${CFGS_PATH}/NDSkim_${year}_data_samples.cfg"
+        printf '%s\n' \
+          "${CFGS_PATH}/NDSkim_${year}_background_samples_cr.cfg" \
+          "${CFGS_PATH}/NDSkim_${year}_data_samples.cfg" \
           "${CFGS_PATH}/NDSkim_${year}_mc_signal_samples.cfg"
-        )
         ;;
       SR)
-        cfgs_ref=(
-          "${CFGS_PATH}/NDSkim_${year}_background_samples.cfg"
-          "${CFGS_PATH}/NDSkim_${year}_data_samples.cfg"
+        printf '%s\n' \
+          "${CFGS_PATH}/NDSkim_${year}_background_samples.cfg" \
+          "${CFGS_PATH}/NDSkim_${year}_data_samples.cfg" \
           "${CFGS_PATH}/NDSkim_${year}_mc_signal_samples_sr.cfg"
-        )
         ;;
       *)
         echo "Error: Unsupported region for Run 3 cfg resolution: $region" >&2
@@ -385,14 +386,12 @@ main() {
   add_run2_cfg_bundle_once() {
     local region="$1"
     local cfg
-    local -a cfgs_for_region=()
     if [[ "$RUN2_BUNDLE_ADDED" == "true" ]]; then
       return 0
     fi
-    get_run2_cfgs_for_region "$region" cfgs_for_region || return 1
-    for cfg in "${cfgs_for_region[@]}"; do
+    while IFS= read -r cfg; do
       add_cfg_once "$cfg" || return 1
-    done
+    done < <(get_run2_cfgs_for_region "$region")
     RUN2_BUNDLE_ADDED=true
   }
 
@@ -400,11 +399,9 @@ main() {
     local region="$1"
     local year="$2"
     local cfg
-    local -a cfgs_for_year=()
-    get_run3_cfgs_for_region_and_year "$region" "$year" cfgs_for_year || return 1
-    for cfg in "${cfgs_for_year[@]}"; do
+    while IFS= read -r cfg; do
       add_cfg_once "$cfg" || return 1
-    done
+    done < <(get_run3_cfgs_for_region_and_year "$region" "$year")
   }
 
   local INPUT_OVERRIDE_LABEL=""

--- a/analysis/topeft_run2/fullR3_run.sh
+++ b/analysis/topeft_run2/fullR3_run.sh
@@ -283,10 +283,13 @@ main() {
   YEAR_LABEL=$(IFS=-; echo "${RESOLVED_YEARS[*]}")
 
   local OUT_NAME
+  local REGION_LABEL
   if [[ "$FLAG_CR" == "true" ]]; then
     OUT_NAME="${YEAR_LABEL}CRs_${TAG}"
+    REGION_LABEL="CR"
   else
     OUT_NAME="${YEAR_LABEL}SRs_${TAG}"
+    REGION_LABEL="SR"
   fi
 
   echo "OUT_NAME: $OUT_NAME"
@@ -306,29 +309,15 @@ main() {
     [UL18]=2018
   )
 
-  local RUN2_CFGS_SR=(
-    "${CFGS_PATH}/mc_signal_samples_NDSkim.cfg"
-    "${CFGS_PATH}/mc_background_samples_NDSkim.cfg"
-    "${CFGS_PATH}/data_samples_NDSkim.cfg"
-  )
-
-  local RUN2_CFGS_CR=(
-    "${CFGS_PATH}/mc_signal_samples_NDSkim.cfg"
-    "${CFGS_PATH}/mc_background_samples_NDSkim.cfg"
-    "${CFGS_PATH}/mc_background_samples_cr_NDSkim.cfg"
-    "${CFGS_PATH}/data_samples_NDSkim.cfg"
-  )
-
-  # local RUN2_CFGS_CR=(
-  #   "${CFGS_PATH}/mc_signal_samples_cr_NDSkim.cfg"
-  #   "${CFGS_PATH}/mc_background_samples_cr_NDSkim.cfg"
-  #   "${CFGS_PATH}/data_samples_cr_NDSkim.cfg"
-  # )
-
   declare -A SEEN_CFGS=()
   local RUN2_BUNDLE_ADDED=false
 
-  add_cfg() {
+  is_run2_year() {
+    local year="$1"
+    [[ -n "${RUN2_YEAR_MAP[$year]+x}" ]]
+  }
+
+  add_cfg_once() {
     local cfg_file="$1"
     if [[ ! -f "$cfg_file" ]]; then
       echo "Error: Required cfg file not found: $cfg_file" >&2
@@ -342,6 +331,82 @@ main() {
     return 0
   }
 
+  get_run2_cfgs_for_region() {
+    local region="$1"
+    local -n cfgs_ref="$2"
+    case "$region" in
+      CR)
+        cfgs_ref=(
+          "${CFGS_PATH}/mc_signal_samples_cr_NDSkim.cfg"
+          "${CFGS_PATH}/mc_background_samples_cr_NDSkim.cfg"
+          "${CFGS_PATH}/data_samples_cr_NDSkim.cfg"
+        )
+        ;;
+      SR)
+        cfgs_ref=(
+          "${CFGS_PATH}/mc_signal_samples_NDSkim.cfg"
+          "${CFGS_PATH}/mc_background_samples_NDSkim.cfg"
+          "${CFGS_PATH}/data_samples_NDSkim.cfg"
+        )
+        ;;
+      *)
+        echo "Error: Unsupported region for Run 2 cfg resolution: $region" >&2
+        return 1
+        ;;
+    esac
+  }
+
+  get_run3_cfgs_for_region_and_year() {
+    local region="$1"
+    local year="$2"
+    local -n cfgs_ref="$3"
+    case "$region" in
+      CR)
+        cfgs_ref=(
+          "${CFGS_PATH}/NDSkim_${year}_background_samples_cr.cfg"
+          "${CFGS_PATH}/NDSkim_${year}_data_samples.cfg"
+          "${CFGS_PATH}/NDSkim_${year}_mc_signal_samples.cfg"
+        )
+        ;;
+      SR)
+        cfgs_ref=(
+          "${CFGS_PATH}/NDSkim_${year}_background_samples.cfg"
+          "${CFGS_PATH}/NDSkim_${year}_data_samples.cfg"
+          "${CFGS_PATH}/NDSkim_${year}_mc_signal_samples_sr.cfg"
+        )
+        ;;
+      *)
+        echo "Error: Unsupported region for Run 3 cfg resolution: $region" >&2
+        return 1
+        ;;
+    esac
+  }
+
+  add_run2_cfg_bundle_once() {
+    local region="$1"
+    local cfg
+    local -a cfgs_for_region=()
+    if [[ "$RUN2_BUNDLE_ADDED" == "true" ]]; then
+      return 0
+    fi
+    get_run2_cfgs_for_region "$region" cfgs_for_region || return 1
+    for cfg in "${cfgs_for_region[@]}"; do
+      add_cfg_once "$cfg" || return 1
+    done
+    RUN2_BUNDLE_ADDED=true
+  }
+
+  add_run3_cfg_bundle_for_year() {
+    local region="$1"
+    local year="$2"
+    local cfg
+    local -a cfgs_for_year=()
+    get_run3_cfgs_for_region_and_year "$region" "$year" cfgs_for_year || return 1
+    for cfg in "${cfgs_for_year[@]}"; do
+      add_cfg_once "$cfg" || return 1
+    done
+  }
+
   local INPUT_OVERRIDE_LABEL=""
   if [[ -n "$SAMPLE_JSON" ]]; then
     CFGS_LIST=("$SAMPLE_JSON")
@@ -350,39 +415,11 @@ main() {
     CFGS_LIST=("$CFG_OVERRIDE")
     INPUT_OVERRIDE_LABEL="CFG: $CFG_OVERRIDE"
   else
-    local CFG YEAR_CFGS
     for YEAR in "${RESOLVED_YEARS[@]}"; do
-      if [[ -n "${RUN2_YEAR_MAP[$YEAR]}" ]]; then
-        if [[ "$RUN2_BUNDLE_ADDED" == "false" ]]; then
-          if [[ "$FLAG_CR" == "true" ]]; then
-            for CFG in "${RUN2_CFGS_CR[@]}"; do
-              add_cfg "$CFG" || return 1
-            done
-          else
-            for CFG in "${RUN2_CFGS_SR[@]}"; do
-              add_cfg "$CFG" || return 1
-            done
-          fi
-          RUN2_BUNDLE_ADDED=true
-        fi
+      if is_run2_year "$YEAR"; then
+        add_run2_cfg_bundle_once "$REGION_LABEL" || return 1
       else
-        if [[ "$FLAG_CR" == "true" ]]; then
-          YEAR_CFGS=(
-            "${CFGS_PATH}/NDSkim_${YEAR}_background_samples_cr.cfg"
-            "${CFGS_PATH}/NDSkim_${YEAR}_data_samples.cfg"
-            "${CFGS_PATH}/NDSkim_${YEAR}_mc_signal_samples.cfg"
-          )
-        else
-          YEAR_CFGS=(
-            #"${CFGS_PATH}/NDSkim_${YEAR}_signal_samples.cfg"
-            "${CFGS_PATH}/NDSkim_${YEAR}_background_samples.cfg"
-            "${CFGS_PATH}/NDSkim_${YEAR}_data_samples.cfg"
-            "${CFGS_PATH}/NDSkim_${YEAR}_mc_signal_samples_sr.cfg"
-          )
-        fi
-        for CFG in "${YEAR_CFGS[@]}"; do
-          add_cfg "$CFG" || return 1
-        done
+        add_run3_cfg_bundle_for_year "$REGION_LABEL" "$YEAR" || return 1
       fi
     done
   fi
@@ -394,13 +431,6 @@ main() {
     echo "Input override: $INPUT_OVERRIDE_LABEL"
   fi
   echo "Resolved CFGS: $CFGS"
-
-  local REGION_LABEL
-  if [[ "$FLAG_CR" == "true" ]]; then
-    REGION_LABEL="CR"
-  else
-    REGION_LABEL="SR"
-  fi
 
   local -a HIST_LIST_ARGS=()
   if [[ "$HIST_VARS_PROVIDED" == "true" ]]; then

--- a/analysis/topeft_run2/fullR3_run.sh
+++ b/analysis/topeft_run2/fullR3_run.sh
@@ -306,11 +306,11 @@ main() {
     [UL18]=2018
   )
 
-  # local RUN2_CFGS_SR=(
-  #   "${CFGS_PATH}/mc_signal_samples_NDSkim.cfg"
-  #   "${CFGS_PATH}/mc_background_samples_NDSkim.cfg"
-  #   "${CFGS_PATH}/data_samples_NDSkim.cfg"
-  # )
+  local RUN2_CFGS_SR=(
+    "${CFGS_PATH}/mc_signal_samples_NDSkim.cfg"
+    "${CFGS_PATH}/mc_background_samples_NDSkim.cfg"
+    "${CFGS_PATH}/data_samples_NDSkim.cfg"
+  )
 
   local RUN2_CFGS_CR=(
     "${CFGS_PATH}/mc_signal_samples_NDSkim.cfg"

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -731,13 +731,20 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--suppress-forward-eta-stochastic-jer",
+        dest="suppress_forward_eta_stochastic_jer",
         action="store_true",
+        default=True,
         help=(
-            "Opt-in analysis-specific JER mitigation: in 2.5 < abs(eta) < 3.0, "
+            "Apply the default analysis-specific JER mitigation: in 2.5 < abs(eta) < 3.0, "
             "keep scaling JER for hybrid jets but suppress stochastic smearing for "
-            "non-hybrid jets. Disabled by default and requires JME/JERC approval "
-            "before production use."
+            "non-hybrid jets."
         ),
+    )
+    parser.add_argument(
+        "--no-suppress-forward-eta-stochastic-jer",
+        dest="suppress_forward_eta_stochastic_jer",
+        action="store_false",
+        help="Disable the default forward-eta stochastic JER mitigation.",
     )
     parser.add_argument(
         "--fwd-eta-band-pt-apply",

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -730,16 +730,10 @@ if __name__ == "__main__":
         help="Compute systematic variations",
     )
     parser.add_argument(
-        "--suppress-forward-eta-stochastic-jer",
-        dest="suppress_forward_eta_stochastic_jer",
-        action="store_true",
-        default=True,
-        help=argparse.SUPPRESS,
-    )
-    parser.add_argument(
         "--no-suppress-forward-eta-stochastic-jer",
         dest="suppress_forward_eta_stochastic_jer",
         action="store_false",
+        default=True,
         help=(
             "Disable the default forward-eta stochastic JER mitigation in "
             "2.5 < abs(eta) < 3.0."

--- a/analysis/topeft_run2/run_analysis.py
+++ b/analysis/topeft_run2/run_analysis.py
@@ -734,17 +734,16 @@ if __name__ == "__main__":
         dest="suppress_forward_eta_stochastic_jer",
         action="store_true",
         default=True,
-        help=(
-            "Apply the default analysis-specific JER mitigation: in 2.5 < abs(eta) < 3.0, "
-            "keep scaling JER for hybrid jets but suppress stochastic smearing for "
-            "non-hybrid jets."
-        ),
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--no-suppress-forward-eta-stochastic-jer",
         dest="suppress_forward_eta_stochastic_jer",
         action="store_false",
-        help="Disable the default forward-eta stochastic JER mitigation.",
+        help=(
+            "Disable the default forward-eta stochastic JER mitigation in "
+            "2.5 < abs(eta) < 3.0."
+        ),
     )
     parser.add_argument(
         "--fwd-eta-band-pt-apply",

--- a/analysis/topeft_run2/run_cr.sh
+++ b/analysis/topeft_run2/run_cr.sh
@@ -75,7 +75,7 @@ cr_var_sets=(
 # Preserve the previous shared variable default for SR production. Tune this
 # separately when a dedicated SR campaign needs different histogram chunks.
 sr_var_sets=(
-  "lj0pt nbtagsl nbtagsm fwd0pt fwd0eta lt"
+  "lj0pt ptz ptz_wtau lt"
 )
 
 ###############################################################################

--- a/analysis/topeft_run2/run_cr.sh
+++ b/analysis/topeft_run2/run_cr.sh
@@ -39,7 +39,7 @@ run_sr=false
 # Useful while checking resolved years/categories/histograms without launching production.
 dry_run=false
 
-# Current CR distribution production mode.
+# Shared CR/SR production switches.
 #
 # Yuyi's request is for distributions, and the previous colleague-facing setup used
 # systematic variations for CR plotting. Keep nonprompt disabled unless explicitly needed.
@@ -64,11 +64,17 @@ split_lep_flavor=false
 #   - fwd0eta, lj0pt, lt, met, ptz for the relevant non-tau CRs;
 #   - ptz_wtau and tau variables for tau CR coverage;
 #   - invmass, j0eta, j0pt, l0/l1 variables, ljptsum, nbtagsl, njets for tau CRs.
-var_sets=(
+cr_var_sets=(
   # "fwd0pt fwd0eta lj0pt lt met ptz nbtagsl l0conept l0eta"
   # "njets l1conept l1eta j0pt j0eta invmass ljptsum nbtagsm npvsGood"
   # "l0eta l0conept met lt njets ptz_wtau tau0Fpt tau0Tpt"
   # "lt"
+  "lj0pt nbtagsl nbtagsm fwd0pt fwd0eta lt"
+)
+
+# Preserve the previous shared variable default for SR production. Tune this
+# separately when a dedicated SR campaign needs different histogram chunks.
+sr_var_sets=(
   "lj0pt nbtagsl nbtagsm fwd0pt fwd0eta lt"
 )
 
@@ -189,10 +195,14 @@ print_command() {
 }
 
 print_var_sets() {
+  local label="$1"
+  shift
+
   local var_set
   local index=0
 
-  for var_set in "${var_sets[@]}"; do
+  echo "${label} variable chunks:"
+  for var_set in "$@"; do
     index=$((index + 1))
     echo "  ${index}: ${var_set}"
   done
@@ -361,8 +371,8 @@ echo "dry_run: ${dry_run}"
 echo "do_systs: ${do_systs}"
 echo "do_np: ${do_np}"
 echo "split_lep_flavor: ${split_lep_flavor}"
-echo "variable chunks:"
-print_var_sets
+print_var_sets "CR" "${cr_var_sets[@]}"
+print_var_sets "SR" "${sr_var_sets[@]}"
 echo "========================================"
 echo
 
@@ -391,7 +401,7 @@ if [[ "${run_cr}" == "true" ]]; then
     for category_set in "${cr_category_sets[@]}"; do
       read -r -a cats <<< "${category_set}"
 
-      for var_set in "${var_sets[@]}"; do
+      for var_set in "${cr_var_sets[@]}"; do
         run_cr_block "${year_expr}" "${var_set}" "${cats[@]}"
       done
     done
@@ -410,7 +420,7 @@ if [[ "${run_sr}" == "true" ]]; then
     for category_set in "${sr_category_sets[@]}"; do
       read -r -a cats <<< "${category_set}"
 
-      for var_set in "${var_sets[@]}"; do
+      for var_set in "${sr_var_sets[@]}"; do
         run_sr_block "${year_expr}" "${var_set}" "${cats[@]}"
       done
     done

--- a/analysis/topeft_run2/run_cr.sh
+++ b/analysis/topeft_run2/run_cr.sh
@@ -72,8 +72,8 @@ cr_var_sets=(
   "lj0pt nbtagsl nbtagsm fwd0pt fwd0eta lt"
 )
 
-# Preserve the previous shared variable default for SR production. Tune this
-# separately when a dedicated SR campaign needs different histogram chunks.
+# SR variable chunks are configured separately from CR so SR campaigns can use
+# dedicated histogram groups without changing the CR request.
 sr_var_sets=(
   "njets lj0pt ptz ptz_wtau lt"
 )

--- a/analysis/topeft_run2/run_cr.sh
+++ b/analysis/topeft_run2/run_cr.sh
@@ -223,7 +223,6 @@ build_common_command_options() {
 
   cmd_ref+=(
     -p "${output_dir}"
-    --suppress-forward-eta-stochastic-jer
     --all-analysis
   )
 

--- a/analysis/topeft_run2/run_cr.sh
+++ b/analysis/topeft_run2/run_cr.sh
@@ -25,7 +25,7 @@ chunk_size="50000"
 ttgamma_sample_role_policy="split"
 
 # Use a strategy-specific tag to avoid mixing baseline/feature/diagnostic outputs.
-campaign_tag="preappr"
+campaign_tag="preappr_sr"
 
 cr_pkl_base_tag="${campaign_tag}"
 sr_pkl_base_tag="${campaign_tag}"
@@ -33,8 +33,8 @@ sr_pkl_base_tag="${campaign_tag}"
 # Execution switches.
 #
 # This script is currently configured for Yuyi's CR distribution request.
-run_cr=true
-run_sr=false
+run_cr=false
+run_sr=true
 
 # Useful while checking resolved years/categories/histograms without launching production.
 dry_run=false
@@ -44,7 +44,7 @@ dry_run=false
 # Yuyi's request is for distributions, and the previous colleague-facing setup used
 # systematic variations for CR plotting. Keep nonprompt disabled unless explicitly needed.
 do_systs=true
-do_np=false
+do_np=true
 
 # Enable only if the colleague explicitly needs lepton-flavour split outputs.
 split_lep_flavor=false
@@ -75,7 +75,7 @@ cr_var_sets=(
 # Preserve the previous shared variable default for SR production. Tune this
 # separately when a dedicated SR campaign needs different histogram chunks.
 sr_var_sets=(
-  "lj0pt ptz ptz_wtau lt"
+  "njets lj0pt ptz ptz_wtau lt"
 )
 
 ###############################################################################
@@ -124,15 +124,19 @@ sr_year_sets=(
   2022EE
   2023
   2023BPix
-  2016APV
-  2016
-  2017
-  2018
+  # 2016APV
+  # 2016
+  # 2017
+  # 2018
 )
 
 sr_category_sets=(
-  "2l 2lss_1tau 2los_1tau 3l_m_offZ"
-  "3l_p_offZ 3l_onZ_tau 3l_fwd 4l"
+  "2l"
+  "2lss_1tau 2los_1tau"
+  "3l_m_offZ"
+  "3l_p_offZ"
+  "3l_onZ_tau 4l"
+  "3l_fwd"
 )
 
 ###############################################################################

--- a/analysis/topeft_run2/run_ttgamma.sh
+++ b/analysis/topeft_run2/run_ttgamma.sh
@@ -302,7 +302,6 @@ RunSrBlock() {
     --do-np
     -p "${outputDir}"
     --category-groups "${cats[@]}"
-    --suppress-forward-eta-stochastic-jer
     --all-analysis
   )
 

--- a/tests/test_forward_eta_jer_suppression_threading.py
+++ b/tests/test_forward_eta_jer_suppression_threading.py
@@ -1,3 +1,4 @@
+import argparse
 import inspect
 import runpy
 import sys
@@ -13,6 +14,35 @@ from topeft.modules import corrections as cor
 
 
 _RUN_ANALYSIS_PATH = Path("analysis/topeft_run2/run_analysis.py")
+
+
+class _ParsedArgsCaptured(Exception):
+    pass
+
+
+def _parse_run_analysis_args(cli_args):
+    argv = ["run_analysis.py", *cli_args]
+    original_parse_args = argparse.ArgumentParser.parse_args
+
+    def parse_args_and_stop(parser, *args, **kwargs):
+        parsed_args = original_parse_args(parser, *args, **kwargs)
+        raise _ParsedArgsCaptured(parsed_args)
+
+    original_sys_path = list(sys.path)
+    sys.path.insert(0, str(_RUN_ANALYSIS_PATH.parent))
+    try:
+        with mock.patch.object(sys, "argv", argv):
+            with mock.patch.object(
+                argparse.ArgumentParser,
+                "parse_args",
+                parse_args_and_stop,
+            ):
+                with pytest.raises(_ParsedArgsCaptured) as excinfo:
+                    runpy.run_path(str(_RUN_ANALYSIS_PATH), run_name="__main__")
+    finally:
+        sys.path = original_sys_path
+
+    return excinfo.value.args[0]
 
 
 def test_apply_jet_corrections_forwards_resolved_forward_eta_suppression(monkeypatch):
@@ -168,8 +198,24 @@ def test_run_analysis_help_exposes_forward_eta_suppression_flag(capsys):
     help_text = capsys.readouterr().out
 
     assert "--suppress-forward-eta-stochastic-jer" in help_text
-    assert "requires JME/JERC approval" in help_text
+    assert "--no-suppress-forward-eta-stochastic-jer" in help_text
+    assert "Opt-in" not in help_text
+    assert "Disabled by default" not in help_text
     assert "--fwd-eta-band-pt-apply" in help_text
+
+
+@pytest.mark.parametrize(
+    "cli_args, expected",
+    [
+        ([], True),
+        (["--suppress-forward-eta-stochastic-jer"], True),
+        (["--no-suppress-forward-eta-stochastic-jer"], False),
+    ],
+)
+def test_run_analysis_forward_eta_suppression_cli_values(cli_args, expected):
+    args = _parse_run_analysis_args(cli_args)
+
+    assert args.suppress_forward_eta_stochastic_jer is expected
 
 
 def test_run_analysis_threads_forward_eta_suppression_to_main_processor():

--- a/tests/test_forward_eta_jer_suppression_threading.py
+++ b/tests/test_forward_eta_jer_suppression_threading.py
@@ -182,7 +182,7 @@ def test_secondary_processors_default_forward_eta_suppression_false():
     assert btag_processor.suppress_forward_eta_stochastic_jer is False
 
 
-def test_run_analysis_help_exposes_forward_eta_suppression_flag(capsys):
+def test_run_analysis_help_only_exposes_forward_eta_suppression_opt_out(capsys):
     argv = ["run_analysis.py", "--help"]
 
     original_sys_path = list(sys.path)
@@ -197,10 +197,8 @@ def test_run_analysis_help_exposes_forward_eta_suppression_flag(capsys):
     assert excinfo.value.code == 0
     help_text = capsys.readouterr().out
 
-    assert "--suppress-forward-eta-stochastic-jer" in help_text
+    assert "--suppress-forward-eta-stochastic-jer" not in help_text
     assert "--no-suppress-forward-eta-stochastic-jer" in help_text
-    assert "Opt-in" not in help_text
-    assert "Disabled by default" not in help_text
     assert "--fwd-eta-band-pt-apply" in help_text
 
 

--- a/tests/test_forward_eta_jer_suppression_threading.py
+++ b/tests/test_forward_eta_jer_suppression_threading.py
@@ -206,7 +206,6 @@ def test_run_analysis_help_only_exposes_forward_eta_suppression_opt_out(capsys):
     "cli_args, expected",
     [
         ([], True),
-        (["--suppress-forward-eta-stochastic-jer"], True),
         (["--no-suppress-forward-eta-stochastic-jer"], False),
     ],
 )
@@ -214,6 +213,17 @@ def test_run_analysis_forward_eta_suppression_cli_values(cli_args, expected):
     args = _parse_run_analysis_args(cli_args)
 
     assert args.suppress_forward_eta_stochastic_jer is expected
+
+
+def test_run_analysis_rejects_removed_positive_forward_eta_suppression_flag(capsys):
+    with pytest.raises(SystemExit) as excinfo:
+        _parse_run_analysis_args(["--suppress-forward-eta-stochastic-jer"])
+
+    assert excinfo.value.code == 2
+    assert (
+        "unrecognized arguments: --suppress-forward-eta-stochastic-jer"
+        in capsys.readouterr().err
+    )
 
 
 def test_run_analysis_threads_forward_eta_suppression_to_main_processor():

--- a/topeft/channels/ch_lst.json
+++ b/topeft/channels/ch_lst.json
@@ -873,7 +873,22 @@
                     "2l_nozeeveto",
                     "bmask_atleast1m2l",
                     "1tau"
-                ],
+                ]
+            ],
+            "lep_flav_lst": [
+                "ee",
+                "em",
+                "mm"
+            ],
+            "appl_lst": [
+                "isSR_2lOS"
+            ],
+            "jet_lst": [
+                "=2"
+            ]
+        },
+        "2los_1tau_0b": {
+            "lep_chan_lst": [
                 [
                     "2los_1tau_0b",
                     "2los",
@@ -891,9 +906,8 @@
                 "isSR_2lOS"
             ],
             "jet_lst": [
-                "=0",
-                "=1",
-                "=2"
+                "=2",
+                ">3"
             ]
         },
         "1l_1tau_CRtt": {


### PR DESCRIPTION
### Summary

* Refactor `fullR3_run.sh` so Run 2 and Run 3 cfg resolution use explicit helper functions for CR/SR handling.
* Preserve the legacy Run 2 cfg semantics while making Run 3 per-year CR/SR cfg resolution explicit.
* Make the Run 3 forward-eta stochastic JER mitigation enabled by default in `run_analysis.py`, with `--no-suppress-forward-eta-stochastic-jer` as the only CLI opt-out.
* Split the production wrapper variable chunks into independent `cr_var_sets` and `sr_var_sets`.
* Remove obsolete positive forward-JER flag passthroughs from production wrappers and update the CLI/threading tests.

### Motivation

The previous `fullR3_run.sh` cfg resolution mixed two implementation styles: Run 2 used explicit cfg arrays, while Run 3 built cfg lists inline inside the year loop. This made the Run 2/Run 3 behavior harder to audit and maintain, especially for mixed-period commands.

The workflow wrappers also had stale assumptions after the forward-eta stochastic JER mitigation became the default. In particular, wrappers were still passing `--suppress-forward-eta-stochastic-jer`, even though the intended interface is now default-on behavior with an explicit opt-out.

### Implementation details

#### A. `fullR3_run.sh` cfg-resolution cleanup

`analysis/topeft_run2/fullR3_run.sh` now resolves CR/SR cfgs through named helper functions:

* `is_run2_year`
* `add_cfg_once`
* `get_run2_cfgs_for_region`
* `get_run3_cfgs_for_region_and_year`
* `add_run2_cfg_bundle_once`
* `add_run3_cfg_bundle_for_year`

Run 2 cfg behavior is preserved:

```text
Run 2 SR:
  ../../input_samples/cfgs/mc_signal_samples_NDSkim.cfg
  ../../input_samples/cfgs/mc_background_samples_NDSkim.cfg
  ../../input_samples/cfgs/data_samples_NDSkim.cfg

Run 2 CR:
  ../../input_samples/cfgs/mc_signal_samples_NDSkim.cfg
  ../../input_samples/cfgs/mc_background_samples_NDSkim.cfg
  ../../input_samples/cfgs/mc_background_samples_cr_NDSkim.cfg
  ../../input_samples/cfgs/data_samples_NDSkim.cfg
```

Run 3 cfg behavior is unchanged but now explicit:

```text
Run 3 SR per year:
  NDSkim_<year>_background_samples.cfg
  NDSkim_<year>_data_samples.cfg
  NDSkim_<year>_mc_signal_samples_sr.cfg

Run 3 CR per year:
  NDSkim_<year>_background_samples_cr.cfg
  NDSkim_<year>_data_samples.cfg
  NDSkim_<year>_mc_signal_samples.cfg
```

The refactor preserves cfg de-duplication, `--sample-json`, `--cfg-override`, `--hist-vars`, output naming, region skip flags, ttgamma policy forwarding, and other passthrough behavior.

#### B. Forward-eta stochastic JER CLI default

`run_analysis.py` now enables `suppress_forward_eta_stochastic_jer` by default.

The old positive flag was removed:

```text
--suppress-forward-eta-stochastic-jer
```

The remaining supported CLI control is the explicit opt-out:

```text
--no-suppress-forward-eta-stochastic-jer
```

The resulting parser contract is:

```text
no flag                                  -> suppress_forward_eta_stochastic_jer = True
--no-suppress-forward-eta-stochastic-jer -> suppress_forward_eta_stochastic_jer = False
--suppress-forward-eta-stochastic-jer    -> argparse error
```

`analysis_processor.py` was not changed. Existing YAML override behavior remains unchanged.

#### C. Production wrapper updates

`analysis/topeft_run2/run_cr.sh` now has separate variable-list configuration for CR and SR:

```bash
cr_var_sets=(...)
sr_var_sets=(...)
```

The CR path keeps the existing active CR chunk and commented alternatives. The SR path now reads from `sr_var_sets`, so SR histogram chunks can be tuned independently without changing the CR request. The current SR chunk is:

```text
njets lj0pt ptz ptz_wtau lt
```

`run_cr.sh` and `run_ttgamma.sh` no longer pass the removed positive forward-JER flag. They continue to pass their other options, including `--all-analysis`.

#### D. Tests

`tests/test_forward_eta_jer_suppression_threading.py` was updated to cover the new parser behavior:

* no flag gives `True`;
* `--no-suppress-forward-eta-stochastic-jer` gives `False`;
* the removed positive flag is rejected with argparse exit code 2;
* help exposes only the negative opt-out form.

### Testing

The following targeted validation was reported across the CL008AA–CL008AE series:

```text
git diff --check
bash -n analysis/topeft_run2/fullR3_run.sh
bash -n analysis/topeft_run2/run_cr.sh
bash -n analysis/topeft_run2/run_ttgamma.sh
```

`fullR3_run.sh` dry-run coverage included:

```text
./fullR3_run.sh -y run2 --cr --dry-run
./fullR3_run.sh -y run2 --sr --dry-run
./fullR3_run.sh -y run3 --cr --dry-run
./fullR3_run.sh -y run3 --sr --dry-run
./fullR3_run.sh -y UL18 2022EE --cr --dry-run
./fullR3_run.sh -y run2 --cr --hist-vars njets ht --dry-run
```

Additional dry-run checks covered cfg override, sample JSON override, wrapper execution via temporary dry-run copies, and removal of the old positive forward-JER flag from wrapper commands.

Targeted Python validation included scoped compile checks and focused pytest runs for:

```text
tests/test_forward_eta_jer_suppression_threading.py
tests/test_run_analysis_cli_help.py
tests/test_ttgamma_photon_history.py::test_ttgamma_sample_role_policy_defaults_are_split_source_guards
```

The final targeted pytest report was:

```text
16 passed, 1 warning
```

The warning was the known uproot/pkg_resources deprecation warning.

For the final comment-only cleanup in `run_cr.sh`, validation was:

```text
git diff --check
bash -n analysis/topeft_run2/run_cr.sh
```

Full pytest, full compileall, and production validation were not run.

### Review notes

* The forward-eta stochastic JER mitigation is now default-on at the `run_analysis.py` CLI level. Use `--no-suppress-forward-eta-stochastic-jer` to opt out.
* The old positive flag `--suppress-forward-eta-stochastic-jer` is intentionally removed and will now fail with argparse if used by external callers.
* `analysis_processor.py` was not modified; the change is in CLI defaulting and wrapper passthrough behavior.
* The Run 2 CR cfg policy remains the legacy mixed cfg bundle; this PR does not switch Run 2 CR to the dedicated CR signal/data cfgs.
* The wrapper SR variable list is now independent from CR. Before enabling `run_sr=true` for production, review whether the current SR histogram chunk is the desired SR campaign configuration.
* Validation was dry-run and targeted-test based. No production campaign, pkl production, or full pytest was run.
