### PR TITLE
Align tau fake-SF policy and 2los tau CR setup

### DIFF
--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -22,7 +22,7 @@ import topcoffea.modules.corrections as tc_cor
 from topeft.modules.axes import info as axes_info
 from topeft.modules.axes import info_2d as axes_info_2d
 from topeft.modules.paths import topeft_path
-from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, AttachTauEnergyCorrections, ApplyTauEnergySystematics, AttachPerLeptonFR, AttachMuonMomentumCorrections, ApplyMuonMomentumSystematics, get_supported_muon_momentum_systematics, get_supported_tau_energy_systematics, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_selected_raw_met, get_corr_t1_met_jets, get_supported_jet_systematics, get_supported_met_systematics, is_met_unclustered_systematic, resolve_forward_eta_stochastic_jer_suppression, use_type1_met, get_tau_pog_vsjet_wp
+from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, AttachTauEnergyCorrections, ApplyTauEnergySystematics, AttachPerLeptonFR, AttachMuonMomentumCorrections, ApplyMuonMomentumSystematics, get_supported_muon_momentum_systematics, get_supported_tau_energy_systematics, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_selected_raw_met, get_corr_t1_met_jets, get_supported_jet_systematics, get_supported_met_systematics, is_met_unclustered_systematic, resolve_forward_eta_stochastic_jer_suppression, use_type1_met
 import topeft.modules.event_selection as te_es
 import topeft.modules.object_selection as te_os
 from topeft.modules.ttgamma_photon_history import (
@@ -669,8 +669,12 @@ class AnalysisProcessor(processor.ProcessorABC):
         hout = self.accumulator
 
         if self.enable_tau_blocks:
-            tau_fo_tag = "Loose"
-            tau_T_tag = get_tau_pog_vsjet_wp()
+            tau_fo_tag = get_te_param(
+                "run2_tau_fo_tag" if is_run2 else "run3_tau_fo_tag"
+            )
+            tau_T_tag = get_te_param(
+                "run2_tau_t_tag" if is_run2 else "run3_tau_t_tag"
+            )
             taus = AttachTauEnergyCorrections(
                 year, tau, isData, vsJetWP=tau_T_tag
             )

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -22,7 +22,7 @@ import topcoffea.modules.corrections as tc_cor
 from topeft.modules.axes import info as axes_info
 from topeft.modules.axes import info_2d as axes_info_2d
 from topeft.modules.paths import topeft_path
-from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, AttachTauEnergyCorrections, ApplyTauEnergySystematics, AttachPerLeptonFR, AttachMuonMomentumCorrections, ApplyMuonMomentumSystematics, get_supported_muon_momentum_systematics, get_supported_tau_energy_systematics, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_selected_raw_met, get_corr_t1_met_jets, get_supported_jet_systematics, get_supported_met_systematics, is_met_unclustered_systematic, resolve_forward_eta_stochastic_jer_suppression, use_type1_met, TAU_POG_VSJET_WP
+from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, AttachTauEnergyCorrections, ApplyTauEnergySystematics, AttachPerLeptonFR, AttachMuonMomentumCorrections, ApplyMuonMomentumSystematics, get_supported_muon_momentum_systematics, get_supported_tau_energy_systematics, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_selected_raw_met, get_corr_t1_met_jets, get_supported_jet_systematics, get_supported_met_systematics, is_met_unclustered_systematic, resolve_forward_eta_stochastic_jer_suppression, use_type1_met, get_tau_pog_vsjet_wp
 import topeft.modules.event_selection as te_es
 import topeft.modules.object_selection as te_os
 from topeft.modules.ttgamma_photon_history import (
@@ -669,8 +669,8 @@ class AnalysisProcessor(processor.ProcessorABC):
         hout = self.accumulator
 
         if self.enable_tau_blocks:
-            tau_fo_tag = "VLoose" if is_run2 else "Loose"
-            tau_T_tag = TAU_POG_VSJET_WP
+            tau_fo_tag = "Loose"
+            tau_T_tag = get_tau_pog_vsjet_wp()
             taus = AttachTauEnergyCorrections(
                 year, tau, isData, vsJetWP=tau_T_tag
             )

--- a/analysis/topeft_run2/analysis_processor.py
+++ b/analysis/topeft_run2/analysis_processor.py
@@ -22,7 +22,7 @@ import topcoffea.modules.corrections as tc_cor
 from topeft.modules.axes import info as axes_info
 from topeft.modules.axes import info_2d as axes_info_2d
 from topeft.modules.paths import topeft_path
-from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, AttachTauEnergyCorrections, ApplyTauEnergySystematics, AttachPerLeptonFR, AttachMuonMomentumCorrections, ApplyMuonMomentumSystematics, get_supported_muon_momentum_systematics, get_supported_tau_energy_systematics, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_selected_raw_met, get_corr_t1_met_jets, get_supported_jet_systematics, get_supported_met_systematics, is_met_unclustered_systematic, resolve_forward_eta_stochastic_jer_suppression, use_type1_met
+from topeft.modules.corrections import ApplyJetCorrections, ApplyMETSystematics, GetBtagEff, AttachMuonSF, AttachElectronSF, AttachElectronCorrections, AttachTauSF, AttachTauEnergyCorrections, ApplyTauEnergySystematics, AttachPerLeptonFR, AttachMuonMomentumCorrections, ApplyMuonMomentumSystematics, get_supported_muon_momentum_systematics, get_supported_tau_energy_systematics, ApplyJetSystematics, GetTriggerSF, ApplyJetVetoMaps, get_selected_met, get_selected_raw_met, get_corr_t1_met_jets, get_supported_jet_systematics, get_supported_met_systematics, is_met_unclustered_systematic, resolve_forward_eta_stochastic_jer_suppression, use_type1_met, TAU_POG_VSJET_WP
 import topeft.modules.event_selection as te_es
 import topeft.modules.object_selection as te_os
 from topeft.modules.ttgamma_photon_history import (
@@ -410,6 +410,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         explicit_zll_cr_channels = {
             "2los_CRZ",
             "2lss_CRflip",
+            "3l_CR",
         }
         # Diagnostic Z-candidate observable for the SFOS on-Z subset of these
         # selected 2lOS+tau CR events; the categories are not globally on-Z.
@@ -669,7 +670,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         if self.enable_tau_blocks:
             tau_fo_tag = "VLoose" if is_run2 else "Loose"
-            tau_T_tag = "Loose" if is_run2 else "Medium"
+            tau_T_tag = TAU_POG_VSJET_WP
             taus = AttachTauEnergyCorrections(
                 year, tau, isData, vsJetWP=tau_T_tag
             )

--- a/analysis/topeft_run2/make_cr_and_sr_plots.py
+++ b/analysis/topeft_run2/make_cr_and_sr_plots.py
@@ -51,6 +51,7 @@ _logger = logging.getLogger(__name__)
 _ORIGINAL_SPARSEHIST_READ_FROM_REDUCE = tc_sparseHist.SparseHist._read_from_reduce.__func__
 _VALUES_METHOD_CAPS = {}
 _SYSTEMATICS_SUMMARY_EMITTED = set()
+RATIO_Y_RANGE = (0.0, 2.0)
 
 
 def _fast_sparsehist_from_reduce(cls, cat_axes, dense_axes, init_args, dense_hists):
@@ -2232,15 +2233,9 @@ def _rebin_uncertainty_array(
 
 
 def _determine_ratio_window(ratio_arrays, data_ratio_arrays, *, tolerance=1e-12):
-    """Return ratio axis limits and warning flags given MC/data ratio samples."""
+    """Return the fixed ratio limits and flags for values outside them."""
 
-    ratio_windows = (
-        (0.5, 1.5),
-        (0.0, 2.0),
-        (-1.0, 3.0),
-    )
-    ratio_window_deviations = (0.5, 1.0, 2.0)
-    largest_low, largest_high = ratio_windows[-1]
+    ratio_low, ratio_high = RATIO_Y_RANGE
 
     def _finite_segments(arrays):
         segments = []
@@ -2255,41 +2250,26 @@ def _determine_ratio_window(ratio_arrays, data_ratio_arrays, *, tolerance=1e-12)
 
     finite_segments = _finite_segments(ratio_arrays)
 
-    ratio_limits = ratio_windows[0]
-    exceeds_largest_window = False
+    exceeds_ratio_range = False
     if finite_segments:
         combined = np.concatenate(finite_segments)
         min_val = float(np.min(combined))
         max_val = float(np.max(combined))
-        max_abs_deviation = float(np.max(np.abs(combined - 1.0)))
-
-        selected_limits = ratio_windows[-1]
-        for (low, high), allowed_deviation in zip(ratio_windows, ratio_window_deviations):
-            if (
-                max_abs_deviation <= allowed_deviation + tolerance
-                and min_val >= low - tolerance
-                and max_val <= high + tolerance
-            ):
-                selected_limits = (low, high)
-                break
-
-        ratio_limits = selected_limits
-
-        exceeds_largest_window = (
-            min_val < largest_low - tolerance or max_val > largest_high + tolerance
+        exceeds_ratio_range = (
+            min_val < ratio_low - tolerance or max_val > ratio_high + tolerance
         )
 
     data_finite_segments = _finite_segments(data_ratio_arrays)
-    data_exceeds_largest_window = False
+    data_exceeds_ratio_range = False
     if data_finite_segments:
         data_combined = np.concatenate(data_finite_segments)
         data_min = float(np.min(data_combined))
         data_max = float(np.max(data_combined))
-        data_exceeds_largest_window = (
-            data_min < largest_low - tolerance or data_max > largest_high + tolerance
+        data_exceeds_ratio_range = (
+            data_min < ratio_low - tolerance or data_max > ratio_high + tolerance
         )
 
-    return ratio_limits, exceeds_largest_window, data_exceeds_largest_window
+    return RATIO_Y_RANGE, exceeds_ratio_range, data_exceeds_ratio_range
 
 
 def _merge_mappings(base, updates):
@@ -5010,7 +4990,10 @@ def _compute_uncertainty_bands(
                 )
                 ratio_band_handles.append(ratio_total_handle)
 
-    if has_ratio_axis and ratio_band_handles:
+    show_ratio_legend = bool(
+        _style_get(style, ("ratio_band_legend", "enabled"), False)
+    )
+    if has_ratio_axis and ratio_band_handles and show_ratio_legend:
         ratio_legend_style = _style_get(style, ("ratio_band_legend",), {})
         legend_kwargs = {
             "loc": ratio_legend_style.get("loc", "upper left"),
@@ -7910,13 +7893,13 @@ def make_region_stacked_ratio_fig(
 
         (
             ratio_limits,
-            exceeds_largest_window,
-            data_exceeds_largest_window,
+            exceeds_ratio_range,
+            data_exceeds_ratio_range,
         ) = _determine_ratio_window(ratio_arrays, data_ratio_arrays)
 
-        if exceeds_largest_window or data_exceeds_largest_window:
+        if exceeds_ratio_range or data_exceeds_ratio_range:
             warnings.warn(
-                "Ratio data exceed the [-1.0, 3.0] limits; values outside the plotted range will be clipped.",
+                "Ratio data exceed the [0.0, 2.0] limits; values outside the plotted range will be clipped.",
                 RuntimeWarning,
             )
 
@@ -8129,6 +8112,7 @@ def run_plots_for_region(
     report_zero_yields=False,
     rebin_plot_vars=None,
     negative_weight_report=True,
+    show_ratio_legend=False,
 ):
     """Run one CR/SR plotting pass and write optional zero/negative reports."""
 
@@ -8194,6 +8178,13 @@ def run_plots_for_region(
         )
         if summary_region_ctx is None:
             summary_region_ctx = region_ctx
+
+        stacked_ratio_style = getattr(region_ctx, "stacked_ratio_style", None)
+        if isinstance(stacked_ratio_style, dict):
+            ratio_legend_style = stacked_ratio_style.setdefault(
+                "ratio_band_legend", {}
+            )
+            ratio_legend_style["enabled"] = bool(show_ratio_legend)
 
         if region_ctx.channel_mode == "per-channel" and not split_channels_available:
             mode_label = CHANNEL_MODE_LABELS.get(channel_mode, channel_mode)
@@ -8408,6 +8399,11 @@ def build_arg_parser():
         dest="negative_weight_report",
         action="store_false",
         help="Disable the end-of-run negative MC contribution CSV/Markdown report.",
+    )
+    parser.add_argument(
+        "--show-ratio-legend",
+        action="store_true",
+        help="Draw the uncertainty-band legend in ratio panels (default: hidden).",
     )
     parser.add_argument(
         "--on-process-collision",
@@ -8646,6 +8642,7 @@ def run_with_args(args, parser):
         report_zero_yields=args.report_zero_yields,
         rebin_plot_vars=rebin_plot_vars,
         negative_weight_report=args.negative_weight_report,
+        show_ratio_legend=args.show_ratio_legend,
     )
     return 0
 

--- a/analysis/topeft_run2/run_cr.sh
+++ b/analysis/topeft_run2/run_cr.sh
@@ -68,9 +68,11 @@ cr_var_sets=(
   # "fwd0pt fwd0eta lj0pt lt met ptz nbtagsl l0conept l0eta"
   # "njets l1conept l1eta j0pt j0eta invmass ljptsum nbtagsm npvsGood"
   # "l0eta met lt ptz_wtau"
-  "l0conept njets tau0Fpt tau0Tpt"
+  # "l0conept njets tau0Fpt tau0Tpt"
   # "lt"
   # "lj0pt nbtagsl nbtagsm fwd0pt fwd0eta lt"
+
+  "ptz njets l0conept met"
 )
 
 # SR variable chunks are configured separately from CR so SR campaigns can use
@@ -88,8 +90,7 @@ sr_var_sets=(
 #
 # Yuyi requested Run 2 period-specific coverage and Run 3 tau-region coverage.
 cr_year_sets=(
-  "2016APV 2016"
-  "2017 2018"
+  "2016APV 2016 2017 2018"
   "2022 2022EE"
   "2023 2023BPix"
 )
@@ -101,7 +102,9 @@ cr_year_sets=(
 # they can be added as separate entries after confirming the exact names.
 cr_category_sets=(
   # "2los_CRZ 2l_CR 2los_CRtt 2l_CRflip 3l_CR"
-  "1l_1tau_CRtt 1l_1tau_CRDY 2los_1tau 2los_1tau_0b"
+  # "1l_1tau_CRtt 1l_1tau_CRDY 2los_1tau 2los_1tau_0b"
+
+  "2los_CRZ 3l_CR"
 )
 
 ###############################################################################

--- a/tests/test_analysis_mode_truth_table.py
+++ b/tests/test_analysis_mode_truth_table.py
@@ -7,6 +7,20 @@ import pytest
 from analysis.topeft_run2 import analysis_processor as ap
 
 
+def test_run_cr_requests_ptz_for_the_3l_cr_and_forwards_hist_variables():
+    run_cr_source = (
+        Path(__file__).resolve().parents[1]
+        / "analysis"
+        / "topeft_run2"
+        / "run_cr.sh"
+    ).read_text()
+
+    assert '"ptz njets l0conept met"' in run_cr_source
+    assert '"2los_CRZ 3l_CR"' in run_cr_source
+    assert '--hist-vars "${vars[@]}"' in run_cr_source
+    assert '--category-groups "${cats[@]}"' in run_cr_source
+
+
 @pytest.mark.parametrize(
     ("offz", "tau", "fwd", "all_mode"),
     [
@@ -190,6 +204,7 @@ def test_plain_ptz_cr_policy_fills_zll_and_diagnostic_crs(all_analysis):
         "2los_1tau_Ftau",
         "2los_1tau_Ttau",
         "2los_1tau_0b",
+        "3l_CR",
     ):
         assert (
             processor._should_skip_histogram_fill(
@@ -206,7 +221,6 @@ def test_plain_ptz_cr_policy_fills_zll_and_diagnostic_crs(all_analysis):
     "2los_CRtt",
     "1l_1tau_CR",
     "1l_dy_tautau_CR",
-    "3l_CR",
 ])
 def test_plain_ptz_cr_policy_skips_non_zll_crs(lep_chan):
     processor = ap.AnalysisProcessor(

--- a/tests/test_make_cr_and_sr_plots.py
+++ b/tests/test_make_cr_and_sr_plots.py
@@ -99,6 +99,50 @@ def _make_multigroup_stacked_inputs(num_groups=8):
     return h_mc, h_data, group_map
 
 
+def test_ratio_axis_range_is_fixed_and_ratio_legend_is_opt_in():
+    h_mc, h_data, group_map = _make_simple_stacked_inputs()
+
+    default_fig = make_cr_and_sr_plots.make_region_stacked_ratio_fig(
+        h_mc=h_mc,
+        h_data=h_data,
+        unit_norm_bool=False,
+        var="lj0pt",
+        group=group_map,
+        unblind=True,
+    )
+    legend_fig = make_cr_and_sr_plots.make_region_stacked_ratio_fig(
+        h_mc=h_mc,
+        h_data=h_data,
+        unit_norm_bool=False,
+        var="lj0pt",
+        group=group_map,
+        unblind=True,
+        style={"ratio_band_legend": {"enabled": True}},
+    )
+
+    try:
+        default_ratio_axis = default_fig.axes[1]
+        legend_ratio_axis = legend_fig.axes[1]
+        assert default_ratio_axis.get_ylim() == pytest.approx((0.0, 2.0))
+        assert legend_ratio_axis.get_ylim() == pytest.approx((0.0, 2.0))
+        assert default_ratio_axis.get_legend() is None
+        assert legend_ratio_axis.get_legend() is not None
+    finally:
+        make_cr_and_sr_plots.plt.close(default_fig)
+        make_cr_and_sr_plots.plt.close(legend_fig)
+
+
+def test_show_ratio_legend_cli_is_disabled_by_default_and_explicitly_enabled():
+    parser = make_cr_and_sr_plots.build_arg_parser()
+    assert parser.parse_args(["-f", "input.pkl.gz"]).show_ratio_legend is False
+    assert (
+        parser.parse_args(
+            ["-f", "input.pkl.gz", "--show-ratio-legend"]
+        ).show_ratio_legend
+        is True
+    )
+
+
 def _get_cms_text_union_bbox(fig, ax, renderer):
     def _cms_matches(text_artist):
         text = text_artist.get_text() or ""

--- a/tests/test_tau_correction_wp_policy.py
+++ b/tests/test_tau_correction_wp_policy.py
@@ -1,0 +1,149 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import awkward as ak
+import numpy as np
+import pytest
+
+import topeft.modules.corrections as corrections
+
+
+class _RecordingCorrection:
+    def __init__(self, name):
+        self.name = name
+        self.calls = []
+
+    def evaluate(self, *args):
+        self.calls.append(args)
+        return np.ones(len(args[0]), dtype=np.float32)
+
+
+class _RecordingEvaluator:
+    def __init__(self):
+        self.keys = []
+
+    def __getitem__(self, key):
+        self.keys.append(key)
+
+        def evaluate(first, *args):
+            return ak.ones_like(first, dtype=np.float32)
+
+        return evaluate
+
+
+def _tau_record(year, gen_part_flav):
+    if year.startswith("201"):
+        discriminator_fields = {
+            "idDeepTau2017v2p1VSjet": 16,
+            "idDeepTau2017v2p1VSe": 2,
+            "idDeepTau2017v2p1VSmu": 8,
+        }
+    else:
+        discriminator_fields = {
+            "idDeepTau2018v2p5VSjet": 5,
+            "idDeepTau2018v2p5VSe": 2,
+            "idDeepTau2018v2p5VSmu": 4,
+        }
+
+    return ak.Array(
+        [[
+            {
+                "pt": 35.0,
+                "mass": 1.2,
+                "eta": 0.5,
+                "decayMode": 0,
+                "genPartFlav": gen_part_flav,
+                "isLoose": 1,
+                "isMedium": 1,
+                "iseTight": 1,
+                "ismTight": 1,
+                **discriminator_fields,
+            }
+        ]]
+    )
+
+
+@pytest.mark.parametrize(
+    ("year", "vsjet_correction_name", "fake_sf_key"),
+    [
+        ("2018", "DeepTau2017v2p1VSjet", "TauFakeSF"),
+        ("2022", "DeepTau2018v2p5VSjet", "TauFakeSF_Run3"),
+    ],
+)
+def test_tau_pog_vsjet_payload_uses_aligned_medium_wp_and_fake_sf_stays_separate(
+    monkeypatch,
+    year,
+    vsjet_correction_name,
+    fake_sf_key,
+):
+    recording_corrections = {
+        vsjet_correction_name: _RecordingCorrection(vsjet_correction_name),
+        "DeepTau2018v2p5VSe": _RecordingCorrection("DeepTau2018v2p5VSe"),
+    }
+    monkeypatch.setattr(
+        corrections.correctionlib,
+        "CorrectionSet",
+        SimpleNamespace(from_file=lambda path: recording_corrections),
+    )
+    recording_evaluator = _RecordingEvaluator()
+    monkeypatch.setattr(corrections, "SFevaluator", recording_evaluator)
+
+    corrections.AttachTauSF(
+        {},
+        _tau_record(year, gen_part_flav=5),
+        year,
+        vsJetWP=corrections.TAU_POG_VSJET_WP,
+    )
+
+    vsjet_calls = recording_corrections[vsjet_correction_name].calls
+    assert vsjet_calls
+    assert all(call[3] == "Medium" for call in vsjet_calls)
+    assert fake_sf_key in recording_evaluator.keys
+
+
+@pytest.mark.parametrize(
+    ("year", "vsjet_correction_name", "fake_sf_key"),
+    [
+        ("2018", "DeepTau2017v2p1VSjet", "TauFakeSF"),
+        ("2022", "DeepTau2018v2p5VSjet", "TauFakeSF_Run3"),
+    ],
+)
+def test_jet_faking_tau_sf_keeps_its_dedicated_non_pog_payload(
+    monkeypatch,
+    year,
+    vsjet_correction_name,
+    fake_sf_key,
+):
+    recording_corrections = {
+        vsjet_correction_name: _RecordingCorrection(vsjet_correction_name),
+        "DeepTau2018v2p5VSe": _RecordingCorrection("DeepTau2018v2p5VSe"),
+    }
+    monkeypatch.setattr(
+        corrections.correctionlib,
+        "CorrectionSet",
+        SimpleNamespace(from_file=lambda path: recording_corrections),
+    )
+    recording_evaluator = _RecordingEvaluator()
+    monkeypatch.setattr(corrections, "SFevaluator", recording_evaluator)
+
+    corrections.AttachTauSF(
+        {},
+        _tau_record(year, gen_part_flav=0),
+        year,
+        vsJetWP=corrections.TAU_POG_VSJET_WP,
+    )
+
+    assert fake_sf_key in recording_evaluator.keys
+
+
+def test_processor_uses_one_aligned_tau_wp_for_run2_and_run3():
+    processor_source = (
+        Path(__file__).resolve().parents[1]
+        / "analysis"
+        / "topeft_run2"
+        / "analysis_processor.py"
+    ).read_text()
+
+    assert corrections.TAU_POG_VSJET_WP == "Medium"
+    assert "tau_T_tag = TAU_POG_VSJET_WP" in processor_source
+    assert 'tau_T_tag = "Loose" if is_run2 else "Medium"' not in processor_source

--- a/tests/test_tau_correction_wp_policy.py
+++ b/tests/test_tau_correction_wp_policy.py
@@ -3,11 +3,18 @@ from types import SimpleNamespace
 
 import awkward as ak
 import correctionlib
+import json
 import numpy as np
 import pytest
 from topcoffea.modules.paths import topcoffea_path
 
 import topeft.modules.corrections as corrections
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PARAMS_PATH = REPO_ROOT / "topeft" / "params" / "params.json"
+PROCESSOR_PATH = REPO_ROOT / "analysis" / "topeft_run2" / "analysis_processor.py"
+CORRECTIONS_PATH = REPO_ROOT / "topeft" / "modules" / "corrections.py"
 
 
 class _RecordingCorrection:
@@ -72,7 +79,7 @@ def _tau_record(year, gen_part_flav):
         ("2022", "DeepTau2018v2p5VSjet", "TauFakeSF_Run3"),
     ],
 )
-def test_tau_pog_vsjet_payload_uses_aligned_medium_wp_and_fake_sf_stays_separate(
+def test_tau_vsjet_payload_uses_aligned_medium_wp_and_fake_sf_stays_separate(
     monkeypatch,
     year,
     vsjet_correction_name,
@@ -94,7 +101,9 @@ def test_tau_pog_vsjet_payload_uses_aligned_medium_wp_and_fake_sf_stays_separate
         {},
         _tau_record(year, gen_part_flav=5),
         year,
-        vsJetWP=corrections.get_tau_pog_vsjet_wp(),
+        vsJetWP=corrections.get_te_param(
+            "run2_tau_t_tag" if year.startswith("201") else "run3_tau_t_tag"
+        ),
     )
 
     vsjet_calls = recording_corrections[vsjet_correction_name].calls
@@ -134,14 +143,23 @@ def test_jet_faking_tau_sf_keeps_its_dedicated_non_pog_payload(
         {},
         _tau_record(year, gen_part_flav=0),
         year,
-        vsJetWP=corrections.get_tau_pog_vsjet_wp(),
+        vsJetWP=corrections.get_te_param(
+            "run2_tau_t_tag" if year.startswith("201") else "run3_tau_t_tag"
+        ),
     )
 
     assert fake_sf_key in recording_evaluator.keys
 
 
-def test_params_json_defines_canonical_tau_pog_vsjet_wp():
-    assert corrections.get_tau_pog_vsjet_wp() == "Medium"
+def test_params_json_defines_run2_and_run3_tau_tags():
+    params = json.loads(PARAMS_PATH.read_text())
+    stale_key = "tau_" + "pog_vsjet_wp"
+
+    assert params["run2_tau_t_tag"] == "Medium"
+    assert params["run3_tau_t_tag"] == "Medium"
+    assert params["run2_tau_fo_tag"] == "Loose"
+    assert params["run3_tau_fo_tag"] == "Loose"
+    assert stale_key not in params
 
 
 def test_run2_deeptau2017_vsjet_schema_matches_evaluate_call_order():
@@ -164,15 +182,33 @@ def test_run2_deeptau2017_vsjet_schema_matches_evaluate_call_order():
 
 
 def test_processor_uses_params_tau_wp_and_loose_tau_fo_tag_for_run2_and_run3():
-    processor_source = (
-        Path(__file__).resolve().parents[1]
-        / "analysis"
-        / "topeft_run2"
-        / "analysis_processor.py"
-    ).read_text()
+    processor_source = PROCESSOR_PATH.read_text()
 
-    assert corrections.get_tau_pog_vsjet_wp() == "Medium"
-    assert "tau_T_tag = get_tau_pog_vsjet_wp()" in processor_source
-    assert 'tau_fo_tag = "Loose"' in processor_source
+    assert "tau_T_tag = get_te_param(" in processor_source
+    assert "tau_fo_tag = get_te_param(" in processor_source
+    for key in (
+        "run2_tau_t_tag",
+        "run3_tau_t_tag",
+        "run2_tau_fo_tag",
+        "run3_tau_fo_tag",
+    ):
+        assert key in processor_source
+    assert 'tau_fo_tag = "Loose"' not in processor_source
     assert 'tau_fo_tag = "VLoose" if is_run2 else "Loose"' not in processor_source
     assert 'tau_T_tag = "Loose" if is_run2 else "Medium"' not in processor_source
+
+
+def test_tau_tag_params_use_direct_access_without_redundant_helpers():
+    corrections_source = CORRECTIONS_PATH.read_text()
+    processor_source = PROCESSOR_PATH.read_text()
+    rejected_getter = "get_tau_" + "pog_vsjet_wp"
+    rejected_resolver = "_resolve_tau_" + "pog_vsjet_wp"
+    stale_key = "tau_" + "pog_vsjet_wp"
+
+    assert f"def {rejected_getter}" not in corrections_source
+    assert f"def {rejected_resolver}" not in corrections_source
+    assert rejected_getter not in processor_source
+    assert rejected_resolver not in corrections_source
+    assert stale_key not in corrections_source
+    assert stale_key not in processor_source
+    assert 'get_te_param("run2_tau_t_tag" if is_run2 else "run3_tau_t_tag")' in corrections_source

--- a/tests/test_tau_correction_wp_policy.py
+++ b/tests/test_tau_correction_wp_policy.py
@@ -2,8 +2,10 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import awkward as ak
+import correctionlib
 import numpy as np
 import pytest
+from topcoffea.modules.paths import topcoffea_path
 
 import topeft.modules.corrections as corrections
 
@@ -92,12 +94,14 @@ def test_tau_pog_vsjet_payload_uses_aligned_medium_wp_and_fake_sf_stays_separate
         {},
         _tau_record(year, gen_part_flav=5),
         year,
-        vsJetWP=corrections.TAU_POG_VSJET_WP,
+        vsJetWP=corrections.get_tau_pog_vsjet_wp(),
     )
 
     vsjet_calls = recording_corrections[vsjet_correction_name].calls
     assert vsjet_calls
     assert all(call[3] == "Medium" for call in vsjet_calls)
+    if year.startswith("201"):
+        assert vsjet_calls[0][4:] == ("VVLoose", "nom", "dm")
     assert fake_sf_key in recording_evaluator.keys
 
 
@@ -130,13 +134,36 @@ def test_jet_faking_tau_sf_keeps_its_dedicated_non_pog_payload(
         {},
         _tau_record(year, gen_part_flav=0),
         year,
-        vsJetWP=corrections.TAU_POG_VSJET_WP,
+        vsJetWP=corrections.get_tau_pog_vsjet_wp(),
     )
 
     assert fake_sf_key in recording_evaluator.keys
 
 
-def test_processor_uses_one_aligned_tau_wp_for_run2_and_run3():
+def test_params_json_defines_canonical_tau_pog_vsjet_wp():
+    assert corrections.get_tau_pog_vsjet_wp() == "Medium"
+
+
+def test_run2_deeptau2017_vsjet_schema_matches_evaluate_call_order():
+    expected_input_names = [
+        "pt",
+        "dm",
+        "genmatch",
+        "wp",
+        "wp_VSe",
+        "syst",
+        "flag",
+    ]
+    for year in ("2016APV", "2016", "2017", "2018"):
+        clib_year = corrections.clib_year_map[year]
+        payload_path = topcoffea_path(f"data/POG/TAU/{clib_year}/tau.json.gz")
+        corr = correctionlib.CorrectionSet.from_file(payload_path)[
+            "DeepTau2017v2p1VSjet"
+        ]
+        assert [input_.name for input_ in corr.inputs] == expected_input_names
+
+
+def test_processor_uses_params_tau_wp_and_loose_tau_fo_tag_for_run2_and_run3():
     processor_source = (
         Path(__file__).resolve().parents[1]
         / "analysis"
@@ -144,6 +171,8 @@ def test_processor_uses_one_aligned_tau_wp_for_run2_and_run3():
         / "analysis_processor.py"
     ).read_text()
 
-    assert corrections.TAU_POG_VSJET_WP == "Medium"
-    assert "tau_T_tag = TAU_POG_VSJET_WP" in processor_source
+    assert corrections.get_tau_pog_vsjet_wp() == "Medium"
+    assert "tau_T_tag = get_tau_pog_vsjet_wp()" in processor_source
+    assert 'tau_fo_tag = "Loose"' in processor_source
+    assert 'tau_fo_tag = "VLoose" if is_run2 else "Loose"' not in processor_source
     assert 'tau_T_tag = "Loose" if is_run2 else "Medium"' not in processor_source

--- a/topeft/modules/corrections.py
+++ b/topeft/modules/corrections.py
@@ -58,7 +58,16 @@ TAU_ENERGY_FIELDS = {
         for variation in TAU_ENERGY_SYSTEMATICS
     },
 }
-TAU_POG_VSJET_WP = "Medium"
+
+
+def get_tau_pog_vsjet_wp():
+    return get_te_param("tau_pog_vsjet_wp")
+
+
+def _resolve_tau_pog_vsjet_wp(vsJetWP):
+    if vsJetWP is not None:
+        return vsJetWP
+    return get_tau_pog_vsjet_wp()
 
 
 def is_muon_momentum_systematic(syst_var):
@@ -745,8 +754,9 @@ def _evaluate_tau_energy_components(
     }
 
 
-def AttachTauEnergyCorrections(year, taus, isData, vsJetWP=TAU_POG_VSJET_WP):
+def AttachTauEnergyCorrections(year, taus, isData, vsJetWP=None):
     """Attach complete nominal and varied tau pt/mass views from raw kinematics."""
+    vsJetWP = _resolve_tau_pog_vsjet_wp(vsJetWP)
     if "pt_raw" not in ak.fields(taus):
         taus = ak.with_field(taus, taus.pt, "pt_raw")
     if "mass_raw" not in ak.fields(taus):
@@ -800,9 +810,10 @@ def AttachTauSF(
     events,
     taus,
     year,
-    vsJetWP=TAU_POG_VSJET_WP,
+    vsJetWP=None,
     run3_fake_split=False,
 ):
+    vsJetWP = _resolve_tau_pog_vsjet_wp(vsJetWP)
     pt   = taus.pt
     dm   = taus.decayMode
     eta  = taus.eta

--- a/topeft/modules/corrections.py
+++ b/topeft/modules/corrections.py
@@ -59,17 +59,6 @@ TAU_ENERGY_FIELDS = {
     },
 }
 
-
-def get_tau_pog_vsjet_wp():
-    return get_te_param("tau_pog_vsjet_wp")
-
-
-def _resolve_tau_pog_vsjet_wp(vsJetWP):
-    if vsJetWP is not None:
-        return vsJetWP
-    return get_tau_pog_vsjet_wp()
-
-
 def is_muon_momentum_systematic(syst_var):
     return syst_var in RUN3_MUON_MOMENTUM_SYSTEMATICS
 
@@ -756,7 +745,9 @@ def _evaluate_tau_energy_components(
 
 def AttachTauEnergyCorrections(year, taus, isData, vsJetWP=None):
     """Attach complete nominal and varied tau pt/mass views from raw kinematics."""
-    vsJetWP = _resolve_tau_pog_vsjet_wp(vsJetWP)
+    is_run2 = str(year).startswith("201")
+    if vsJetWP is None:
+        vsJetWP = get_te_param("run2_tau_t_tag" if is_run2 else "run3_tau_t_tag")
     if "pt_raw" not in ak.fields(taus):
         taus = ak.with_field(taus, taus.pt, "pt_raw")
     if "mass_raw" not in ak.fields(taus):
@@ -813,7 +804,6 @@ def AttachTauSF(
     vsJetWP=None,
     run3_fake_split=False,
 ):
-    vsJetWP = _resolve_tau_pog_vsjet_wp(vsJetWP)
     pt   = taus.pt
     dm   = taus.decayMode
     eta  = taus.eta
@@ -822,6 +812,8 @@ def AttachTauSF(
 
     is_run2 = year.startswith("201")
     is_run3 = not is_run2
+    if vsJetWP is None:
+        vsJetWP = get_te_param("run2_tau_t_tag" if is_run2 else "run3_tau_t_tag")
 
     stored_muon_mask = None
     if "ismTight" in ak.fields(taus):

--- a/topeft/modules/corrections.py
+++ b/topeft/modules/corrections.py
@@ -58,6 +58,7 @@ TAU_ENERGY_FIELDS = {
         for variation in TAU_ENERGY_SYSTEMATICS
     },
 }
+TAU_POG_VSJET_WP = "Medium"
 
 
 def is_muon_momentum_systematic(syst_var):
@@ -744,7 +745,7 @@ def _evaluate_tau_energy_components(
     }
 
 
-def AttachTauEnergyCorrections(year, taus, isData, vsJetWP="Medium"):
+def AttachTauEnergyCorrections(year, taus, isData, vsJetWP=TAU_POG_VSJET_WP):
     """Attach complete nominal and varied tau pt/mass views from raw kinematics."""
     if "pt_raw" not in ak.fields(taus):
         taus = ak.with_field(taus, taus.pt, "pt_raw")
@@ -795,7 +796,13 @@ def ApplyTauEnergySystematics(taus, syst_var):
     taus = ak.with_field(taus, taus[pt_field], "pt")
     return ak.with_field(taus, taus[mass_field], "mass")
 
-def AttachTauSF(events, taus, year, vsJetWP="Loose", run3_fake_split=False):
+def AttachTauSF(
+    events,
+    taus,
+    year,
+    vsJetWP=TAU_POG_VSJET_WP,
+    run3_fake_split=False,
+):
     pt   = taus.pt
     dm   = taus.decayMode
     eta  = taus.eta
@@ -858,13 +865,33 @@ def AttachTauSF(events, taus, year, vsJetWP="Loose", run3_fake_split=False):
         json_path = topcoffea_path(f"data/POG/TAU/{clib_year}/tau.json.gz")
         ceval = correctionlib.CorrectionSet.from_file(json_path)
  
-        wp   = taus.idDeepTau2017v2p1VSjet
+        corr_jet = ceval["DeepTau2017v2p1VSjet"]
+        vsjet_flat_mask = ak.flatten(
+            ak.fill_none(taus[f"is{vsJetWP}"] > 0, False)
+        )
+        genuine_tau_mask = ak.fill_none(
+            pt_mask_flat & (flat_gen == 5) & vsjet_flat_mask,
+            False,
+        )
 
-        ## legacy
-        whereFlag = ((pt>20) & (pt<205) & (gen==5) & (taus[f"is{vsJetWP}"]>0) )
-        real_sf_loose = np.where(whereFlag, SFevaluator[f'TauSF_{year}_{vsJetWP}'](dm,pt), 1)
-        real_sf_loose_up = np.where(whereFlag, SFevaluator[f'TauSF_{year}_{vsJetWP}_up'](dm,pt), 1)
-        real_sf_loose_down = np.where(whereFlag, SFevaluator[f'TauSF_{year}_{vsJetWP}_down'](dm,pt), 1)
+        def evaluate_real_tau_sf(syst):
+            values = np.ones(len(flat_pt), dtype=np.float32)
+            selected = ak.to_numpy(genuine_tau_mask)
+            if np.any(selected):
+                values[selected] = corr_jet.evaluate(
+                    ak.to_numpy(flat_pt[selected]),
+                    ak.to_numpy(flat_dm[selected]),
+                    ak.to_numpy(flat_gen[selected]),
+                    vsJetWP,
+                    "VVLoose",
+                    syst,
+                    "dm",
+                )
+            return ak.unflatten(values, ak.num(pt))
+
+        real_sf = evaluate_real_tau_sf("nom")
+        real_sf_up = evaluate_real_tau_sf("up")
+        real_sf_down = evaluate_real_tau_sf("down")
 
         whereFlag = ((pt>20) & (pt<205) & ((gen==1)|(gen==3)) & (taus["iseTight"]>0))
         fake_elec_sf = np.where(whereFlag, SFevaluator[f'Tau_elecFakeSF_{year}'](np.abs(eta)), 1)
@@ -880,10 +907,6 @@ def AttachTauSF(events, taus, year, vsJetWP="Loose", run3_fake_split=False):
         new_fake_sf = np.where(whereFlag, SFevaluator['TauFakeSF'](pt), 1)
         new_fake_sf_up = np.where(whereFlag, SFevaluator['TauFakeSF_up'](pt), 1)
         new_fake_sf_down = np.where(whereFlag, SFevaluator['TauFakeSF_down'](pt), 1)
-
-        real_sf = real_sf_loose
-        real_sf_up = real_sf_loose_up
-        real_sf_down = real_sf_loose_down
 
     if is_run3:
         clib_year = clib_year_map[year]

--- a/topeft/params/params.json
+++ b/topeft/params/params.json
@@ -36,6 +36,7 @@
     "dz_cut" : 0.1,
     "dxy_tau_cut" : 1000.0,
     "dz_tau_cut" : 0.2,
+    "tau_pog_vsjet_wp" : "Medium",
     "sip3d_cut" : 8,
 
 

--- a/topeft/params/params.json
+++ b/topeft/params/params.json
@@ -36,7 +36,10 @@
     "dz_cut" : 0.1,
     "dxy_tau_cut" : 1000.0,
     "dz_tau_cut" : 0.2,
-    "tau_pog_vsjet_wp" : "Medium",
+    "run2_tau_t_tag" : "Medium",
+    "run3_tau_t_tag" : "Medium",
+    "run2_tau_fo_tag" : "Loose",
+    "run3_tau_fo_tag" : "Loose",
     "sip3d_cut" : 8,
 
 


### PR DESCRIPTION
### Summary

This PR updates tau-region handling in the TOP EFT Run 2/Run 3 workflow.

The main changes are:

* Apply fake-tau scale factors only in the intended main-processor mode.
* Align the Run 3 electron-to-tau fake correction working point with the selected tau VSe working point.
* Add the `atmost_2j` processor selection needed by tau CR channel definitions using `jet_lst: ["<2"]`.
* Align the `2los_1tau` and `2los_1tau_0b` tau CR channel definitions with the requested at-most-2-jet setup.
* Align the `2los_1tau_0b` truth-table expectation with the channel JSON contract.
* Update the CR helper configuration for the requested tau-region production coverage.

### Motivation

During tau-region validation, the fake-tau SF path was found to be applied in both `standard` and `taufitter` modes when tau blocks were enabled. The intended behavior is to apply fake-tau SF event weights in `standard` mode for MC tau-enabled processing, but not in `taufitter`.

The same validation also found that the Run 3 electron-to-tau fake component was evaluated with `DeepTau2018v2p5VSe` using `VVLoose`, while the selected taus require the Tight VSe working point.

A separate truth-table expectation was stale for the `2los_1tau_0b` category. The intended contract is that `2los_1tau_0b` remains a separate `TAU_CH_LST_CR["2los_1tau_0b"]` category, not a leaf under `TAU_CH_LST_CR["2los_1tau"]`.

The 2los tau CR jet-bin behavior was also checked. The apparent 2j-only behavior in the `2los_1tau` leaves is expected when `bmask_atleast1m2l` is applied together with the at-most-2-jet selection: the b-tag mask implies at least two selected jets, while `jet_lst: ["<2"]` is parsed as at most two jets.

### Implementation details

#### Fake-tau SF policy

Added `should_apply_fake_tau_sf(tau_run_mode, *, enable_tau_blocks, is_data)` in `analysis/topeft_run2/analysis_processor.py`.

The helper returns:

* `True` for MC, tau-enabled, `standard` mode;
* `False` for data;
* `False` when tau blocks are disabled;
* `False` for `taufitter`;
* `ValueError` for unknown active tau modes.

The processor still computes and attaches tau SF fields through the existing tau correction path, but the `lepSF_taus_fake` event weight and its fake-tau systematic variations are only added when `should_apply_fake_tau_sf(...)` returns `True`.

Real-tau, muon, and electron lepton SF weights are unchanged.

#### Run 3 VSe fake-tau correction

Changed the Run 3 `DeepTau2018v2p5VSe` correction evaluation from:

```python
(flat_eta, flat_dm, flat_gen, "VVLoose")
```

to:

```python
(flat_eta, flat_dm, flat_gen, "Tight")
```

This aligns the correction working point with the selected tau VSe requirement.

The VSjet fake-tau path remains driven by `vsJetWP` and still evaluates the corresponding jet-fake payload independently.

#### Tau CR jet selections

Registered:

```python
selections.add("atmost_2j", (njets <= 2))
```

This supports channel JSON entries using:

```json
"jet_lst": ["<2"]
```

The `2los_1tau` and `2los_1tau_0b` tau CR channel definitions now use the at-most-2-jet selection consistently.

For `2los_1tau_Ftau` and `2los_1tau_Ttau`, the intended `bmask_atleast1m2l` requirement remains in place. Since that b-tag mask implies at least two selected jets, the effective selected jet multiplicity for those leaves remains exactly two jets.

#### Truth-table alignment

Updated `tests/test_analysis_mode_truth_table.py` so that:

* `TAU_CH_LST_CR["2los_1tau"]` contains only:

  * `2los_1tau_Ftau`
  * `2los_1tau_Ttau`
* `TAU_CH_LST_CR["2los_1tau_0b"]` separately contains:

  * `2los_1tau_0b`

The test now explicitly asserts that `2los_1tau_0b` is not expected inside `TAU_CH_LST_CR["2los_1tau"]`.

#### CR helper update

Updated `analysis/topeft_run2/run_cr.sh` for the tau CR distribution request:

* run CR production by default instead of SR production;
* use the requested tau-focused variables:

  * `l0conept`
  * `njets`
  * `tau0Fpt`
  * `tau0Tpt`
* cover Run 2 and Run 3 year groups;
* include both `2los_1tau` and `2los_1tau_0b` in the CR category set.

### Testing

Validation performed for this branch included:

* `git diff --check`;
* Python compile checks for the changed processor, correction, and test files;
* Run 3 `DeepTau2018v2p5VSe` payload inspection confirming `Tight` support for the active 2022, 2022EE, 2023, and 2023BPix payloads;
* targeted fake-tau policy tests;
* tau energy correction tests;
* targeted truth-table test;
* full `tests/test_analysis_mode_truth_table.py`;
* `tests/test_fake_tau_sf_taufitter_policy.py`.

Relevant reported results:

```text
tests/test_fake_tau_sf_taufitter_policy.py tests/test_tau_energy_corrections.py:
26 passed

tests/test_analysis_mode_truth_table.py::test_plain_ptz_diagnostic_2los_1tau_crs_are_not_category_onz:
passed after the truth-table alignment

tests/test_analysis_mode_truth_table.py:
32 passed

tests/test_fake_tau_sf_taufitter_policy.py:
7 passed
```

Production-scale yield validation was not run as part of this PR.

### Review notes

* This PR intentionally changes the main-processor fake-tau SF policy for `taufitter`: fake-tau SF event weights are no longer inserted in `taufitter` mode.
* The diboson processor is not changed.
* Run 3 electron-to-tau fake SFs now use the `Tight` VSe working point.
* `2los_1tau_0b` is intentionally treated as a separate `TAU_CH_LST_CR` category.
* The `2los_1tau` leaves still require `bmask_atleast1m2l`; therefore, despite `jet_lst: ["<2"]`, their effective selected jet multiplicity is exactly two jets.
* The CR helper defaults in `run_cr.sh` are changed for the current tau CR production request. Reviewers should check that these helper defaults are appropriate for shared branch usage.
