### PR TITLE
Make CR/SR plotter robust to skipped processes and add rebin/negative-weight diagnostics

### DIFF
--- a/analysis/topeft_run2/README.md
+++ b/analysis/topeft_run2/README.md
@@ -9,6 +9,8 @@ This directory contains scripts for the Full Run 2 EFT analysis. This README doc
 - [Scripts for finding, comparing and plotting yields from histograms (from the processor)](#scripts-for-finding-comparing-and-plotting-yields-from-histograms-from-the-processor)
 - [Scripts for making and checking the datacards](#scripts-for-making-and-checking-the-datacards)
 - [CR/SR plotting CLI quickstart](#crsr-plotting-cli-quickstart)
+  - [Plot-Time Variable Rebinning](#plot-time-variable-rebinning)
+  - [Negative MC Contribution Reports](#negative-mc-contribution-reports)
   - [run\_plotter.sh shell wrapper quickstart](#run_plottersh-shell-wrapper-quickstart)
 - [HTCondor plotting on Glados](#htcondor-plotting-on-glados)
 - [make_cr_and_sr_plots.py internals](#make_cr_and_sr_plotspy-internals)
@@ -140,6 +142,8 @@ This directory contains scripts for the Full Run 2 EFT analysis. This README doc
     - Pass `--log-y` to draw the stacked yields with a logarithmic y-axis (the ratio panel remains linear). The flag defaults to off so existing plots keep their linear scale unless explicitly requested, and is available both on the Python CLI and via `run_plotter.sh`.
     - Pass `--verbose` when you need detailed diagnostics (sample inventories, per-variable channel dumps). The default `--quiet` mode keeps the console output to high-level progress summaries.
     - `--report-zero-yields` emits a detailed summary of processes with zero or missing yields after plotting.
+    - `--rebin-plot-vars j0pt:2,l1conept=2` rebins only the listed variables at plot/report time. The input pickle is not modified.
+    - The negative MC contribution report is enabled by default and writes `negative_weight_contribution_report.csv` plus `negative_weight_contribution_summary.md` under the plot output directory. Add `--no-negative-weight-report` to suppress those files.
     - Histograms with multiple dense axes (e.g. the `SparseHist`-based `lepton_pt_vs_eta`) are automatically rendered as CMS-style 2D heatmaps, while the 1D rebinning and systematic envelopes quietly skip them. The heatmap canvas now includes a dedicated Data/MC ratio panel so comparisons are available at a glance alongside the nominal MC and data projections.
 
 ### CR/SR plotting CLI quickstart
@@ -188,11 +192,80 @@ Common invocation patterns (`-y/--year` accepts multiple tokens for combined cam
 * Producing unblinded CR plots with explicit tagging and timestamped directories: `python make_cr_and_sr_plots.py -f histos/CR2018.pkl.gz -y 2018 --cr -t -n cr_2018_scan`
 * Switching the stacked panel to a log scale: `python make_cr_and_sr_plots.py -f histos/plotsCR_Run2.pkl.gz -y run2 --log-y`
 
+#### Plot-Time Variable Rebinning
+
+Use `--rebin-plot-vars` when a plot needs coarser visible bins but the input pickle should remain untouched. The option takes comma-separated `variable:factor` or `variable=factor` entries, and each factor must be an integer greater than or equal to 2:
+
+```bash
+python make_cr_and_sr_plots.py \
+  -f histos/plotsCR_Run2.pkl.gz \
+  -y 2017 \
+  --variables j0pt l1conept \
+  --rebin-plot-vars j0pt:2,l1conept=2
+```
+
+Rebinning happens only inside the plotting/reporting path. The source histograms and input pickle are not rewritten. Visible-bin contents are summed, variances and `sumw2` values are summed, and any leftover visible bins that do not fill a complete factor group are merged into the final rebinned bin rather than being dropped.
+
+The rebinned edges are used for the stacked plot, ratio inputs, statistical and systematic uncertainty-band inputs, and the `post_rebin` rows in the negative MC contribution report. Variables not listed in `--rebin-plot-vars` keep their normal binning and, when applicable, use the configured `analysis_bins` edges from `cr_sr_plots_metadata.yml`. Rebinning is most useful together with `--variables` so focused checks do not render the entire pickle.
+
+#### Negative MC Contribution Reports
+
+The plotter writes negative MC contribution diagnostics by default. Disable them with `--no-negative-weight-report` if you only want figures. The output files are written under the selected plot output directory:
+
+```text
+negative_weight_contribution_report.csv
+negative_weight_contribution_summary.md
+```
+
+The CSV contains one row per negative bin contribution at two levels:
+
+* `level = process` identifies the raw process that contributed the negative bin.
+* `level = group` identifies the stacked plot group affected by the negative bin.
+
+The `stage` column records which binning was inspected:
+
+* `nominal_no_rebin` is used when no plot-time rebinning applies to that variable.
+* `pre_rebin` records the original visible bins when plot-time rebinning is requested.
+* `post_rebin` records the merged bins after plot-time rebinning.
+
+Important columns include `yield`, `sumw2`, `total_mc_yield`, `data_yield`, `yield_over_total_mc`, and `abs_yield_over_total_mc`. When `sumw2 >= 0`, `error = sqrt(sumw2)`. When `sumw2 > 0`, `effective_entries = yield^2 / sumw2`. The boolean flags use:
+
+* `is_compatible_with_zero_1sigma`: `abs(yield) <= error`;
+* `is_single_effective_entry_like`: `effective_entries <= 1.05`;
+* `is_low_effective_entries`: `effective_entries <= 5`.
+
+These reports are diagnostic aids, not physics corrections. Single-effective-entry-like rows often point to one or very few high-weight signed events. Rows compatible with zero at one sigma can be ordinary statistical fluctuations. Use the process and group rows to decide whether to rebin, annotate, or investigate a sample.
+
+`--report-zero-yields` is separate. It reports processes with zero or missing yields after plotting: it answers "what is absent or zero?" The negative contribution report answers "which signed MC components drive negative bins?"
+
+#### Focused CR Rebinning Example
+
+For a focused CR check of the known narrow-bin variables, run only the variables under study and request plot-time rebinning explicitly:
+
+```bash
+YR=2017
+PKL=/groups/klannon/apiccine/preappr_260613/2017CRs_preappr_2los_CRZ-2l_CR_njets-l1conept-l1eta-j0pt-j0eta-invmass-ljptsum-nbtagsm-npvsGood_np.pkl.gz
+
+python make_cr_and_sr_plots.py \
+  -f "$PKL" \
+  -n CR_preappr_rebin_check_${YR} \
+  -o ../../histos/ \
+  -y "$YR" \
+  --verbose \
+  --cr \
+  --workers 1 \
+  --channel-output both \
+  --variables j0pt l1conept \
+  --rebin-plot-vars j0pt:2,l1conept:2
+```
+
+The figures and negative-weight report files land under `../../histos/CR_preappr_rebin_check_${YR}`. The command does not modify `$PKL`.
+
 #### run_plotter.sh shell wrapper quickstart
 
 The `run_plotter.sh` helper script lives alongside `make_cr_and_sr_plots.py` and reproduces the same filename-based auto-detection for control vs. signal regions. After resolving the region it appends the corresponding `--cr` or `--sr` flag before delegating to the Python CLI. When both `CR` and `SR` tokens appear in the filename the wrapper prints a warning and falls back to the control-region defaults unless you pass an explicit override.
 
-Wrapper options mirror the Python interface with a few naming differences: `run_plotter.sh` uses `--input`/`--output-dir`/`--name` (vs `--pkl-file-path`/`--output-path`/`--output-name` on the Python CLI), requires `-y/--year`, and accepts `--variable` as a shorthand that it forwards as `--variables`. The required `-y/--year` flag shares the same individual years and `run2`/`run3` aggregates as the Python CLI (`run2` → `UL16 UL16APV UL17 UL18`, `run3` → `2022 2022EE 2023 2023BPix`), so you can reuse the shortcuts when hopping between Run 2 and Run 3 payloads. `--channel-output` forwards the merged/split/both selection along with the `*-njets` variants that preserve the per-njet bins from `cr_sr_plots_metadata.yml`, and `--blind` / `--unblind` toggle data visibility after the wrapper has selected a region. You can still provide manual `--cr` or `--sr` overrides, and any other switches the wrapper does not understand are forwarded untouched to `make_cr_and_sr_plots.py`. The historical `--` passthrough marker remains accepted for backward compatibility but is no longer required.
+Wrapper options mirror the Python interface with a few naming differences: `run_plotter.sh` uses `--input`/`--output-dir`/`--name` (vs `--pkl-file-path`/`--output-path`/`--output-name` on the Python CLI), requires `-y/--year`, and accepts `--variable` as a shorthand that it forwards as `--variables`. The required `-y/--year` flag shares the same individual years and `run2`/`run3` aggregates as the Python CLI (`run2` → `UL16 UL16APV UL17 UL18`, `run3` → `2022 2022EE 2023 2023BPix`), so you can reuse the shortcuts when hopping between Run 2 and Run 3 payloads. `--channel-output` forwards the merged/split/both selection along with the `*-njets` variants that preserve the per-njet bins from `cr_sr_plots_metadata.yml`, and `--blind` / `--unblind` toggle data visibility after the wrapper has selected a region. The wrapper also forwards `--rebin-plot-vars` and `--no-negative-weight-report`; any other switches the wrapper does not understand are passed untouched to `make_cr_and_sr_plots.py`. The historical `--` passthrough marker remains accepted for backward compatibility but is no longer required.
 
 If you need to control the Python interpreter, export `PYTHON_BIN="$PYTHON_ENV"` (or `PYTHON="$PYTHON_ENV"`) before calling the wrapper.
 
@@ -207,6 +280,8 @@ Example commands:
 * Enforcing a blinded SR pass with specific variables: `./run_plotter.sh -f histos/plotsTopEFT.pkl.gz -o ~/www/sr -n sr_scan -y run3 --sr --blind --variable lj0pt --variable ptz`
 * Passing additional CLI flags through the wrapper: `./run_plotter.sh -f histos/SR2018.pkl.gz -o ~/www/sr_2018 -y 2018 --unblind --skip-syst`
 * Switching the stacked panel to a log scale via the wrapper: `./run_plotter.sh -f histos/plotsCR_Run2.pkl.gz -o ~/www/cr_plots -y run2 --log-y`
+* Focused rebinning with the default negative report: `./run_plotter.sh -f histos/plotsCR_2017.pkl.gz -o ~/www/cr_plots -y 2017 --cr --variables j0pt l1conept --rebin-plot-vars j0pt:2,l1conept:2`
+* Suppressing the negative report when only figures are needed: `./run_plotter.sh -f histos/plotsCR_Run2.pkl.gz -o ~/www/cr_plots -y run2 --no-negative-weight-report`
 
 #### HTCondor plotting on Glados
 
@@ -238,6 +313,19 @@ Prefix the command with `--dry-run` when you want to review the generated job wr
 
 `--request-cpus` requires a positive integer and `--request-memory` must be a non-empty HTCondor size string; the helper validates both before submitting so typos are caught locally during the dry-run step. The generated submit file exports `TOPEFT_REPO_ROOT` (the parent directory of `analysis/topeft_run2`) and `TOPEFT_ENTRY_DIR` (`analysis/topeft_run2` itself) to mirror the `initialdir` specified in the submit description, so the entry script can derive its working directory deterministically; add `--conda-prefix ...` when you also need the helper to append `TOPEFT_CONDA_PREFIX` for environment activation. A literal `--` separator is still tolerated if you have scripts that emit it, but new invocations can omit it entirely.
 
+Plotter options such as `--variables`, `--rebin-plot-vars`, and `--no-negative-weight-report` are forwarded through `submit_plotter_condor.sh` to `run_plotter.sh`. For example, keep Condor options before the delimiter and plotting options after it when you want to make the split explicit:
+
+```bash
+./submit_plotter_condor.sh \
+  --request-cpus 2 --request-memory 6GB \
+  -- \
+  -f /cephfs/<group>/<netid>/topeft/pickles/plotsCR_2017.pkl.gz \
+  -o /cephfs/<group>/<netid>/topeft/plots/cr_2017_rebin \
+  -y 2017 --cr \
+  --variables j0pt l1conept \
+  --rebin-plot-vars j0pt:2,l1conept:2
+```
+
 **Entry-script environment steps**
 
 Jobs land in `analysis/topeft_run2/condor_plotter_entry.sh`, which unsets `PYTHONPATH`, resolves its working directory from `TOPEFT_ENTRY_DIR`/Condor's `initialdir`/the script path, logs the choice, and activates `clib-env` via either the discovered Conda installation or an explicit `TOPEFT_CONDA_PREFIX`. Override those environment variables in the submit script when you need to point at a different checkout, wrapper directory, or Conda stack, or if you prefer to activate a bespoke environment before calling `run_plotter.sh`. The entry script shares the same `main()`-style return handling as the other helpers, so sourcing it during local smoke tests or unit checks surfaces failures without exiting your shell.
@@ -265,11 +353,24 @@ Under the hood the CLI defers to a unified region runner so that both CR and SR 
 
 `produce_region_plots()` then iterates over the requested histograms, applies the appropriate channel transformations, and orchestrates the per-category plotting. In aggregate (CR) mode the channel axis is integrated before rendering, while the SR configuration keeps each channel separate. During this sweep the code also:
 
-* Removes samples that do not belong to the selected MC/data view and applies optional group-specific removals. Category skip rules in the metadata are ignored unless you explicitly add `--enable-category-skips`.
+* Removes samples that do not belong to the selected MC/data view and applies optional group-specific removals. Category skip rules in the metadata are ignored unless you explicitly add `--enable-category-skips`; sample/group removals and category skip rules are separate controls.
 * Fetches `sumw2` histograms for statistical uncertainties and combines them with shape/rate systematics where requested.
 * Switches between raw 1D plotting and the dedicated 2D heatmap path when sparse histograms are encountered.
+* Applies requested plot-time rebinning and collects negative MC contribution rows without mutating the input histograms.
 
 Because everything flows through the same `RegionContext`, adding a new region or adjusting behaviour in the YAML automatically updates both CR and SR plotting passes without touching the CLI.
+
+#### Sumw2 Companion Histograms
+
+The plotter uses `sumw2` companion histograms for statistical uncertainty bands and for the negative-report `error` and `effective_entries` diagnostics. Nominal histograms normally expose a dense axis named after the variable, such as `j0pt`. Companion `sumw2` histograms may use that same dense-axis name or a companion name such as `j0pt_sumw2`. If neither name exists and the histogram has exactly one unambiguous dense numeric axis, the plotter can use that axis. Missing or ambiguous dense axes raise a clear error so uncertainty bands and effective-entry calculations do not silently use the wrong binning.
+
+This naming flexibility matters most after plot-time rebinning: nominal contents, data contents, and summed `sumw2` values must be merged with the same target edges even when the companion histogram uses a `_sumw2` dense-axis name.
+
+#### Missing-Process-Tolerant Shape Systematics
+
+Shape-systematic group maps can name processes that are absent from a currently plotted histogram because of metadata skips, sample removals, year filtering, or category-specific process availability. During shape-systematic evaluation, absent process labels are ignored for the affected histogram/group. If a group has no available processes after intersecting with the histogram process axis, it contributes zero/absent uncertainty for that systematic rather than causing a global shape-systematic failure.
+
+This keeps ordinary skipped or absent processes from disabling unrelated shape systematics such as `renorm` or `fact`. It does not hide genuine problems: missing systematic labels, malformed axes, or failures unrelated to process-axis availability can still warn or fail normally.
 
 
 ### CR/SR metadata reference

--- a/analysis/topeft_run2/README.md
+++ b/analysis/topeft_run2/README.md
@@ -244,7 +244,7 @@ For a focused CR check of the known narrow-bin variables, run only the variables
 
 ```bash
 YR=2017
-PKL=/groups/klannon/apiccine/preappr_260613/2017CRs_preappr_2los_CRZ-2l_CR_njets-l1conept-l1eta-j0pt-j0eta-invmass-ljptsum-nbtagsm-npvsGood_np.pkl.gz
+PKL=/path/to/plotsCR_${YR}.pkl.gz
 
 python make_cr_and_sr_plots.py \
   -f "$PKL" \

--- a/analysis/topeft_run2/make_cr_and_sr_plots.py
+++ b/analysis/topeft_run2/make_cr_and_sr_plots.py
@@ -2075,6 +2075,47 @@ def _clone_with_rebinned_axis(histogram, axis_name, target_edges):
     )
 
 
+def _histogram_dense_axis_names(histogram):
+    """Return numeric dense-axis names available for plot-time rebinning."""
+
+    if histogram is None:
+        return []
+    if hasattr(histogram, "dense_axes"):
+        axes = histogram.dense_axes
+    elif isinstance(histogram, hist.Hist):
+        axes = histogram.axes
+    else:
+        return []
+    return [
+        axis.name
+        for axis in axes
+        if hasattr(axis, "edges") and not axis.__class__.__name__.endswith("Category")
+    ]
+
+
+def _resolve_sumw2_rebin_axis_name(histogram, variable):
+    """Resolve the dense axis to use when rebinding a sumw2 companion histogram."""
+
+    if histogram is None:
+        return None
+
+    dense_axis_names = _histogram_dense_axis_names(histogram)
+    candidates = [variable, f"{variable}_sumw2"]
+    for candidate in candidates:
+        if candidate in dense_axis_names:
+            return candidate
+
+    if len(dense_axis_names) == 1:
+        return dense_axis_names[0]
+
+    available = ", ".join(dense_axis_names) if dense_axis_names else "<none>"
+    tried = ", ".join(candidates)
+    raise ValueError(
+        "Cannot resolve sumw2 dense axis for variable "
+        f"'{variable}'. Tried: {tried}. Available dense axes: {available}."
+    )
+
+
 def _rebin_uncertainty_array(
     values,
     original_edges,
@@ -3964,8 +4005,9 @@ def collect_negative_rows_for_plot_stage(
     if target_edges is not None:
         hist_mc = _clone_with_rebinned_axis(hist_mc, variable, target_edges)
         hist_data = _clone_with_rebinned_axis(hist_data, variable, target_edges)
+        sumw2_axis_name = _resolve_sumw2_rebin_axis_name(hist_mc_sumw2, variable)
         hist_mc_sumw2 = _clone_with_rebinned_axis(
-            hist_mc_sumw2, variable, target_edges
+            hist_mc_sumw2, sumw2_axis_name, target_edges
         )
     return collect_negative_contribution_rows(
         variable=variable,
@@ -7526,8 +7568,9 @@ def make_region_stacked_ratio_fig(
                 h_mc = _clone_with_rebinned_axis(h_mc, var, target_edges)
                 h_data = _clone_with_rebinned_axis(h_data, var, target_edges)
                 if h_mc_sumw2 is not None:
+                    sumw2_axis_name = _resolve_sumw2_rebin_axis_name(h_mc_sumw2, var)
                     h_mc_sumw2 = _clone_with_rebinned_axis(
-                        h_mc_sumw2, var, target_edges
+                        h_mc_sumw2, sumw2_axis_name, target_edges
                     )
     else:
         target_edges = None

--- a/analysis/topeft_run2/make_cr_and_sr_plots.py
+++ b/analysis/topeft_run2/make_cr_and_sr_plots.py
@@ -2116,6 +2116,20 @@ def _resolve_sumw2_rebin_axis_name(histogram, variable):
     )
 
 
+def _clone_sumw2_with_rebinned_axis(histogram, variable, target_edges):
+    """Clone a sumw2 histogram using its nominal or companion dense axis.
+
+    Sumw2 companion histograms may use the nominal dense-axis name or a
+    ``<variable>_sumw2`` dense-axis name.  Keep that policy centralized so
+    plot-time rebinning and negative-report collection do not drift apart.
+    """
+
+    if histogram is None:
+        return None
+    sumw2_axis_name = _resolve_sumw2_rebin_axis_name(histogram, variable)
+    return _clone_with_rebinned_axis(histogram, sumw2_axis_name, target_edges)
+
+
 def _rebin_uncertainty_array(
     values,
     original_edges,
@@ -3075,62 +3089,21 @@ def _render_variable_category(
                 "style": region_ctx.stacked_ratio_style,
             }
             bins_override = region_ctx.analysis_bins.get(var_name)
-            target_edges, rebin_factor, rebin_leftover = _resolve_rebin_plot_edges(
-                var_name,
-                hist_mc_integrated,
-                rebin_plot_vars,
+            rebin_report = _prepare_plot_rebin_and_negative_rows(
+                variable=var_name,
+                hist_mc=hist_mc_integrated,
+                hist_mc_sumw2=hist_mc_sumw2_integrated,
+                hist_data=hist_data_integrated,
+                group_map=group,
+                channel_or_region=region_ctx.name,
+                category_if_available=hist_cat,
+                rebin_plot_vars=rebin_plot_vars,
                 base_edges=bins_override,
+                negative_weight_report=negative_weight_report,
             )
-            if target_edges is not None:
-                if rebin_leftover:
-                    logger.warning(
-                        "Plot-time rebinning for variable '%s' by factor %d leaves leftover bins; merging leftovers into the final bin.",
-                        var_name,
-                        rebin_factor,
-                    )
-                stacked_kwargs["bins"] = target_edges
-                if negative_weight_report:
-                    negative_rows.extend(
-                        collect_negative_rows_for_plot_stage(
-                            variable=var_name,
-                            channel_or_region=region_ctx.name,
-                            category_if_available=hist_cat,
-                            stage="pre_rebin",
-                            hist_mc=hist_mc_integrated,
-                            hist_mc_sumw2=hist_mc_sumw2_integrated,
-                            hist_data=hist_data_integrated,
-                            group_map=group,
-                        )
-                    )
-                    negative_rows.extend(
-                        collect_negative_rows_for_plot_stage(
-                            variable=var_name,
-                            channel_or_region=region_ctx.name,
-                            category_if_available=hist_cat,
-                            stage="post_rebin",
-                            hist_mc=hist_mc_integrated,
-                            hist_mc_sumw2=hist_mc_sumw2_integrated,
-                            hist_data=hist_data_integrated,
-                            group_map=group,
-                            target_edges=target_edges,
-                        )
-                    )
-            else:
-                if bins_override is not None:
-                    stacked_kwargs["bins"] = bins_override
-                if negative_weight_report:
-                    negative_rows.extend(
-                        collect_negative_rows_for_plot_stage(
-                            variable=var_name,
-                            channel_or_region=region_ctx.name,
-                            category_if_available=hist_cat,
-                            stage="nominal_no_rebin",
-                            hist_mc=hist_mc_integrated,
-                            hist_mc_sumw2=hist_mc_sumw2_integrated,
-                            hist_data=hist_data_integrated,
-                            group_map=group,
-                        )
-                    )
+            if rebin_report["bins"] is not None:
+                stacked_kwargs["bins"] = rebin_report["bins"]
+            negative_rows.extend(rebin_report["negative_rows"])
             fig = make_region_stacked_ratio_fig(
                 hist_mc_integrated,
                 hist_data_integrated,
@@ -3376,62 +3349,21 @@ def _render_variable_category(
             "style": region_ctx.stacked_ratio_style,
         }
         bins_to_use = bins_override if bins_override is not None else default_bins
-        target_edges, rebin_factor, rebin_leftover = _resolve_rebin_plot_edges(
-            var_name,
-            hist_mc_integrated,
-            rebin_plot_vars,
+        rebin_report = _prepare_plot_rebin_and_negative_rows(
+            variable=var_name,
+            hist_mc=hist_mc_integrated,
+            hist_mc_sumw2=hist_mc_sumw2,
+            hist_data=hist_data_integrated,
+            group_map=stacked_kwargs["group"],
+            channel_or_region=region_ctx.name,
+            category_if_available=hist_cat,
+            rebin_plot_vars=rebin_plot_vars,
             base_edges=bins_to_use,
+            negative_weight_report=negative_weight_report,
         )
-        if target_edges is not None:
-            if rebin_leftover:
-                logger.warning(
-                    "Plot-time rebinning for variable '%s' by factor %d leaves leftover bins; merging leftovers into the final bin.",
-                    var_name,
-                    rebin_factor,
-                )
-            stacked_kwargs["bins"] = target_edges
-            if negative_weight_report:
-                negative_rows.extend(
-                    collect_negative_rows_for_plot_stage(
-                        variable=var_name,
-                        channel_or_region=region_ctx.name,
-                        category_if_available=hist_cat,
-                        stage="pre_rebin",
-                        hist_mc=hist_mc_integrated,
-                        hist_mc_sumw2=hist_mc_sumw2,
-                        hist_data=hist_data_integrated,
-                        group_map=stacked_kwargs["group"],
-                    )
-                )
-                negative_rows.extend(
-                    collect_negative_rows_for_plot_stage(
-                        variable=var_name,
-                        channel_or_region=region_ctx.name,
-                        category_if_available=hist_cat,
-                        stage="post_rebin",
-                        hist_mc=hist_mc_integrated,
-                        hist_mc_sumw2=hist_mc_sumw2,
-                        hist_data=hist_data_integrated,
-                        group_map=stacked_kwargs["group"],
-                        target_edges=target_edges,
-                    )
-                )
-        else:
-            if bins_to_use is not None:
-                stacked_kwargs["bins"] = bins_to_use
-            if negative_weight_report:
-                negative_rows.extend(
-                    collect_negative_rows_for_plot_stage(
-                        variable=var_name,
-                        channel_or_region=region_ctx.name,
-                        category_if_available=hist_cat,
-                        stage="nominal_no_rebin",
-                        hist_mc=hist_mc_integrated,
-                        hist_mc_sumw2=hist_mc_sumw2,
-                        hist_data=hist_data_integrated,
-                        group_map=stacked_kwargs["group"],
-                    )
-                )
+        if rebin_report["bins"] is not None:
+            stacked_kwargs["bins"] = rebin_report["bins"]
+        negative_rows.extend(rebin_report["negative_rows"])
         fig = make_region_stacked_ratio_fig(
             hist_mc_integrated,
             hist_data_integrated,
@@ -4000,14 +3932,13 @@ def collect_negative_rows_for_plot_stage(
     group_map,
     target_edges=None,
 ):
-    """Collect negative rows after optionally applying a plot-time rebin."""
+    """Collect negative rows after optionally applying a plot/report-time rebin."""
 
     if target_edges is not None:
         hist_mc = _clone_with_rebinned_axis(hist_mc, variable, target_edges)
         hist_data = _clone_with_rebinned_axis(hist_data, variable, target_edges)
-        sumw2_axis_name = _resolve_sumw2_rebin_axis_name(hist_mc_sumw2, variable)
-        hist_mc_sumw2 = _clone_with_rebinned_axis(
-            hist_mc_sumw2, sumw2_axis_name, target_edges
+        hist_mc_sumw2 = _clone_sumw2_with_rebinned_axis(
+            hist_mc_sumw2, variable, target_edges
         )
     return collect_negative_contribution_rows(
         variable=variable,
@@ -4019,6 +3950,95 @@ def collect_negative_rows_for_plot_stage(
         hist_data=hist_data,
         group_map=group_map,
     )
+
+
+def _prepare_plot_rebin_and_negative_rows(
+    *,
+    variable,
+    hist_mc,
+    hist_mc_sumw2,
+    hist_data,
+    group_map,
+    channel_or_region,
+    category_if_available,
+    rebin_plot_vars,
+    base_edges=None,
+    negative_weight_report=True,
+):
+    """Resolve plot-time bins and matching negative-report stage rows.
+
+    This is intentionally plot/report-time only: it returns the bin edges to
+    pass into the plotting helper and collects rows with the existing stage
+    labels ``nominal_no_rebin``, ``pre_rebin``, and ``post_rebin`` without
+    mutating the input histograms or changing CLI behavior.
+    """
+
+    negative_rows = []
+    target_edges, rebin_factor, rebin_leftover = _resolve_rebin_plot_edges(
+        variable,
+        hist_mc,
+        rebin_plot_vars,
+        base_edges=base_edges,
+    )
+
+    if target_edges is not None:
+        if rebin_leftover:
+            logger.warning(
+                "Plot-time rebinning for variable '%s' by factor %d leaves leftover bins; merging leftovers into the final bin.",
+                variable,
+                rebin_factor,
+            )
+        if negative_weight_report:
+            common_kwargs = {
+                "variable": variable,
+                "channel_or_region": channel_or_region,
+                "category_if_available": category_if_available,
+                "hist_mc": hist_mc,
+                "hist_mc_sumw2": hist_mc_sumw2,
+                "hist_data": hist_data,
+                "group_map": group_map,
+            }
+            negative_rows.extend(
+                collect_negative_rows_for_plot_stage(
+                    stage="pre_rebin",
+                    **common_kwargs,
+                )
+            )
+            negative_rows.extend(
+                collect_negative_rows_for_plot_stage(
+                    stage="post_rebin",
+                    target_edges=target_edges,
+                    **common_kwargs,
+                )
+            )
+        return {
+            "target_edges": target_edges,
+            "bins": target_edges,
+            "negative_rows": negative_rows,
+            "rebin_factor": rebin_factor,
+            "rebin_leftover": rebin_leftover,
+        }
+
+    if negative_weight_report:
+        negative_rows.extend(
+            collect_negative_rows_for_plot_stage(
+                variable=variable,
+                channel_or_region=channel_or_region,
+                category_if_available=category_if_available,
+                stage="nominal_no_rebin",
+                hist_mc=hist_mc,
+                hist_mc_sumw2=hist_mc_sumw2,
+                hist_data=hist_data,
+                group_map=group_map,
+            )
+        )
+    return {
+        "target_edges": None,
+        "bins": base_edges,
+        "negative_rows": negative_rows,
+        "rebin_factor": None,
+        "rebin_leftover": False,
+    }
 
 
 def _format_report_float(value):
@@ -7568,9 +7588,8 @@ def make_region_stacked_ratio_fig(
                 h_mc = _clone_with_rebinned_axis(h_mc, var, target_edges)
                 h_data = _clone_with_rebinned_axis(h_data, var, target_edges)
                 if h_mc_sumw2 is not None:
-                    sumw2_axis_name = _resolve_sumw2_rebin_axis_name(h_mc_sumw2, var)
-                    h_mc_sumw2 = _clone_with_rebinned_axis(
-                        h_mc_sumw2, sumw2_axis_name, target_edges
+                    h_mc_sumw2 = _clone_sumw2_with_rebinned_axis(
+                        h_mc_sumw2, var, target_edges
                     )
     else:
         target_edges = None

--- a/analysis/topeft_run2/make_cr_and_sr_plots.py
+++ b/analysis/topeft_run2/make_cr_and_sr_plots.py
@@ -1,6 +1,7 @@
 import numpy as np
 import os
 import copy
+import csv
 import datetime
 import argparse
 import json
@@ -1783,6 +1784,109 @@ def _validate_bin_edges(edges):
     return array
 
 
+def parse_rebin_plot_vars(raw_value):
+    """Parse a comma-separated variable-to-integer-factor rebin specification."""
+
+    if raw_value is None:
+        return {}
+    raw_text = str(raw_value).strip()
+    if not raw_text:
+        return {}
+
+    parsed = OrderedDict()
+    for raw_entry in raw_text.split(","):
+        entry = raw_entry.strip()
+        if not entry:
+            continue
+        if ":" in entry:
+            var_name, factor_text = entry.split(":", 1)
+        elif "=" in entry:
+            var_name, factor_text = entry.split("=", 1)
+        else:
+            raise ValueError(
+                f"Malformed rebin entry '{entry}'. Expected '<variable>:<factor>'."
+            )
+        var_name = var_name.strip()
+        factor_text = factor_text.strip()
+        if not var_name:
+            raise ValueError(f"Malformed rebin entry '{entry}': variable is empty.")
+        try:
+            factor = int(factor_text)
+        except ValueError as exc:
+            raise ValueError(
+                f"Invalid rebin factor for variable '{var_name}': '{factor_text}'."
+            ) from exc
+        if factor < 2:
+            raise ValueError(
+                f"Invalid rebin factor for variable '{var_name}': expected integer >= 2."
+            )
+        parsed[var_name] = factor
+
+    return parsed
+
+
+def _rebin_factor_slices(n_bins, factor):
+    if factor < 2:
+        raise ValueError("Rebin factor must be >= 2.")
+    if n_bins < 1:
+        raise ValueError("Cannot rebin an empty 1D bin array.")
+    return [
+        slice(start, min(start + factor, n_bins))
+        for start in range(0, n_bins, factor)
+    ]
+
+
+def rebin_1d_values(values, factor):
+    """Return 1D bin contents rebinned by summing groups of *factor* bins."""
+
+    array = np.asarray(values)
+    if array.ndim != 1:
+        raise ValueError("Only one-dimensional arrays can be rebinned.")
+    return np.asarray([array[slc].sum() for slc in _rebin_factor_slices(array.size, factor)])
+
+
+def rebin_1d_variances(variances, factor):
+    """Return 1D variances rebinned by summing grouped-bin variances."""
+
+    return rebin_1d_values(variances, factor)
+
+
+def rebin_1d_edges(edges, factor):
+    """Return variable-width edges after grouping visible bins by *factor*.
+
+    If the source bin count is not divisible by *factor*, the leftover bins are
+    merged into the final rebinned bin.
+    """
+
+    edge_array = _validate_bin_edges(edges)
+    n_bins = edge_array.size - 1
+    slices = _rebin_factor_slices(n_bins, factor)
+    new_edges = [edge_array[0]]
+    for slc in slices:
+        new_edges.append(edge_array[slc.stop])
+    return np.asarray(new_edges, dtype=float)
+
+
+def _rebin_has_leftover(edges, factor):
+    edge_array = _validate_bin_edges(edges)
+    return ((edge_array.size - 1) % factor) != 0
+
+
+def _resolve_rebin_plot_edges(var_name, histogram, rebin_plot_vars, base_edges=None):
+    factor = (rebin_plot_vars or {}).get(var_name)
+    if factor is None:
+        return None, None, False
+    if base_edges is None:
+        try:
+            base_edges = histogram.axes[var_name].edges
+        except (AttributeError, KeyError) as exc:
+            raise ValueError(
+                f"Cannot apply plot-time rebinning to variable '{var_name}': no compatible dense axis found."
+            ) from exc
+    target_edges = rebin_1d_edges(base_edges, factor)
+    return target_edges, factor, _rebin_has_leftover(base_edges, factor)
+
+
 def _build_variable_axis_like(axis, edges):
     """Construct a Variable axis matching the metadata of an existing dense axis."""
 
@@ -1867,8 +1971,10 @@ def _rebin_dense_histogram(dense_hist, axis_name, target_edges):
     """Return a rebinned copy of a dense hist.Hist along the specified axis."""
 
     try:
-        axis_index = dense_hist.axes.index(axis_name)
-    except ValueError as exc:  # pragma: no cover - defensive guard
+        axis_index = next(
+            idx for idx, axis in enumerate(dense_hist.axes) if axis.name == axis_name
+        )
+    except StopIteration as exc:  # pragma: no cover - defensive guard
         raise ValueError(f"Axis '{axis_name}' not found in histogram.") from exc
 
     original_axis = dense_hist.axes[axis_index]
@@ -2193,6 +2299,8 @@ def _initialize_render_worker(
     unblind_flag,
     stacked_log_y,
     verbose,
+    rebin_plot_vars=None,
+    negative_weight_report=True,
     prepared_payloads=None,
     shared_region_ctx=None,
 ):
@@ -2221,6 +2329,8 @@ def _initialize_render_worker(
         "unblind_flag": unblind_flag,
         "stacked_log_y": stacked_log_y,
         "verbose": bool(verbose),
+        "rebin_plot_vars": dict(rebin_plot_vars or {}),
+        "negative_weight_report": bool(negative_weight_report),
         "prepared_variables": prepared_variables,
     }
 
@@ -2267,7 +2377,7 @@ def _render_variable_from_worker(task_id, payload):
     )
 
     if category is None:
-        stat_only, stat_and_syst, html_set = _render_variable(
+        stat_only, stat_and_syst, html_set, negative_rows = _render_variable(
             var_name,
             ctx["region_ctx"],
             ctx["save_dir_path"],
@@ -2278,10 +2388,12 @@ def _render_variable_from_worker(task_id, payload):
             verbose=verbose,
             category=category,
             variable_payload=variable_payload,
+            rebin_plot_vars=ctx["rebin_plot_vars"],
+            negative_weight_report=ctx["negative_weight_report"],
         )
     else:
         if not variable_payload:
-            stat_only, stat_and_syst, html_set = 0, 0, set()
+            stat_only, stat_and_syst, html_set, negative_rows = 0, 0, set(), []
         else:
             region_ctx = ctx["region_ctx"]
             channel_bins = variable_payload["channel_dict"].get(category)
@@ -2291,9 +2403,9 @@ def _render_variable_from_worker(task_id, payload):
                     region_ctx.category_skip_rules, category, var_name
                 )
             ):
-                stat_only, stat_and_syst, html_set = 0, 0, set()
+                stat_only, stat_and_syst, html_set, negative_rows = 0, 0, set(), []
             else:
-                stat_only, stat_and_syst, html_set = _render_variable_category(
+                stat_only, stat_and_syst, html_set, negative_rows = _render_variable_category(
                     var_name,
                     category,
                     channel_bins,
@@ -2313,8 +2425,10 @@ def _render_variable_from_worker(task_id, payload):
                         "channel_display_labels", {}
                     ),
                     available_channels=variable_payload.get("available_channels"),
+                    rebin_plot_vars=ctx["rebin_plot_vars"],
+                    negative_weight_report=ctx["negative_weight_report"],
                 )
-    return task_id, stat_only, stat_and_syst, html_set
+    return task_id, stat_only, stat_and_syst, html_set, negative_rows
 
 
 def _prepare_variable_payload(
@@ -2491,6 +2605,8 @@ def _render_variable(
     verbose=False,
     category=None,
     variable_payload=None,
+    rebin_plot_vars=None,
+    negative_weight_report=True,
 ):
     """Render plots for *var_name* and return summary accounting."""
 
@@ -2506,7 +2622,7 @@ def _render_variable(
             unblind_flag=unblind_flag,
         )
     if not variable_payload:
-        return 0, 0, set()
+        return 0, 0, set(), []
 
     _ensure_variable_channel_coverage_validated(var_name, region_ctx, variable_payload)
 
@@ -2516,6 +2632,7 @@ def _render_variable(
     stat_only_plots = 0
     stat_and_syst_plots = 0
     html_dirs = set()
+    negative_rows = []
 
     if category is not None:
         channel_items = (
@@ -2534,7 +2651,7 @@ def _render_variable(
         ):
             continue
 
-        stat_only, stat_and_syst, html_set = _render_variable_category(
+        stat_only, stat_and_syst, html_set, category_negative_rows = _render_variable_category(
             var_name,
             hist_cat,
             channel_bins,
@@ -2552,12 +2669,15 @@ def _render_variable(
             verbose=verbose,
             channel_display_labels=channel_display_labels,
             available_channels=variable_payload.get("available_channels"),
+            rebin_plot_vars=rebin_plot_vars,
+            negative_weight_report=negative_weight_report,
         )
         stat_only_plots += stat_only
         stat_and_syst_plots += stat_and_syst
         html_dirs.update(html_set)
+        negative_rows.extend(category_negative_rows)
 
-    return stat_only_plots, stat_and_syst_plots, html_dirs
+    return stat_only_plots, stat_and_syst_plots, html_dirs, negative_rows
 
 
 def _render_variable_category(
@@ -2579,8 +2699,15 @@ def _render_variable_category(
     verbose=False,
     channel_display_labels=None,
     available_channels=None,
+    rebin_plot_vars=None,
+    negative_weight_report=True,
 ):
     """Render a single (variable, category) pair and return bookkeeping totals."""
+
+    negative_rows = []
+
+    def _empty_render_result():
+        return 0, 0, html_dirs, negative_rows
 
     if available_channels is None:
         available_channels = _resolve_channel_axis_labels(hist_mc)
@@ -2602,7 +2729,7 @@ def _render_variable_category(
         )
 
     if not filtered_bins:
-        return 0, 0, set()
+        return 0, 0, set(), negative_rows
 
     validate_channel_group(
         [hist_mc, hist_data],
@@ -2685,7 +2812,7 @@ def _render_variable_category(
                 hist_mc_integrated is not None,
                 hist_data_integrated is not None,
             )
-            return 0, 0, html_dirs
+            return _empty_render_result()
         hist_mc_sumw2_integrated = None
         if hist_mc_sumw2_orig is not None:
             hist_mc_sumw2_integrated = _integrate_category(
@@ -2821,7 +2948,7 @@ def _render_variable_category(
                     hist_cat,
                     var_name,
                 )
-                return 0, 0, html_dirs
+                return _empty_render_result()
             hist_mc_nominal = hist_mc_integrated[{"process": sum}].integrate(
                 "systematic", "nominal"
             )
@@ -2836,7 +2963,7 @@ def _render_variable_category(
                     hist_cat,
                     var_name,
                 )
-                return 0, 0, html_dirs
+                return _empty_render_result()
             fig = make_sparse2d_fig(
                 hist_mc_nominal,
                 hist_data_nominal,
@@ -2871,7 +2998,7 @@ def _render_variable_category(
                     mc_empty=mc_empty,
                     data_empty=data_empty,
                 )
-                return 0, 0, html_dirs
+                return _empty_render_result()
             if unblind_flag and not has_data:
                 _warn_undrawable_plot(
                     reason="empty-data-content",
@@ -2881,7 +3008,7 @@ def _render_variable_category(
                     mc_empty=mc_empty,
                     data_empty=data_empty,
                 )
-                return 0, 0, html_dirs
+                return _empty_render_result()
             if mc_empty or (unblind_flag and data_empty):
                 _warn_undrawable_plot(
                     reason="empty-or-missing-input",
@@ -2891,7 +3018,7 @@ def _render_variable_category(
                     mc_empty=mc_empty,
                     data_empty=data_empty,
                 )
-                return 0, 0, html_dirs
+                return _empty_render_result()
             x_range = (0, 250) if var_name == "ht" else None
             group = {k: v for k, v in region_ctx.group_map.items() if v}
             stacked_kwargs = {
@@ -2907,8 +3034,62 @@ def _render_variable_category(
                 "style": region_ctx.stacked_ratio_style,
             }
             bins_override = region_ctx.analysis_bins.get(var_name)
-            if bins_override is not None:
-                stacked_kwargs["bins"] = bins_override
+            target_edges, rebin_factor, rebin_leftover = _resolve_rebin_plot_edges(
+                var_name,
+                hist_mc_integrated,
+                rebin_plot_vars,
+                base_edges=bins_override,
+            )
+            if target_edges is not None:
+                if rebin_leftover:
+                    logger.warning(
+                        "Plot-time rebinning for variable '%s' by factor %d leaves leftover bins; merging leftovers into the final bin.",
+                        var_name,
+                        rebin_factor,
+                    )
+                stacked_kwargs["bins"] = target_edges
+                if negative_weight_report:
+                    negative_rows.extend(
+                        collect_negative_rows_for_plot_stage(
+                            variable=var_name,
+                            channel_or_region=region_ctx.name,
+                            category_if_available=hist_cat,
+                            stage="pre_rebin",
+                            hist_mc=hist_mc_integrated,
+                            hist_mc_sumw2=hist_mc_sumw2_integrated,
+                            hist_data=hist_data_integrated,
+                            group_map=group,
+                        )
+                    )
+                    negative_rows.extend(
+                        collect_negative_rows_for_plot_stage(
+                            variable=var_name,
+                            channel_or_region=region_ctx.name,
+                            category_if_available=hist_cat,
+                            stage="post_rebin",
+                            hist_mc=hist_mc_integrated,
+                            hist_mc_sumw2=hist_mc_sumw2_integrated,
+                            hist_data=hist_data_integrated,
+                            group_map=group,
+                            target_edges=target_edges,
+                        )
+                    )
+            else:
+                if bins_override is not None:
+                    stacked_kwargs["bins"] = bins_override
+                if negative_weight_report:
+                    negative_rows.extend(
+                        collect_negative_rows_for_plot_stage(
+                            variable=var_name,
+                            channel_or_region=region_ctx.name,
+                            category_if_available=hist_cat,
+                            stage="nominal_no_rebin",
+                            hist_mc=hist_mc_integrated,
+                            hist_mc_sumw2=hist_mc_sumw2_integrated,
+                            hist_data=hist_data_integrated,
+                            group_map=group,
+                        )
+                    )
             fig = make_region_stacked_ratio_fig(
                 hist_mc_integrated,
                 hist_data_integrated,
@@ -2928,7 +3109,7 @@ def _render_variable_category(
                     mc_empty=mc_empty,
                     data_empty=data_empty,
                 )
-                return 0, 0, html_dirs
+                return _empty_render_result()
         title = category_label + "_" + var_name
         if unit_norm_bool:
             title = title + "_unitnorm"
@@ -2976,7 +3157,7 @@ def _render_variable_category(
             if chan in hist_mc.axes["channel"]
         ]
         if not channels:
-            return 0, 0, html_dirs
+            return _empty_render_result()
         hist_mc_channel = hist_mc.integrate("channel", channels)[{"channel": sum}]
         samples_to_rm = _collect_samples_to_remove(
             region_ctx.sample_removal_rules, hist_cat, region_ctx
@@ -3110,7 +3291,7 @@ def _render_variable_category(
                 mc_empty=_hist_is_empty(hist_mc_integrated),
                 data_empty=_hist_is_empty(hist_data_integrated),
             )
-            return 0, 0, html_dirs
+            return _empty_render_result()
         if unblind_flag and not has_data:
             _warn_undrawable_plot(
                 reason="empty-data-content",
@@ -3120,7 +3301,7 @@ def _render_variable_category(
                 mc_empty=_hist_is_empty(hist_mc_integrated),
                 data_empty=_hist_is_empty(hist_data_integrated),
             )
-            return 0, 0, html_dirs
+            return _empty_render_result()
         mc_empty = _hist_is_empty(hist_mc_integrated)
         data_empty = _hist_is_empty(hist_data_integrated)
         if mc_empty or (unblind_flag and data_empty):
@@ -3132,7 +3313,7 @@ def _render_variable_category(
                 mc_empty=mc_empty,
                 data_empty=data_empty,
             )
-            return 0, 0, html_dirs
+            return _empty_render_result()
         title = f"{category_label}_{var_name}"
         if unit_norm_bool:
             title = f"{title}_unitnorm"
@@ -3154,8 +3335,62 @@ def _render_variable_category(
             "style": region_ctx.stacked_ratio_style,
         }
         bins_to_use = bins_override if bins_override is not None else default_bins
-        if bins_to_use is not None:
-            stacked_kwargs["bins"] = bins_to_use
+        target_edges, rebin_factor, rebin_leftover = _resolve_rebin_plot_edges(
+            var_name,
+            hist_mc_integrated,
+            rebin_plot_vars,
+            base_edges=bins_to_use,
+        )
+        if target_edges is not None:
+            if rebin_leftover:
+                logger.warning(
+                    "Plot-time rebinning for variable '%s' by factor %d leaves leftover bins; merging leftovers into the final bin.",
+                    var_name,
+                    rebin_factor,
+                )
+            stacked_kwargs["bins"] = target_edges
+            if negative_weight_report:
+                negative_rows.extend(
+                    collect_negative_rows_for_plot_stage(
+                        variable=var_name,
+                        channel_or_region=region_ctx.name,
+                        category_if_available=hist_cat,
+                        stage="pre_rebin",
+                        hist_mc=hist_mc_integrated,
+                        hist_mc_sumw2=hist_mc_sumw2,
+                        hist_data=hist_data_integrated,
+                        group_map=stacked_kwargs["group"],
+                    )
+                )
+                negative_rows.extend(
+                    collect_negative_rows_for_plot_stage(
+                        variable=var_name,
+                        channel_or_region=region_ctx.name,
+                        category_if_available=hist_cat,
+                        stage="post_rebin",
+                        hist_mc=hist_mc_integrated,
+                        hist_mc_sumw2=hist_mc_sumw2,
+                        hist_data=hist_data_integrated,
+                        group_map=stacked_kwargs["group"],
+                        target_edges=target_edges,
+                    )
+                )
+        else:
+            if bins_to_use is not None:
+                stacked_kwargs["bins"] = bins_to_use
+            if negative_weight_report:
+                negative_rows.extend(
+                    collect_negative_rows_for_plot_stage(
+                        variable=var_name,
+                        channel_or_region=region_ctx.name,
+                        category_if_available=hist_cat,
+                        stage="nominal_no_rebin",
+                        hist_mc=hist_mc_integrated,
+                        hist_mc_sumw2=hist_mc_sumw2,
+                        hist_data=hist_data_integrated,
+                        group_map=stacked_kwargs["group"],
+                    )
+                )
         fig = make_region_stacked_ratio_fig(
             hist_mc_integrated,
             hist_data_integrated,
@@ -3172,7 +3407,7 @@ def _render_variable_category(
                 mc_empty=mc_empty,
                 data_empty=data_empty,
             )
-            return 0, 0, html_dirs
+            return _empty_render_result()
         save_path = os.path.join(save_dir_path_tmp, f"{title}.png")
         fig.savefig(save_path, bbox_inches="tight", pad_inches=0.05)
         _close_figure_payload(fig)
@@ -3197,7 +3432,7 @@ def _render_variable_category(
     if "www" in save_dir_path_tmp:
         html_dirs.add(save_dir_path_tmp)
 
-    return stat_only_plots, stat_and_syst_plots, html_dirs
+    return stat_only_plots, stat_and_syst_plots, html_dirs, negative_rows
 def _resolve_requested_variables(dict_of_hists, variables, context):
     """Return the ordered list of variables to process for a plotting function."""
 
@@ -3483,6 +3718,362 @@ def _safe_divide(num, denom, default, zero_over_zero=None):
         zero_zero_mask = (denom_arr == 0) & (num_arr == 0)
         out[zero_zero_mask] = zero_over_zero
     return out
+
+
+NEGATIVE_WEIGHT_REPORT_COLUMNS = [
+    "variable",
+    "channel_or_region",
+    "category_if_available",
+    "stage",
+    "level",
+    "process",
+    "group",
+    "bin_index",
+    "bin_low",
+    "bin_high",
+    "yield",
+    "sumw2",
+    "error",
+    "effective_entries",
+    "total_mc_yield",
+    "data_yield",
+    "yield_over_total_mc",
+    "abs_yield_over_total_mc",
+    "is_compatible_with_zero_1sigma",
+    "is_single_effective_entry_like",
+    "is_low_effective_entries",
+]
+
+
+def effective_entries(yield_value, sumw2_value):
+    """Return yield²/sumw², or NaN when sumw² is unavailable/non-positive."""
+
+    if sumw2_value is None or not np.isfinite(sumw2_value) or sumw2_value <= 0:
+        return np.nan
+    return (float(yield_value) * float(yield_value)) / float(sumw2_value)
+
+
+def _negative_row_flags(yield_value, sumw2_value):
+    error = np.nan
+    if sumw2_value is not None and np.isfinite(sumw2_value) and sumw2_value >= 0:
+        error = math.sqrt(float(sumw2_value))
+    eff_entries = effective_entries(yield_value, sumw2_value)
+    return {
+        "error": error,
+        "effective_entries": eff_entries,
+        "is_compatible_with_zero_1sigma": bool(
+            np.isfinite(error) and abs(float(yield_value)) <= error
+        ),
+        "is_single_effective_entry_like": bool(
+            np.isfinite(eff_entries) and eff_entries <= 1.05
+        ),
+        "is_low_effective_entries": bool(
+            np.isfinite(eff_entries) and eff_entries <= 5.0
+        ),
+    }
+
+
+def _hist_1d_edges(hist_obj, var_name):
+    try:
+        return np.asarray(hist_obj.axes[var_name].edges, dtype=float)
+    except (AttributeError, KeyError) as exc:
+        raise ValueError(f"Histogram has no dense axis '{var_name}'.") from exc
+
+
+def _hist_1d_visible_values(hist_obj, var_name):
+    values = np.asarray(_values_without_flow(hist_obj, include_overflow=False), dtype=float)
+    if values.ndim == 0:
+        values = values.reshape(1)
+    if values.ndim != 1:
+        raise ValueError(
+            f"Expected a one-dimensional histogram projection for '{var_name}', got shape {values.shape}."
+        )
+    return values
+
+
+def _process_values_from_hist(hist_obj, processes, var_name, template):
+    if hist_obj is None:
+        return np.full_like(template, np.nan, dtype=float)
+    try:
+        available = set(hist_obj.axes["process"])
+    except (AttributeError, KeyError):
+        return np.full_like(template, np.nan, dtype=float)
+    if processes is sum:
+        selected = hist_obj[{"process": sum}]
+        return _hist_1d_visible_values(selected, var_name)
+    present = [proc for proc in processes if proc in available]
+    if not present:
+        return np.zeros_like(template, dtype=float)
+    selected = hist_obj[{"process": present}][{"process": sum}]
+    return _hist_1d_visible_values(selected, var_name)
+
+
+def _make_negative_contribution_row(
+    *,
+    variable,
+    channel_or_region,
+    category_if_available,
+    stage,
+    level,
+    process,
+    group,
+    bin_index,
+    bin_low,
+    bin_high,
+    yield_value,
+    sumw2_value,
+    total_mc_yield,
+    data_yield,
+):
+    flags = _negative_row_flags(yield_value, sumw2_value)
+    yield_over_total = np.nan
+    if np.isfinite(total_mc_yield) and not np.isclose(total_mc_yield, 0.0):
+        yield_over_total = float(yield_value) / float(total_mc_yield)
+    row = {
+        "variable": variable,
+        "channel_or_region": channel_or_region,
+        "category_if_available": category_if_available or "",
+        "stage": stage,
+        "level": level,
+        "process": process or "",
+        "group": group or "",
+        "bin_index": int(bin_index),
+        "bin_low": float(bin_low),
+        "bin_high": float(bin_high),
+        "yield": float(yield_value),
+        "sumw2": float(sumw2_value) if sumw2_value is not None else np.nan,
+        "total_mc_yield": float(total_mc_yield),
+        "data_yield": float(data_yield),
+        "yield_over_total_mc": yield_over_total,
+        "abs_yield_over_total_mc": abs(yield_over_total)
+        if np.isfinite(yield_over_total)
+        else np.nan,
+    }
+    row.update(flags)
+    return row
+
+
+def collect_negative_contribution_rows(
+    *,
+    variable,
+    channel_or_region,
+    category_if_available,
+    stage,
+    hist_mc,
+    hist_mc_sumw2,
+    hist_data,
+    group_map,
+):
+    """Collect process-level and group-level negative MC contribution rows."""
+
+    if hist_mc is None:
+        return []
+
+    edges = _hist_1d_edges(hist_mc, variable)
+    template = _hist_1d_visible_values(hist_mc[{"process": sum}], variable)
+    total_mc_values = template
+    data_values = (
+        _process_values_from_hist(hist_data, sum, variable, template)
+        if hist_data is not None
+        else np.zeros_like(template, dtype=float)
+    )
+
+    process_labels = list(hist_mc.axes["process"])
+    process_to_group = {}
+    for group_name, members in (group_map or {}).items():
+        for process_name in members:
+            process_to_group.setdefault(process_name, group_name)
+
+    rows = []
+
+    for process_name in process_labels:
+        values = _process_values_from_hist(hist_mc, [process_name], variable, template)
+        sumw2_values = _process_values_from_hist(
+            hist_mc_sumw2, [process_name], variable, template
+        )
+        for bin_index, yield_value in enumerate(values):
+            if yield_value >= 0:
+                continue
+            rows.append(
+                _make_negative_contribution_row(
+                    variable=variable,
+                    channel_or_region=channel_or_region,
+                    category_if_available=category_if_available,
+                    stage=stage,
+                    level="process",
+                    process=process_name,
+                    group=process_to_group.get(process_name, ""),
+                    bin_index=bin_index,
+                    bin_low=edges[bin_index],
+                    bin_high=edges[bin_index + 1],
+                    yield_value=yield_value,
+                    sumw2_value=sumw2_values[bin_index],
+                    total_mc_yield=total_mc_values[bin_index],
+                    data_yield=data_values[bin_index],
+                )
+            )
+
+    available_processes = set(process_labels)
+    for group_name, members in (group_map or {}).items():
+        present_members = [member for member in members if member in available_processes]
+        if not present_members:
+            continue
+        values = _process_values_from_hist(hist_mc, present_members, variable, template)
+        sumw2_values = _process_values_from_hist(
+            hist_mc_sumw2, present_members, variable, template
+        )
+        for bin_index, yield_value in enumerate(values):
+            if yield_value >= 0:
+                continue
+            rows.append(
+                _make_negative_contribution_row(
+                    variable=variable,
+                    channel_or_region=channel_or_region,
+                    category_if_available=category_if_available,
+                    stage=stage,
+                    level="group",
+                    process="",
+                    group=group_name,
+                    bin_index=bin_index,
+                    bin_low=edges[bin_index],
+                    bin_high=edges[bin_index + 1],
+                    yield_value=yield_value,
+                    sumw2_value=sumw2_values[bin_index],
+                    total_mc_yield=total_mc_values[bin_index],
+                    data_yield=data_values[bin_index],
+                )
+            )
+
+    return rows
+
+
+def collect_negative_rows_for_plot_stage(
+    *,
+    variable,
+    channel_or_region,
+    category_if_available,
+    stage,
+    hist_mc,
+    hist_mc_sumw2,
+    hist_data,
+    group_map,
+    target_edges=None,
+):
+    """Collect negative rows after optionally applying a plot-time rebin."""
+
+    if target_edges is not None:
+        hist_mc = _clone_with_rebinned_axis(hist_mc, variable, target_edges)
+        hist_data = _clone_with_rebinned_axis(hist_data, variable, target_edges)
+        hist_mc_sumw2 = _clone_with_rebinned_axis(
+            hist_mc_sumw2, variable, target_edges
+        )
+    return collect_negative_contribution_rows(
+        variable=variable,
+        channel_or_region=channel_or_region,
+        category_if_available=category_if_available,
+        stage=stage,
+        hist_mc=hist_mc,
+        hist_mc_sumw2=hist_mc_sumw2,
+        hist_data=hist_data,
+        group_map=group_map,
+    )
+
+
+def _format_report_float(value):
+    if value is None:
+        return ""
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return value
+    if not np.isfinite(numeric):
+        return ""
+    return "{:.12g}".format(numeric)
+
+
+def write_negative_weight_report(rows, output_dir, summary_limit=20):
+    """Write negative MC contribution CSV and Markdown summary."""
+
+    os.makedirs(output_dir, exist_ok=True)
+    csv_path = os.path.join(output_dir, "negative_weight_contribution_report.csv")
+    md_path = os.path.join(output_dir, "negative_weight_contribution_summary.md")
+
+    normalized_rows = list(rows or [])
+    with open(csv_path, "w", newline="") as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=NEGATIVE_WEIGHT_REPORT_COLUMNS)
+        writer.writeheader()
+        for row in normalized_rows:
+            writer.writerow(
+                {
+                    column: _format_report_float(row.get(column))
+                    for column in NEGATIVE_WEIGHT_REPORT_COLUMNS
+                }
+            )
+
+    process_rows = [row for row in normalized_rows if row.get("level") == "process"]
+    group_rows = [row for row in normalized_rows if row.get("level") == "group"]
+    single_eff_group_rows = [
+        row for row in group_rows if row.get("is_single_effective_entry_like")
+    ]
+    low_eff_group_rows = [row for row in group_rows if row.get("is_low_effective_entries")]
+    negative_total_bins = {
+        (
+            row.get("variable"),
+            row.get("channel_or_region"),
+            row.get("category_if_available"),
+            row.get("stage"),
+            row.get("bin_index"),
+        )
+        for row in normalized_rows
+        if row.get("total_mc_yield") is not None
+        and np.isfinite(row.get("total_mc_yield"))
+        and row.get("total_mc_yield") < 0
+    }
+
+    def _top_rows(level_rows):
+        return sorted(level_rows, key=lambda row: abs(row.get("yield", 0.0)), reverse=True)[
+            :summary_limit
+        ]
+
+    def _row_label(row):
+        owner = row.get("process") or row.get("group") or "<unknown>"
+        return (
+            f"{row.get('variable')} {row.get('category_if_available') or row.get('channel_or_region')} "
+            f"{row.get('stage')} bin {row.get('bin_index')} [{row.get('bin_low')}, {row.get('bin_high')}): "
+            f"{owner} yield={_format_report_float(row.get('yield'))}, "
+            f"sumw2={_format_report_float(row.get('sumw2'))}, "
+            f"neff={_format_report_float(row.get('effective_entries'))}"
+        )
+
+    with open(md_path, "w") as md_file:
+        md_file.write("# Negative MC Contribution Summary\n\n")
+        md_file.write(f"- total negative process bins: {len(process_rows)}\n")
+        md_file.write(f"- total negative group bins: {len(group_rows)}\n")
+        md_file.write(
+            "- negative group bins with effective_entries <= 1.05: "
+            f"{len(single_eff_group_rows)}\n"
+        )
+        md_file.write(
+            "- negative group bins with effective_entries <= 5: "
+            f"{len(low_eff_group_rows)}\n"
+        )
+        md_file.write(f"- bins with negative total MC: {len(negative_total_bins)}\n\n")
+
+        md_file.write("## Top Negative Process Contributions\n\n")
+        if process_rows:
+            for row in _top_rows(process_rows):
+                md_file.write(f"- {_row_label(row)}\n")
+        else:
+            md_file.write("- none\n")
+
+        md_file.write("\n## Top Negative Group Contributions\n\n")
+        if group_rows:
+            for row in _top_rows(group_rows):
+                md_file.write(f"- {_row_label(row)}\n")
+        else:
+            md_file.write("- none\n")
+
+    return {"csv": csv_path, "markdown": md_path}
 
 
 def _normalize_histograms(
@@ -5505,6 +6096,8 @@ def produce_region_plots(
     *,
     workers=1,
     verbose=False,
+    rebin_plot_vars=None,
+    negative_weight_report=True,
 ):
     dict_of_hists = region_ctx.dict_of_hists
     context_label = f"{region_ctx.name} region"
@@ -5586,6 +6179,7 @@ def produce_region_plots(
     stat_only_plots = 0
     stat_and_syst_plots = 0
     html_dirs = set()
+    negative_rows = []
 
     worker_count = max(int(workers or 1), 1)
     tasks = list(eligible_variables)
@@ -5691,6 +6285,8 @@ def produce_region_plots(
                     unblind_flag,
                     stacked_log_y,
                     verbose,
+                    rebin_plot_vars,
+                    negative_weight_report,
                     prepared_payloads,
                     shared_region_ctx,
                 ),
@@ -5707,10 +6303,17 @@ def produce_region_plots(
                     for task_id, payload, _, _, _ in task_specs
                 ]
                 for future in as_completed(futures):
-                    task_id, stat_only, stat_and_syst, html_set = future.result()
+                    (
+                        task_id,
+                        stat_only,
+                        stat_and_syst,
+                        html_set,
+                        task_negative_rows,
+                    ) = future.result()
                     stat_only_plots += stat_only
                     stat_and_syst_plots += stat_and_syst
                     html_dirs.update(html_set)
+                    negative_rows.extend(task_negative_rows)
                     _report_progress(id_to_label.get(task_id, str(task_id)))
         finally:
             _SHARED_REGION_CTX = None
@@ -5719,7 +6322,7 @@ def produce_region_plots(
         for _, _, label, var_name, hist_cat in task_specs:
             variable_payload = _get_variable_payload(var_name)
             if hist_cat is None:
-                stat_only, stat_and_syst, html_set = _render_variable(
+                stat_only, stat_and_syst, html_set, task_negative_rows = _render_variable(
                     var_name,
                     region_ctx,
                     save_dir_path,
@@ -5730,10 +6333,12 @@ def produce_region_plots(
                     verbose=verbose,
                     category=hist_cat,
                     variable_payload=variable_payload,
+                    rebin_plot_vars=rebin_plot_vars,
+                    negative_weight_report=negative_weight_report,
                 )
             else:
                 if not variable_payload:
-                    stat_only, stat_and_syst, html_set = 0, 0, set()
+                    stat_only, stat_and_syst, html_set, task_negative_rows = 0, 0, set(), []
                 else:
                     _ensure_variable_channel_coverage_validated(
                         var_name, region_ctx, variable_payload
@@ -5745,9 +6350,14 @@ def produce_region_plots(
                             region_ctx.category_skip_rules, hist_cat, var_name
                         )
                     ):
-                        stat_only, stat_and_syst, html_set = 0, 0, set()
+                        stat_only, stat_and_syst, html_set, task_negative_rows = 0, 0, set(), []
                     else:
-                        stat_only, stat_and_syst, html_set = _render_variable_category(
+                        (
+                            stat_only,
+                            stat_and_syst,
+                            html_set,
+                            task_negative_rows,
+                        ) = _render_variable_category(
                             var_name,
                             hist_cat,
                             channel_bins,
@@ -5766,10 +6376,13 @@ def produce_region_plots(
                             channel_display_labels=variable_payload.get(
                                 "channel_display_labels", {}
                             ),
+                            rebin_plot_vars=rebin_plot_vars,
+                            negative_weight_report=negative_weight_report,
                         )
             stat_only_plots += stat_only
             stat_and_syst_plots += stat_and_syst
             html_dirs.update(html_set)
+            negative_rows.extend(task_negative_rows)
             _report_progress(label)
 
     for html_dir in sorted(html_dirs):
@@ -5798,6 +6411,8 @@ def produce_region_plots(
         print(f" in {save_dir_path}")
     else:
         print()
+
+    return negative_rows
 
 
 def _ensure_list(values):
@@ -7437,6 +8052,8 @@ def run_plots_for_region(
     channel_output="merged",
     enable_category_skips=False,
     report_zero_yields=False,
+    rebin_plot_vars=None,
+    negative_weight_report=True,
 ):
     _SYSTEMATICS_SUMMARY_EMITTED.clear()
 
@@ -7464,6 +8081,7 @@ def run_plots_for_region(
         )
     restored_channel_labels = False
     summary_region_ctx = None
+    all_negative_rows = []
 
     if (
         is_lepton_flavor_in_pkl
@@ -7515,7 +8133,7 @@ def run_plots_for_region(
             mode_label = CHANNEL_MODE_LABELS.get(channel_mode, channel_mode)
             print(f"\n[{region_ctx.name}] Channel output mode: {mode_label}")
 
-        produce_region_plots(
+        negative_rows = produce_region_plots(
             region_ctx,
             save_dir_path,
             variables,
@@ -7525,7 +8143,11 @@ def run_plots_for_region(
             unblind=unblind,
             workers=workers,
             verbose=verbose,
+            rebin_plot_vars=rebin_plot_vars,
+            negative_weight_report=negative_weight_report,
         )
+        if negative_rows:
+            all_negative_rows.extend(negative_rows)
 
     zero_yield_summary = _summarize_zero_yield_processes(
         dict_of_hists,
@@ -7538,6 +8160,19 @@ def run_plots_for_region(
         zero_yield_summary,
         detailed=bool(report_zero_yields),
     )
+
+    if negative_weight_report:
+        report_paths = write_negative_weight_report(
+            all_negative_rows,
+            save_dir_path,
+        )
+        print(
+            "Wrote negative MC contribution report: {csv}; summary: {markdown}".format(
+                **report_paths
+            )
+        )
+    else:
+        print("Negative MC contribution report disabled by --no-negative-weight-report.")
 
     return zero_yield_summary
 
@@ -7684,6 +8319,20 @@ def build_arg_parser():
         ),
     )
     parser.add_argument(
+        "--rebin-plot-vars",
+        default="",
+        help=(
+            "Comma-separated plot-time integer rebin factors by variable, e.g. "
+            "'j0pt:2,l1conept=2'. Leftover bins are merged into the final bin."
+        ),
+    )
+    parser.add_argument(
+        "--no-negative-weight-report",
+        dest="negative_weight_report",
+        action="store_false",
+        help="Disable the end-of-run negative MC contribution CSV/Markdown report.",
+    )
+    parser.add_argument(
         "--on-process-collision",
         choices=["error", "warn", "allow"],
         default="error",
@@ -7721,7 +8370,7 @@ def build_arg_parser():
         action="store_false",
         help="Limit output to high-level progress messages (default).",
     )
-    parser.set_defaults(unblind=None, verbose=False)
+    parser.set_defaults(unblind=None, verbose=False, negative_weight_report=True)
     return parser
 
 
@@ -7811,6 +8460,23 @@ def run_with_args(args, parser):
     )
     print(f"Channel output selection: {args.channel_output}")
 
+    try:
+        rebin_plot_vars = parse_rebin_plot_vars(args.rebin_plot_vars)
+    except ValueError as exc:
+        parser.error(str(exc))
+    if rebin_plot_vars:
+        print(
+            "Plot-time rebinning requested: "
+            + ", ".join(
+                f"{var_name}:{factor}" for var_name, factor in rebin_plot_vars.items()
+            )
+        )
+    print(
+        "Negative MC contribution report: {}".format(
+            "enabled" if args.negative_weight_report else "disabled"
+        )
+    )
+
     normalized_variables = []
     if args.variables is not None:
         seen_variables = set()
@@ -7899,6 +8565,8 @@ def run_with_args(args, parser):
         channel_output=args.channel_output,
         enable_category_skips=args.enable_category_skips,
         report_zero_yields=args.report_zero_yields,
+        rebin_plot_vars=rebin_plot_vars,
+        negative_weight_report=args.negative_weight_report,
     )
     return 0
 

--- a/analysis/topeft_run2/make_cr_and_sr_plots.py
+++ b/analysis/topeft_run2/make_cr_and_sr_plots.py
@@ -1873,6 +1873,11 @@ def _rebin_has_leftover(edges, factor):
 
 
 def _resolve_rebin_plot_edges(var_name, histogram, rebin_plot_vars, base_edges=None):
+    """Resolve plot/report-time edges without mutating source histograms.
+
+    Leftover visible bins are handled by rebin_1d_edges as a final merged bin.
+    """
+
     factor = (rebin_plot_vars or {}).get(var_name)
     if factor is None:
         return None, None, False
@@ -6161,6 +6166,8 @@ def produce_region_plots(
     rebin_plot_vars=None,
     negative_weight_report=True,
 ):
+    """Render requested variables and return negative-report rows from the sweep."""
+
     dict_of_hists = region_ctx.dict_of_hists
     context_label = f"{region_ctx.name} region"
     variables_to_plot = _resolve_requested_variables(
@@ -6839,6 +6846,11 @@ def _emit_systematics_summary_once(
 
 # Wrapper for getting plus and minus shape arrs
 def get_shape_syst_arrs(base_histo,group_type="CR",return_details=False):
+    """Compute aggregate shape arrays while tolerating absent process labels.
+
+    Process labels missing from the current process axis are filtered rather
+    than treated as global shape-systematic failures.
+    """
 
     # Get the list of systematic base names (i.e. without the up and down tags),
     # and keep only complete Up/Down pairs.
@@ -7077,6 +7089,7 @@ def get_decorrelated_uncty(
     total_up_arr=None,
     total_down_arr=None,
 ):
+    """Combine decorrelated group uncertainties for present process labels only."""
 
     # Initialize the array we will return (ok technically we return sqrt of this arr squared..)
     if total_up_arr is None:
@@ -8117,6 +8130,8 @@ def run_plots_for_region(
     rebin_plot_vars=None,
     negative_weight_report=True,
 ):
+    """Run one CR/SR plotting pass and write optional zero/negative reports."""
+
     _SYSTEMATICS_SUMMARY_EMITTED.clear()
 
     channel_output_cfg = CHANNEL_OUTPUT_CHOICES.get(channel_output)
@@ -8485,6 +8500,8 @@ def _cache_merged_histograms(merged_hists, cache_path, out_dir):
 
 
 def run_with_args(args, parser):
+    """Normalize CLI arguments, load histograms, and dispatch region plotting."""
+
     pkl_paths = _resolve_pkl_paths(args, parser)
 
     normalized_years = _normalize_year_tokens(args.year)

--- a/analysis/topeft_run2/make_cr_and_sr_plots.py
+++ b/analysis/topeft_run2/make_cr_and_sr_plots.py
@@ -6011,6 +6011,30 @@ def _format_syst_preview(values, max_items=20):
     return ", ".join(values[:max_items]) + f", +{len(values) - max_items} more"
 
 
+def filter_existing_processes(requested_processes, available_processes):
+    """Return requested process labels that exist on the current process axis."""
+
+    available_set = set(available_processes)
+    present = []
+    missing = []
+    for process_name in requested_processes:
+        if process_name in available_set:
+            present.append(process_name)
+        else:
+            missing.append(process_name)
+    return present, missing
+
+
+def _process_axis_labels(histo):
+    """Return labels on the process axis, raising for non-process axis problems."""
+
+    axis_names = [getattr(axis, "name", None) for axis in getattr(histo, "axes", ())]
+    if "process" not in axis_names:
+        raise KeyError("Histogram has no 'process' axis.")
+    return tuple(yt.get_cat_lables(histo, "process"))
+
+
+
 def _discover_shape_systematics(all_syst_var_lst):
     axis_labels = [str(label) for label in all_syst_var_lst]
     axis_label_set = set(axis_labels)
@@ -6152,6 +6176,18 @@ def get_shape_syst_arrs(base_histo,group_type="CR",return_details=False):
     for syst_name in syst_var_lst:
         try:
             relevant_samples_lst = yt.get_cat_lables(base_histo.integrate("systematic",syst_name+"Up"), "process") # The samples relevant to this syst
+            relevant_samples_lst, missing_relevant_samples = filter_existing_processes(
+                relevant_samples_lst,
+                _process_axis_labels(base_histo),
+            )
+            if missing_relevant_samples:
+                _logger.debug(
+                    "Shape systematic '%s' ignored process labels absent from the current process axis: %s",
+                    syst_name,
+                    ", ".join(missing_relevant_samples),
+                )
+            if not relevant_samples_lst:
+                continue
             proc_projection = base_histo.integrate("process", relevant_samples_lst)[{"process": sum}]
             n_arr = _eval_without_underflow(
                 proc_projection.integrate("systematic", "nominal")
@@ -6373,18 +6409,31 @@ def get_decorrelated_uncty(
 
     result_dtype = np.result_type(template_zeros_arr, total_up_arr, total_down_arr)
     a_arr_sum = np.zeros_like(template_zeros_arr, dtype=result_dtype) # Just using this template_zeros_arr for its size
+    available_processes = _process_axis_labels(base_histo)
+    relevant_samples = set(relevant_samples_lst)
 
     # Loop over the groups of processes, generally the processes in the groups will be correlated and the different groups will be uncorrelated
     for proc_grp in grp_map.keys():
         proc_lst = grp_map[proc_grp]
         if proc_grp in ["Nonprompt","Flips","Data"]: continue # Renorm and fact not relevant here
         if proc_lst == []: continue # Nothing here
+        present_proc_lst, missing_proc_lst = filter_existing_processes(
+            proc_lst,
+            available_processes,
+        )
+        if missing_proc_lst:
+            _logger.debug(
+                "Shape systematic '%s' ignored process labels absent from the current process axis for group '%s': %s",
+                syst_name,
+                proc_grp,
+                ", ".join(missing_proc_lst),
+            )
+        proc_lst = [proc_name for proc_name in present_proc_lst if proc_name in relevant_samples]
+        if proc_lst == []: continue # No process in this group contributes to this systematic in the current histogram
 
         # We'll keep all signal processes as uncorrelated, similar to what's done in SR
         if proc_grp == "Signal":
             for proc_name in proc_lst:
-                if proc_name not in relevant_samples_lst: continue
-
                 n_arr_proc = _eval_without_underflow(
                     base_histo[{"process": proc_name, "systematic": "nominal"}]
                 )

--- a/analysis/topeft_run2/run_cr.sh
+++ b/analysis/topeft_run2/run_cr.sh
@@ -75,7 +75,8 @@ cr_var_sets=(
 # SR variable chunks are configured separately from CR so SR campaigns can use
 # dedicated histogram groups without changing the CR request.
 sr_var_sets=(
-  "njets lj0pt ptz ptz_wtau lt"
+  "njets lj0pt"
+  "ptz ptz_wtau lt"
 )
 
 ###############################################################################
@@ -123,7 +124,8 @@ sr_year_sets=(
   # 2022
   # 2022EE
   # 2023
-  2023BPix
+  # 2023BPix
+  "2022 2022EE 2023 2023BPix"
   # 2016APV
   # 2016
   # 2017

--- a/analysis/topeft_run2/run_cr.sh
+++ b/analysis/topeft_run2/run_cr.sh
@@ -122,8 +122,8 @@ cr_category_sets=(
 sr_year_sets=(
   # 2022
   # 2022EE
-  2023
-  # 2023BPix
+  # 2023
+  2023BPix
   # 2016APV
   # 2016
   # 2017
@@ -131,11 +131,11 @@ sr_year_sets=(
 )
 
 sr_category_sets=(
-  # "2l"
-  # "2lss_1tau 2los_1tau"
-  # "3l_m_offZ"
-  # "3l_p_offZ"
-  # "3l_onZ_tau 4l"
+  "2l"
+  "2lss_1tau 2los_1tau"
+  "3l_m_offZ"
+  "3l_p_offZ"
+  "3l_onZ_tau 4l"
   "3l_fwd"
 )
 

--- a/analysis/topeft_run2/run_plotter.sh
+++ b/analysis/topeft_run2/run_plotter.sh
@@ -34,10 +34,14 @@ Optional arguments:
       --variable VAR          Limit plotting to a single histogram variable (repeat to add more)
       --variables VAR [VAR...]
                            Limit plotting to the listed histogram variables
+      --rebin-plot-vars SPEC
+                           Request plot/report-time rebinning, e.g. j0pt:2,l1conept=2
       --workers N          Number of worker processes for parallel plotting (default: 1; start with 2-4; higher values use more memory)
       --channel-output MODE  Forward merged/split channel selection (merged, split, both, merged-njets,
                            split-njets, both-njets). The -njets variants behave like their counterparts
                            but keep the per-njet bins defined in cr_sr_plots_metadata.yml (default: merged)
+      --no-negative-weight-report
+                           Disable the default negative MC contribution CSV/Markdown report
   -v, --verbose            Forward --verbose to enable detailed diagnostics
       --quiet              Forward --quiet to suppress per-variable chatter (default)
       --cr | --sr           Override the auto-detected region
@@ -47,7 +51,12 @@ Optional arguments:
 
 Unrecognised options are forwarded directly to make_cr_and_sr_plots.py. The
 historical "--" delimiter is no longer necessary; any leftover tokens are passed
-through automatically.
+through automatically. Negative MC contribution reports are enabled by default;
+use --no-negative-weight-report when only figures are needed.
+
+Example:
+  ./run_plotter.sh -f histos/plotsCR_2017.pkl.gz -o ~/www/cr_plots -y 2017 \
+    --variables j0pt l1conept --rebin-plot-vars j0pt:2,l1conept=2
 USAGE
 }
 

--- a/analysis/topeft_run2/submit_plotter_condor.sh
+++ b/analysis/topeft_run2/submit_plotter_condor.sh
@@ -44,6 +44,17 @@ options.
 In particular, plotting switches such as --channel-output understand the same
 merged/split/both values as the Python CLI along with the new -njets variants
 that preserve the per-njet bins defined in cr_sr_plots_metadata.yml.
+
+Example passthrough with focused plot-time rebinning:
+  ./submit_plotter_condor.sh --request-cpus 2 --request-memory 6GB -- \
+    -f /cephfs/<group>/<netid>/topeft/pickles/plotsCR_2017.pkl.gz \
+    -o /cephfs/<group>/<netid>/topeft/plots/cr_2017_rebin \
+    -y 2017 --cr --variables j0pt l1conept \
+    --rebin-plot-vars j0pt:2,l1conept:2
+
+Negative MC contribution CSV/Markdown reports are produced by default by the
+Python plotter; pass --no-negative-weight-report with the plotting arguments to
+disable them.
 USAGE
 }
 

--- a/tests/test_make_cr_and_sr_plots.py
+++ b/tests/test_make_cr_and_sr_plots.py
@@ -1619,6 +1619,60 @@ def test_resolve_rebin_plot_edges_skips_unlisted_variables():
     assert had_leftover is False
 
 
+def test_clone_sumw2_with_rebinned_axis_accepts_suffix_axis():
+    _, h_sumw2, _ = _make_negative_report_hists(
+        variable="l1conept",
+        sumw2_axis_name="l1conept_sumw2",
+    )
+    target_edges = make_cr_and_sr_plots.rebin_1d_edges([0.0, 1.0, 2.0, 3.0, 4.0], 2)
+
+    cloned = make_cr_and_sr_plots._clone_sumw2_with_rebinned_axis(
+        h_sumw2,
+        "l1conept",
+        target_edges,
+    )
+
+    assert np.allclose(cloned.axes["l1conept_sumw2"].edges, [0.0, 2.0, 4.0])
+    values = make_cr_and_sr_plots._process_values_from_hist(
+        cloned,
+        ["neg_proc"],
+        "l1conept_sumw2",
+        np.zeros(2),
+    )
+    assert np.allclose(values, [34.0, 8.0])
+
+
+def test_clone_sumw2_with_rebinned_axis_accepts_nominal_axis():
+    _, h_sumw2, _ = _make_negative_report_hists(variable="j0pt")
+    target_edges = make_cr_and_sr_plots.rebin_1d_edges([0.0, 1.0, 2.0, 3.0, 4.0], 2)
+
+    cloned = make_cr_and_sr_plots._clone_sumw2_with_rebinned_axis(
+        h_sumw2,
+        "j0pt",
+        target_edges,
+    )
+
+    assert np.allclose(cloned.axes["j0pt"].edges, [0.0, 2.0, 4.0])
+    values = make_cr_and_sr_plots._process_values_from_hist(
+        cloned,
+        ["neg_proc"],
+        "j0pt",
+        np.zeros(2),
+    )
+    assert np.allclose(values, [34.0, 8.0])
+
+
+def test_clone_sumw2_with_rebinned_axis_returns_none_for_none_input():
+    assert (
+        make_cr_and_sr_plots._clone_sumw2_with_rebinned_axis(
+            None,
+            "j0pt",
+            [0.0, 2.0, 4.0],
+        )
+        is None
+    )
+
+
 def _make_negative_report_hists(variable="j0pt", sumw2_axis_name=None):
     sumw2_axis_name = sumw2_axis_name or variable
     process_axis = hist.axis.StrCategory([], name="process", growth=True)
@@ -1723,6 +1777,74 @@ def test_negative_report_omits_positive_bins_and_reports_post_rebin_rows():
     assert process_rows[0]["yield"] == -2.0
     assert process_rows[0]["sumw2"] == 34.0
     assert all(row["yield"] < 0 for row in rows)
+
+
+def test_prepare_plot_rebin_and_negative_rows_collects_pre_and_post_rows():
+    h_mc, h_sumw2, h_data = _make_negative_report_hists()
+
+    result = make_cr_and_sr_plots._prepare_plot_rebin_and_negative_rows(
+        variable="j0pt",
+        channel_or_region="CR",
+        category_if_available="2los_CRZ",
+        hist_mc=h_mc,
+        hist_mc_sumw2=h_sumw2,
+        hist_data=h_data,
+        group_map={"Singleboson": ["neg_proc"], "Other": ["pos_proc"]},
+        rebin_plot_vars={"j0pt": 2},
+        negative_weight_report=True,
+    )
+
+    assert np.allclose(result["bins"], [0.0, 2.0, 4.0])
+    stages = {row["stage"] for row in result["negative_rows"]}
+    assert stages == {"pre_rebin", "post_rebin"}
+    post_process_row = next(
+        row
+        for row in result["negative_rows"]
+        if row["stage"] == "post_rebin" and row["level"] == "process"
+    )
+    assert post_process_row["yield"] == -2.0
+    assert post_process_row["sumw2"] == 34.0
+
+
+def test_prepare_plot_rebin_and_negative_rows_collects_nominal_when_not_rebinned():
+    h_mc, h_sumw2, h_data = _make_negative_report_hists()
+    base_edges = [0.0, 1.0, 2.0, 3.0, 4.0]
+
+    result = make_cr_and_sr_plots._prepare_plot_rebin_and_negative_rows(
+        variable="j0pt",
+        channel_or_region="CR",
+        category_if_available="2los_CRZ",
+        hist_mc=h_mc,
+        hist_mc_sumw2=h_sumw2,
+        hist_data=h_data,
+        group_map={"Singleboson": ["neg_proc"], "Other": ["pos_proc"]},
+        rebin_plot_vars={},
+        base_edges=base_edges,
+        negative_weight_report=True,
+    )
+
+    assert result["target_edges"] is None
+    assert result["bins"] is base_edges
+    assert {row["stage"] for row in result["negative_rows"]} == {"nominal_no_rebin"}
+
+
+def test_prepare_plot_rebin_and_negative_rows_skips_rows_when_report_disabled():
+    h_mc, h_sumw2, h_data = _make_negative_report_hists()
+
+    result = make_cr_and_sr_plots._prepare_plot_rebin_and_negative_rows(
+        variable="j0pt",
+        channel_or_region="CR",
+        category_if_available="2los_CRZ",
+        hist_mc=h_mc,
+        hist_mc_sumw2=h_sumw2,
+        hist_data=h_data,
+        group_map={"Singleboson": ["neg_proc"], "Other": ["pos_proc"]},
+        rebin_plot_vars={"j0pt": 2},
+        negative_weight_report=False,
+    )
+
+    assert np.allclose(result["bins"], [0.0, 2.0, 4.0])
+    assert result["negative_rows"] == []
 
 
 def test_negative_report_post_rebin_resolves_sumw2_suffix_axis():

--- a/tests/test_make_cr_and_sr_plots.py
+++ b/tests/test_make_cr_and_sr_plots.py
@@ -1619,11 +1619,16 @@ def test_resolve_rebin_plot_edges_skips_unlisted_variables():
     assert had_leftover is False
 
 
-def _make_negative_report_hists():
+def _make_negative_report_hists(variable="j0pt", sumw2_axis_name=None):
+    sumw2_axis_name = sumw2_axis_name or variable
     process_axis = hist.axis.StrCategory([], name="process", growth=True)
-    value_axis = hist.axis.Variable([0.0, 1.0, 2.0, 3.0, 4.0], name="j0pt")
+    value_axis = hist.axis.Variable([0.0, 1.0, 2.0, 3.0, 4.0], name=variable)
+    sumw2_axis = hist.axis.Variable(
+        [0.0, 1.0, 2.0, 3.0, 4.0],
+        name=sumw2_axis_name,
+    )
     h_mc = hist.Hist(process_axis, value_axis, storage=hist.storage.Double())
-    h_sumw2 = hist.Hist(process_axis, value_axis, storage=hist.storage.Double())
+    h_sumw2 = hist.Hist(process_axis, sumw2_axis, storage=hist.storage.Double())
     h_data = hist.Hist(process_axis, value_axis, storage=hist.storage.Double())
 
     mc_values = {
@@ -1636,14 +1641,22 @@ def _make_negative_report_hists():
     }
     for process_name, values in mc_values.items():
         for bin_index, value in enumerate(values):
-            h_mc.fill(process=process_name, j0pt=bin_index + 0.5, weight=value)
+            h_mc.fill(
+                process=process_name,
+                **{variable: bin_index + 0.5},
+                weight=value,
+            )
             h_sumw2.fill(
                 process=process_name,
-                j0pt=bin_index + 0.5,
+                **{sumw2_axis_name: bin_index + 0.5},
                 weight=sumw2_values[process_name][bin_index],
             )
     for bin_index in range(4):
-        h_data.fill(process="data", j0pt=bin_index + 0.5, weight=10.0)
+        h_data.fill(
+            process="data",
+            **{variable: bin_index + 0.5},
+            weight=10.0,
+        )
 
     return h_mc, h_sumw2, h_data
 
@@ -1710,6 +1723,114 @@ def test_negative_report_omits_positive_bins_and_reports_post_rebin_rows():
     assert process_rows[0]["yield"] == -2.0
     assert process_rows[0]["sumw2"] == 34.0
     assert all(row["yield"] < 0 for row in rows)
+
+
+def test_negative_report_post_rebin_resolves_sumw2_suffix_axis():
+    h_mc, h_sumw2, h_data = _make_negative_report_hists(
+        variable="l1conept",
+        sumw2_axis_name="l1conept_sumw2",
+    )
+    target_edges = make_cr_and_sr_plots.rebin_1d_edges([0.0, 1.0, 2.0, 3.0, 4.0], 2)
+
+    rows = make_cr_and_sr_plots.collect_negative_rows_for_plot_stage(
+        variable="l1conept",
+        channel_or_region="CR",
+        category_if_available="2los_CRZ",
+        stage="post_rebin",
+        hist_mc=h_mc,
+        hist_mc_sumw2=h_sumw2,
+        hist_data=h_data,
+        group_map={"Singleboson": ["neg_proc"], "Other": ["pos_proc"]},
+        target_edges=target_edges,
+    )
+
+    process_row = next(row for row in rows if row["level"] == "process")
+    assert process_row["variable"] == "l1conept"
+    assert process_row["stage"] == "post_rebin"
+    assert process_row["bin_low"] == 0.0
+    assert process_row["bin_high"] == 2.0
+    assert process_row["yield"] == -2.0
+    assert process_row["sumw2"] == 34.0
+    assert process_row["effective_entries"] == pytest.approx(4.0 / 34.0)
+
+
+def test_negative_report_post_rebin_without_sumw2_does_not_crash():
+    h_mc, _, h_data = _make_negative_report_hists(variable="l1conept")
+    target_edges = make_cr_and_sr_plots.rebin_1d_edges([0.0, 1.0, 2.0, 3.0, 4.0], 2)
+
+    rows = make_cr_and_sr_plots.collect_negative_rows_for_plot_stage(
+        variable="l1conept",
+        channel_or_region="CR",
+        category_if_available="2los_CRZ",
+        stage="post_rebin",
+        hist_mc=h_mc,
+        hist_mc_sumw2=None,
+        hist_data=h_data,
+        group_map={"Singleboson": ["neg_proc"], "Other": ["pos_proc"]},
+        target_edges=target_edges,
+    )
+
+    process_row = next(row for row in rows if row["level"] == "process")
+    assert process_row["yield"] == -2.0
+    assert np.isnan(process_row["sumw2"])
+    assert np.isnan(process_row["effective_entries"])
+
+
+def test_negative_report_ambiguous_sumw2_dense_axis_lists_available_axes():
+    h_mc, _, h_data = _make_negative_report_hists(variable="l1conept")
+    process_axis = hist.axis.StrCategory([], name="process", growth=True)
+    h_sumw2 = hist.Hist(
+        process_axis,
+        hist.axis.Variable([0.0, 1.0, 2.0, 3.0, 4.0], name="alt_a"),
+        hist.axis.Variable([0.0, 1.0, 2.0, 3.0, 4.0], name="alt_b"),
+        storage=hist.storage.Double(),
+    )
+    target_edges = make_cr_and_sr_plots.rebin_1d_edges([0.0, 1.0, 2.0, 3.0, 4.0], 2)
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Cannot resolve sumw2 dense axis for variable 'l1conept'.*"
+            "Available dense axes: alt_a, alt_b"
+        ),
+    ):
+        make_cr_and_sr_plots.collect_negative_rows_for_plot_stage(
+            variable="l1conept",
+            channel_or_region="CR",
+            category_if_available="2los_CRZ",
+            stage="post_rebin",
+            hist_mc=h_mc,
+            hist_mc_sumw2=h_sumw2,
+            hist_data=h_data,
+            group_map={"Singleboson": ["neg_proc"], "Other": ["pos_proc"]},
+            target_edges=target_edges,
+        )
+
+
+def test_negative_report_missing_sumw2_dense_axis_lists_available_axes():
+    h_mc, _, h_data = _make_negative_report_hists(variable="l1conept")
+    process_axis = hist.axis.StrCategory([], name="process", growth=True)
+    h_sumw2 = hist.Hist(process_axis, storage=hist.storage.Double())
+    target_edges = make_cr_and_sr_plots.rebin_1d_edges([0.0, 1.0, 2.0, 3.0, 4.0], 2)
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Cannot resolve sumw2 dense axis for variable 'l1conept'.*"
+            "Available dense axes: <none>"
+        ),
+    ):
+        make_cr_and_sr_plots.collect_negative_rows_for_plot_stage(
+            variable="l1conept",
+            channel_or_region="CR",
+            category_if_available="2los_CRZ",
+            stage="post_rebin",
+            hist_mc=h_mc,
+            hist_mc_sumw2=h_sumw2,
+            hist_data=h_data,
+            group_map={"Singleboson": ["neg_proc"], "Other": ["pos_proc"]},
+            target_edges=target_edges,
+        )
 
 
 def test_write_negative_weight_report_creates_csv_and_markdown(tmp_path):

--- a/tests/test_make_cr_and_sr_plots.py
+++ b/tests/test_make_cr_and_sr_plots.py
@@ -1,4 +1,5 @@
 import copy
+import csv
 import re
 import warnings
 from types import SimpleNamespace
@@ -1572,3 +1573,187 @@ def test_data_driven_reinsertion_respects_year_tokens():
         assert label in ctx_run2.mc_samples
     assert "nonprompt2022" not in ctx_run2.mc_samples
     assert "flips2022" not in ctx_run2.mc_samples
+
+
+def test_parse_rebin_plot_vars_accepts_colon_and_equals():
+    parsed = make_cr_and_sr_plots.parse_rebin_plot_vars("j0pt:2,l1conept=3")
+
+    assert parsed == {"j0pt": 2, "l1conept": 3}
+
+
+@pytest.mark.parametrize(
+    "raw_value",
+    ["j0pt", "j0pt:abc", "j0pt:1", ":2"],
+)
+def test_parse_rebin_plot_vars_rejects_malformed_entries(raw_value):
+    with pytest.raises(ValueError):
+        make_cr_and_sr_plots.parse_rebin_plot_vars(raw_value)
+
+
+def test_rebin_1d_helpers_preserve_yields_and_sum_variances_with_leftovers():
+    values = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    variances = np.array([1.0, 4.0, 9.0, 16.0, 25.0])
+    edges = np.array([0.0, 10.0, 20.0, 30.0, 40.0, 50.0])
+
+    rebinned_values = make_cr_and_sr_plots.rebin_1d_values(values, 2)
+    rebinned_variances = make_cr_and_sr_plots.rebin_1d_variances(variances, 2)
+    rebinned_edges = make_cr_and_sr_plots.rebin_1d_edges(edges, 2)
+
+    assert np.sum(rebinned_values) == np.sum(values)
+    assert np.allclose(rebinned_values, [3.0, 7.0, 5.0])
+    assert np.allclose(rebinned_variances, [5.0, 25.0, 25.0])
+    assert np.allclose(rebinned_edges, [0.0, 20.0, 40.0, 50.0])
+
+
+def test_resolve_rebin_plot_edges_skips_unlisted_variables():
+    h_mc, _, _ = _make_simple_stacked_inputs()
+
+    target_edges, factor, had_leftover = make_cr_and_sr_plots._resolve_rebin_plot_edges(
+        "lj0pt",
+        h_mc,
+        {"j0pt": 2},
+    )
+
+    assert target_edges is None
+    assert factor is None
+    assert had_leftover is False
+
+
+def _make_negative_report_hists():
+    process_axis = hist.axis.StrCategory([], name="process", growth=True)
+    value_axis = hist.axis.Variable([0.0, 1.0, 2.0, 3.0, 4.0], name="j0pt")
+    h_mc = hist.Hist(process_axis, value_axis, storage=hist.storage.Double())
+    h_sumw2 = hist.Hist(process_axis, value_axis, storage=hist.storage.Double())
+    h_data = hist.Hist(process_axis, value_axis, storage=hist.storage.Double())
+
+    mc_values = {
+        "neg_proc": [-5.0, 3.0, 2.0, 2.0],
+        "pos_proc": [1.0, 1.0, 1.0, 1.0],
+    }
+    sumw2_values = {
+        "neg_proc": [25.0, 9.0, 4.0, 4.0],
+        "pos_proc": [1.0, 1.0, 1.0, 1.0],
+    }
+    for process_name, values in mc_values.items():
+        for bin_index, value in enumerate(values):
+            h_mc.fill(process=process_name, j0pt=bin_index + 0.5, weight=value)
+            h_sumw2.fill(
+                process=process_name,
+                j0pt=bin_index + 0.5,
+                weight=sumw2_values[process_name][bin_index],
+            )
+    for bin_index in range(4):
+        h_data.fill(process="data", j0pt=bin_index + 0.5, weight=10.0)
+
+    return h_mc, h_sumw2, h_data
+
+
+def test_negative_contribution_rows_include_requested_metrics_and_flags():
+    h_mc, h_sumw2, h_data = _make_negative_report_hists()
+
+    rows = make_cr_and_sr_plots.collect_negative_contribution_rows(
+        variable="j0pt",
+        channel_or_region="CR",
+        category_if_available="2los_CRZ",
+        stage="nominal_no_rebin",
+        hist_mc=h_mc,
+        hist_mc_sumw2=h_sumw2,
+        hist_data=h_data,
+        group_map={"Singleboson": ["neg_proc"], "Other": ["pos_proc"]},
+    )
+
+    process_rows = [row for row in rows if row["level"] == "process"]
+    group_rows = [row for row in rows if row["level"] == "group"]
+
+    assert len(process_rows) == 1
+    assert len(group_rows) == 1
+    process_row = process_rows[0]
+    assert process_row["yield"] == -5.0
+    assert process_row["sumw2"] == 25.0
+    assert process_row["error"] == 5.0
+    assert process_row["effective_entries"] == 1.0
+    assert process_row["is_compatible_with_zero_1sigma"] is True
+    assert process_row["is_single_effective_entry_like"] is True
+    assert process_row["is_low_effective_entries"] is True
+    assert process_row["total_mc_yield"] == -4.0
+    assert process_row["data_yield"] == 10.0
+    assert process_row["yield_over_total_mc"] == 1.25
+    assert process_row["abs_yield_over_total_mc"] == 1.25
+    assert process_row["process"] == "neg_proc"
+    assert process_row["group"] == "Singleboson"
+    assert group_rows[0]["process"] == ""
+    assert group_rows[0]["group"] == "Singleboson"
+
+
+def test_negative_report_omits_positive_bins_and_reports_post_rebin_rows():
+    h_mc, h_sumw2, h_data = _make_negative_report_hists()
+    target_edges = make_cr_and_sr_plots.rebin_1d_edges([0.0, 1.0, 2.0, 3.0, 4.0], 2)
+
+    rows = make_cr_and_sr_plots.collect_negative_rows_for_plot_stage(
+        variable="j0pt",
+        channel_or_region="CR",
+        category_if_available="2los_CRZ",
+        stage="post_rebin",
+        hist_mc=h_mc,
+        hist_mc_sumw2=h_sumw2,
+        hist_data=h_data,
+        group_map={"Singleboson": ["neg_proc"], "Other": ["pos_proc"]},
+        target_edges=target_edges,
+    )
+
+    process_rows = [row for row in rows if row["level"] == "process"]
+    assert len(process_rows) == 1
+    assert process_rows[0]["stage"] == "post_rebin"
+    assert process_rows[0]["bin_index"] == 0
+    assert process_rows[0]["bin_low"] == 0.0
+    assert process_rows[0]["bin_high"] == 2.0
+    assert process_rows[0]["yield"] == -2.0
+    assert process_rows[0]["sumw2"] == 34.0
+    assert all(row["yield"] < 0 for row in rows)
+
+
+def test_write_negative_weight_report_creates_csv_and_markdown(tmp_path):
+    h_mc, h_sumw2, h_data = _make_negative_report_hists()
+    rows = make_cr_and_sr_plots.collect_negative_contribution_rows(
+        variable="j0pt",
+        channel_or_region="CR",
+        category_if_available="2los_CRZ",
+        stage="nominal_no_rebin",
+        hist_mc=h_mc,
+        hist_mc_sumw2=h_sumw2,
+        hist_data=h_data,
+        group_map={"Singleboson": ["neg_proc"], "Other": ["pos_proc"]},
+    )
+
+    paths = make_cr_and_sr_plots.write_negative_weight_report(rows, tmp_path)
+
+    csv_path = paths["csv"]
+    md_path = paths["markdown"]
+    with open(csv_path) as f:
+        reader = csv.DictReader(f)
+        written_rows = list(reader)
+    assert reader.fieldnames == make_cr_and_sr_plots.NEGATIVE_WEIGHT_REPORT_COLUMNS
+    assert len(written_rows) == len(rows)
+    assert written_rows[0]["effective_entries"] == "1"
+
+    summary_text = open(md_path).read()
+    assert "total negative process bins: 1" in summary_text
+    assert "total negative group bins: 1" in summary_text
+    assert "Top Negative Process Contributions" in summary_text
+
+
+def test_plotter_parser_exposes_rebin_and_negative_report_switches():
+    parser = make_cr_and_sr_plots.build_arg_parser()
+
+    args = parser.parse_args(
+        [
+            "-f",
+            "input.pkl.gz",
+            "--rebin-plot-vars",
+            "j0pt:2",
+            "--no-negative-weight-report",
+        ]
+    )
+
+    assert args.rebin_plot_vars == "j0pt:2"
+    assert args.negative_weight_report is False

--- a/tests/test_plotter_systematics_robustness.py
+++ b/tests/test_plotter_systematics_robustness.py
@@ -39,6 +39,27 @@ def _make_sparse_hist(systematic_weights):
     return hist_obj
 
 
+def _make_process_sparse_hist(process_systematic_weights):
+    process_axis = hist.axis.StrCategory([], name="process", growth=True)
+    syst_axis = hist.axis.StrCategory([], name="systematic", growth=True)
+    met_axis = hist.axis.Regular(1, 0.0, 1.0, name="met")
+
+    hist_obj = make_cr_and_sr_plots.SparseHist(
+        process_axis, syst_axis, met_axis
+    )
+
+    for process_name, systematic_weights in process_systematic_weights.items():
+        for systematic, weight in systematic_weights.items():
+            hist_obj.fill(
+                process=process_name,
+                systematic=systematic,
+                met=0.5,
+                weight=weight,
+            )
+
+    return hist_obj
+
+
 def test_get_shape_syst_arrs_skips_orphan_and_keeps_valid_pairs():
     hist_obj = _make_sparse_hist(
         {
@@ -180,3 +201,177 @@ def test_emit_systematics_summary_mentions_renormfact_only_when_present(capsys):
 
     out = capsys.readouterr().out
     assert "renormfact' present on axis and explicitly skipped by design." in out
+
+
+def test_filter_existing_processes_keeps_present_and_reports_absent():
+    present, missing = make_cr_and_sr_plots.filter_existing_processes(
+        ["ttH_central2022", "WJetsToLNu_centralUL17"],
+        ["ttH_central2022", "ttbar_central2022"],
+    )
+
+    assert present == ["ttH_central2022"]
+    assert missing == ["WJetsToLNu_centralUL17"]
+
+
+def test_filter_existing_processes_requires_process_axis():
+    hist_obj = hist.Hist(
+        hist.axis.StrCategory(["nominal"], name="systematic"),
+        hist.axis.Regular(1, 0.0, 1.0, name="met"),
+    )
+
+    with pytest.raises(KeyError, match="process"):
+        make_cr_and_sr_plots._process_axis_labels(hist_obj)
+
+
+def test_decorrelated_systematic_uses_present_subset_when_group_member_absent():
+    hist_obj = _make_process_sparse_hist(
+        {
+            "ttH_central2022": {
+                "nominal": 10.0,
+                "renormUp": 13.0,
+                "renormDown": 7.0,
+            },
+        }
+    )
+
+    p_arr, m_arr = make_cr_and_sr_plots.get_decorrelated_uncty(
+        "renorm",
+        {"Signal": ["ttH_central2022", "WJetsToLNu_centralUL17"]},
+        ["ttH_central2022"],
+        hist_obj,
+        np.array([0.0]),
+    )
+
+    assert np.allclose(p_arr, np.array([3.0]))
+    assert np.allclose(m_arr, np.array([-3.0]))
+
+
+def test_decorrelated_systematic_all_absent_group_returns_zero_contribution():
+    hist_obj = _make_process_sparse_hist(
+        {
+            "ttH_central2022": {
+                "nominal": 10.0,
+                "renormUp": 13.0,
+                "renormDown": 7.0,
+            },
+        }
+    )
+
+    p_arr, m_arr = make_cr_and_sr_plots.get_decorrelated_uncty(
+        "renorm",
+        {"Singleboson": ["WJetsToLNu_centralUL17"]},
+        ["ttH_central2022"],
+        hist_obj,
+        np.array([0.0]),
+    )
+
+    assert np.allclose(p_arr, np.array([0.0]))
+    assert np.allclose(m_arr, np.array([-0.0]))
+
+
+def test_renorm_systematic_is_not_skipped_when_group_map_has_missing_process(monkeypatch):
+    hist_obj = _make_process_sparse_hist(
+        {
+            "ttH_central2022": {
+                "nominal": 10.0,
+                "renormUp": 13.0,
+                "renormDown": 7.0,
+                "factUp": 12.0,
+                "factDown": 8.0,
+            },
+            "ttbar_central2022": {
+                "nominal": 20.0,
+                "renormUp": 24.0,
+                "renormDown": 16.0,
+                "factUp": 25.0,
+                "factDown": 15.0,
+            },
+        }
+    )
+
+    monkeypatch.setattr(
+        make_cr_and_sr_plots,
+        "CR_GRP_MAP",
+        {
+            "Signal": ["ttH_central2022"],
+            "Top": ["ttbar_central2022", "WJetsToLNu_centralUL17"],
+            "Singleboson": ["MissingSingleboson"],
+        },
+    )
+
+    (shape_m, shape_p), details = make_cr_and_sr_plots.get_shape_syst_arrs(
+        hist_obj,
+        group_type="CR",
+        return_details=True,
+    )
+
+    assert details["valid_bases"] == ("renorm", "fact")
+    assert details["skipped_failed"] == ()
+    assert np.allclose(shape_p, np.array([3.0**2 + 4.0**2 + 2.0**2 + 5.0**2]))
+    assert np.allclose(shape_m, shape_p)
+
+
+def test_renorm_all_present_grouping_behavior_is_unchanged(monkeypatch):
+    hist_obj = _make_process_sparse_hist(
+        {
+            "ttbar_central2022": {
+                "nominal": 20.0,
+                "renormUp": 24.0,
+                "renormDown": 16.0,
+            },
+            "TTTo2L2Nu_central2022": {
+                "nominal": 5.0,
+                "renormUp": 6.0,
+                "renormDown": 4.0,
+            },
+        }
+    )
+    monkeypatch.setattr(
+        make_cr_and_sr_plots,
+        "CR_GRP_MAP",
+        {"Top": ["ttbar_central2022", "TTTo2L2Nu_central2022"]},
+    )
+
+    (shape_m, shape_p), details = make_cr_and_sr_plots.get_shape_syst_arrs(
+        hist_obj,
+        group_type="CR",
+        return_details=True,
+    )
+
+    assert details["valid_bases"] == ("renorm",)
+    assert details["skipped_failed"] == ()
+    assert np.allclose(shape_p, np.array([5.0**2]))
+    assert np.allclose(shape_m, np.array([5.0**2]))
+
+
+def test_metadata_skipped_group_is_not_reintroduced_for_systematics(monkeypatch):
+    hist_obj = _make_process_sparse_hist(
+        {
+            "ttbar_central2022": {
+                "nominal": 20.0,
+                "renormUp": 24.0,
+                "renormDown": 16.0,
+            },
+            "WJetsToLNu_centralUL17": {
+                "nominal": 100.0,
+                "renormUp": 150.0,
+                "renormDown": 50.0,
+            },
+        }
+    )
+    monkeypatch.setattr(
+        make_cr_and_sr_plots,
+        "CR_GRP_MAP",
+        {"Top": ["ttbar_central2022"]},
+    )
+
+    (shape_m, shape_p), details = make_cr_and_sr_plots.get_shape_syst_arrs(
+        hist_obj,
+        group_type="CR",
+        return_details=True,
+    )
+
+    assert details["valid_bases"] == ("renorm",)
+    assert details["skipped_failed"] == ()
+    assert np.allclose(shape_p, np.array([4.0**2]))
+    assert np.allclose(shape_m, np.array([4.0**2]))

--- a/topeft/modules/axes.py
+++ b/topeft/modules/axes.py
@@ -1,10 +1,10 @@
 info = {
     "npvs": {
-        "regular": (100, 0, 100),
+        "regular": (50, 0, 100),
         "label": r"Number of reco primary vertices ",
     },
     "npvsGood": {
-        "regular": (100, 0, 100),
+        "regular": (50, 0, 100),
         "label": r"Number of Good reco primary vertices ",
     },
     "invmass": {
@@ -62,18 +62,19 @@ info = {
     },
     "l1conept": {
         "regular": (15, 0, 150),
+        "variable": [10, 20, 30, 40, 50, 60, 80, 100],
         "label": r"Subleading lep cone-$p_{T}$ (GeV) "
     },
     "l1eta": {
-        "regular": (20, -2.5, 2.5),
+        "regular": (10, -2.5, 2.5),
         "label": r"Subleading $\eta$ "
     },
     "j0pt": {
-        "regular": (50, 0, 500),
+        "regular": (15, 0, 300),
         "label": r"Leading jet  $p_{T}$ (GeV) "
     },
     "fwd0pt": {
-        "regular": (50, 0, 500),
+        "regular": (10, 0, 200),
         "label": r"Leading forward jet $p_{T}$ (GeV) "
     },
     "b0pt": {
@@ -81,12 +82,12 @@ info = {
         "label": r"Leading b jet  $p_{T}$ (GeV) "
     },
     "j0eta": {
-        "regular": (30, -3, 3),
+        "regular": (15, -3, 3),
         "label": r"Leading jet  $\eta$ "
     },
     "fwd0eta": {
         "regular": (50, -5, 5),
-        "variable": [-5, -4.5, -4, -3.8, -3.6, -3.4, -3.2, -3, -2.8, -2.6, -2.4, 2.4, 2.6, 2.8, 3, 3.2, 3.4, 3.6, 3.8, 4, 4.5, 5],
+        "variable": [-5, -4.5, -4, -3.6, -3.2, -2.8, -2.4, 2.4, 2.8, 3.2, 3.6, 4, 4.5, 5],
         "label": r"Leading forward jet $\eta$ "
     },
     "ht": {

--- a/topeft/modules/axes.py
+++ b/topeft/modules/axes.py
@@ -67,7 +67,7 @@ info = {
     },
     "l1eta": {
         "regular": (10, -2.5, 2.5),
-        "label": r"Subleading $\eta$ "
+        "label": r"Subleading lep $\eta$ "
     },
     "j0pt": {
         "regular": (15, 0, 300),


### PR DESCRIPTION
### Summary

This PR improves the CR/SR plotting workflow by making shape-systematic evaluation tolerant of metadata-skipped or otherwise absent processes, adding plot-time variable rebinning, and adding diagnostics for negative MC bin contributions.

It also documents the new plotter behavior and updates selected plotting workflow defaults and axis definitions used by the current CR/SR plotting campaign.

### Motivation

The CR/SR plotter could fail or skip shape-systematic evaluation when a systematic group map referenced processes that were intentionally absent from the currently plotted histogram, for example because of metadata skips, sample removals, or category-specific process availability.

In addition, some CR plots had narrow or negative MC bins where it was useful to inspect whether the effect came from one or very few high-weight signed events. The plotter now provides focused plot-time rebinning and negative-contribution diagnostics to make those cases easier to understand without modifying the input pickle.

### Implementation details

* Add missing-process-tolerant shape-systematic handling:

  * filter requested process labels against the current process axis;
  * ignore absent labels for the current histogram/group;
  * treat groups with no available processes as absent/zero contributions rather than global shape-systematic failures.

* Add plot-time variable rebinning:

  * new `--rebin-plot-vars` option;
  * supports syntax such as `j0pt:2,l1conept=2`;
  * rebins only at plot/report time;
  * preserves input pickles and source histograms;
  * merges leftover visible bins into the final rebinned bin.

* Add negative MC contribution diagnostics:

  * default CSV and Markdown report outputs;
  * `--no-negative-weight-report` to disable them;
  * process-level and group-level negative-bin rows;
  * `nominal_no_rebin`, `pre_rebin`, and `post_rebin` stages;
  * diagnostic metrics such as `sumw2`, `error`, `effective_entries`, and low-effective-entry flags.

* Improve sumw2 companion handling:

  * support sumw2 dense axes named either `<variable>` or `<variable>_sumw2`;
  * allow a single unambiguous dense numeric fallback axis;
  * report clear errors for missing or ambiguous sumw2 axes.

* Harmonize plotter internals:

  * centralize sumw2 rebin cloning;
  * centralize aggregate/per-channel plot-time rebin and negative-report stage collection;
  * keep plotting outputs, report schema, CLI behavior, and systematics behavior stable.

* Update documentation and helper usage text:

  * document `--rebin-plot-vars`;
  * document negative MC contribution reports;
  * document sumw2 companion expectations;
  * document missing-process-tolerant shape systematics;
  * update `run_plotter.sh` and `submit_plotter_condor.sh` usage examples.

* Update plotting workflow configuration:

  * adjust selected `run_cr.sh` SR campaign defaults;
  * update selected axis/binning definitions in `topeft/modules/axes.py`.

### Testing

Validation performed during the prompt sequence included:

* `git diff --check`;
* Python `py_compile` checks;
* targeted pytest coverage for:

  * rebin option parsing;
  * 1D rebinning helpers;
  * negative MC report row generation;
  * sumw2 companion-axis resolution;
  * missing-process-tolerant shape systematics;
* `compileall`;
* shell syntax checks for wrapper scripts;
* parser and wrapper help capture;
* focused real-pkl diagnostic with:

  * `--variables j0pt l1conept`;
  * `--rebin-plot-vars j0pt:2,l1conept:2`;
  * `--channel-output both`.

The focused real-pkl diagnostic confirmed:

* the previous sumw2-axis failure for rebinned `j0pt`/`l1conept` is resolved;
* negative-weight CSV and Markdown reports are produced;
* `j0pt` and `l1conept` `post_rebin` rows are present;
* old skipped-systematic warnings for `renorm` and `fact` are absent;
* CR rate and shape systematic computations succeed.

### Review notes

The `run_cr.sh` and `topeft/modules/axes.py` changes are intentional and are part of the plotting workflow update. They are not accidental spillover from the plotter robustness/refactor work.

The negative MC contribution report is diagnostic only. It does not correct yields or alter physics content.

Plot-time rebinning affects only the plotting/reporting path. It does not rewrite the input pickle or change histogram production.
