### PR TITLE
feat(topeft): retain analysis configs and metadata

### DIFF
--- a/analysis/topeft_run2/run_cr.sh
+++ b/analysis/topeft_run2/run_cr.sh
@@ -7,7 +7,8 @@ cd /users/apiccine/work/correction-lib/topeft/analysis/topeft_run2
 # Global configuration
 ###############################################################################
 
-output_dir="/groups/klannon/apiccine/preappr_1l1tau_260613"
+# output_dir="/groups/klannon/apiccine/preappr_260710"
+output_dir="/groups/klannon/apiccine/preappr_260710_CR"
 chunk_size="50000"
 
 # Nominal TOP-23-002-like ttgamma sample-role strategy.
@@ -25,7 +26,7 @@ chunk_size="50000"
 ttgamma_sample_role_policy="split"
 
 # Use a strategy-specific tag to avoid mixing baseline/feature/diagnostic outputs.
-campaign_tag="preappr_tauwp_loose"
+campaign_tag="new-tau-sf"
 
 cr_pkl_base_tag="${campaign_tag}"
 sr_pkl_base_tag="${campaign_tag}"
@@ -70,14 +71,13 @@ split_lep_flavor=false
 ###############################################################################
 
 cr_var_sets=(
-  # "fwd0pt fwd0eta lj0pt lt met ptz nbtagsl l0conept l0eta"
-  # "njets l1conept l1eta j0pt j0eta invmass ljptsum nbtagsm npvsGood"
-  # "l0eta met lt ptz_wtau"
-  # "l0conept njets tau0Fpt tau0Tpt"
-  # "lt"
-  # "lj0pt nbtagsl nbtagsm fwd0pt fwd0eta lt"
+  ## non-tau CRs
+  "fwd0pt fwd0eta lj0pt lt met ptz nbtagsl l0conept l0eta"
+  "njets l1conept l1eta j0pt j0eta invmass ljptsum nbtagsm npvsGood"
 
-  "ptz_wtau njets l0conept tau0Tpt tau0Fpt"
+  ## tau CRs
+  # "l0conept l0eta met lj0pt nbtagsl nbtagsm"
+  # "ptz_wtau njets lt tau0Tpt tau0Fpt fwd0pt fwd0eta"
 )
 
 # Keep year periods separate so the output pkls are period-specific.
@@ -85,8 +85,7 @@ cr_var_sets=(
 # Yuyi requested Run 2 period-specific coverage and Run 3 tau-region coverage.
 cr_year_sets=(
   "2016APV 2016 2017 2018"
-  # "2022 2022EE"
-  # "2023 2023BPix"
+  "2022 2022EE 2023 2023BPix"
 )
 
 # Current category names used by the analysis helpers.
@@ -95,9 +94,11 @@ cr_year_sets=(
 # If the branch has explicit 2los_1tau_Ftau / 2los_1tau_Ttau category groups,
 # they can be added as separate entries after confirming the exact names.
 cr_category_sets=(
-  # "2los_CRZ 2l_CR 2los_CRtt 2l_CRflip 3l_CR"
+  "2los_CRZ" # 2l_CR 2los_CRtt 2l_CRflip 3l_CR"
   # "1l_1tau_CRtt 1l_1tau_CRDY 2los_1tau 2los_1tau_0b"
-  "2los_CRZ 2los_1tau 2los_1tau_0b" # 3l_CR"
+  # "2los_CRZ 2los_1tau 2los_1tau_0b" # 3l_CR"
+
+  # "1l_1tau_CRtt 1l_1tau_CRDY 2los_1tau 2los_1tau_0b"
 )
 
 ###############################################################################
@@ -107,8 +108,7 @@ cr_category_sets=(
 # SR variable chunks are configured separately from CR so SR campaigns can use
 # dedicated histogram groups without changing the CR request.
 sr_var_sets=(
-  "njets lj0pt"
-  "ptz ptz_wtau lt"
+  "njets lj0pt ptz ptz_wtau lt"
 )
 
 # Kept available, but disabled by default for this request.
@@ -117,20 +117,21 @@ sr_year_sets=(
   # 2022EE
   # 2023
   # 2023BPix
-  "2022 2022EE 2023 2023BPix"
-  # 2016APV
-  # 2016
-  # 2017
-  # 2018
+  "2022 2022EE"
+  "2023 2023BPix"
+  # "2016APV 2016 2017 2018"
 )
 
 sr_category_sets=(
-  "2l"
-  "2lss_1tau 2los_1tau"
-  "3l_m_offZ"
-  "3l_p_offZ"
-  "3l_onZ_tau 4l"
-  "3l_fwd"
+  # "2l"
+  # "2lss_1tau 2los_1tau"
+  # "3l_m_offZ"
+  # "3l_p_offZ"
+  # "3l_onZ_tau 4l"
+  # "3l_fwd"
+  "2l 2lss_1tau 2los_1tau 4l"
+  "3l_m_offZ 3l_p_offZ"
+  "3l_onZ_tau 3l_fwd"
 )
 
 ###############################################################################

--- a/analysis/topeft_run2/run_sow.py
+++ b/analysis/topeft_run2/run_sow.py
@@ -90,7 +90,7 @@ processor_instance = sow_processor.AnalysisProcessor(samples_to_process,wc_lst)
 
 if executor == "work_queue":
     executor_args = {
-        'master_name': '{}SoW-coffea'.format(os.environ['USER']),
+        'master_name': 'SoW-coffea{}'.format(os.environ['USER']),
 
         # find a port to run work queue in this range:
         'port': [9123,9130],

--- a/input_samples/cfgs/missing_parton_run3_central_tzq_NDSkim.cfg
+++ b/input_samples/cfgs/missing_parton_run3_central_tzq_NDSkim.cfg
@@ -1,0 +1,8 @@
+# Run 3 central NLO tZq samples for missing-parton input pkl production.
+# This cfg is intentionally limited to central tZq NDSkim JSONs.
+
+root://cmsxrootd.crc.nd.edu/
+../../input_samples/sample_jsons/signal_samples/ND_skim2022/TZQB-Zto2L-4FS_MLL-30_NDSkim_2022.json
+../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/TZQB-Zto2L-4FS_MLL-30_NDSkim_2022EE.json
+../../input_samples/sample_jsons/signal_samples/ND_skim2023/TZQB-Zto2L-4FS_MLL-30_NDSkim_2023.json
+../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/TZQB-Zto2L-4FS_MLL-30_NDSkim_2023BPix.json

--- a/input_samples/cfgs/missing_parton_run3_private_tllq_NDSkim.cfg
+++ b/input_samples/cfgs/missing_parton_run3_private_tllq_NDSkim.cfg
@@ -1,0 +1,8 @@
+# Run 3 private LO tllq samples for missing-parton input pkl production.
+# This cfg is intentionally limited to private tllq JSONs.
+
+root://cmsxrootd.crc.nd.edu/
+../../input_samples/sample_jsons/signal_samples/ND_skim2022/tllq_2022.json
+../../input_samples/sample_jsons/signal_samples/ND_skim2022EE/tllq_2022EE.json
+../../input_samples/sample_jsons/signal_samples/ND_skim2023/tllq_2023.json
+../../input_samples/sample_jsons/signal_samples/ND_skim2023BPix/tllq_2023BPix.json

--- a/input_samples/cfgs/missing_parton_top22006_central_tzq_NDSkim.cfg
+++ b/input_samples/cfgs/missing_parton_top22006_central_tzq_NDSkim.cfg
@@ -1,0 +1,8 @@
+# Run 2 central NLO tZq samples for TOP-22-006 missing-parton input pkl production.
+# This cfg is intentionally limited to central tZq NDSkim JSONs.
+
+root://cmsxrootd.crc.nd.edu/
+../../input_samples/sample_jsons/signal_samples/central_UL/UL16APV_tZq_NDSkim.json
+../../input_samples/sample_jsons/signal_samples/central_UL/UL16_tZq_NDSkim.json
+../../input_samples/sample_jsons/signal_samples/central_UL/UL17_tZq_NDSkim.json
+../../input_samples/sample_jsons/signal_samples/central_UL/UL18_tZq_NDSkim.json

--- a/input_samples/cfgs/missing_parton_top22006_private_tllq_NDSkim.cfg
+++ b/input_samples/cfgs/missing_parton_top22006_private_tllq_NDSkim.cfg
@@ -1,0 +1,8 @@
+# Run 2 private LO tllq samples for TOP-22-006 missing-parton input pkl production.
+# This cfg is intentionally limited to private tllq NDSkim JSONs.
+
+root://cmsxrootd.crc.nd.edu/
+../../input_samples/sample_jsons/signal_samples/private_UL/UL16APV_tllq_b1_NDSkim.json
+../../input_samples/sample_jsons/signal_samples/private_UL/UL16_tllq_b1_NDSkim.json
+../../input_samples/sample_jsons/signal_samples/private_UL/UL17_tllq_b1_NDSkim.json
+../../input_samples/sample_jsons/signal_samples/private_UL/UL18_tllq_b1_NDSkim.json

--- a/input_samples/sample_jsons/signal_samples/ND_SRskim2022/tllq_NDSkim_2022.json
+++ b/input_samples/sample_jsons/signal_samples/ND_SRskim2022/tllq_NDSkim_2022.json
@@ -1,5 +1,5 @@
 {
-  "xsec": 0.0758,
+  "xsec": 0.08,
   "year": "2022",
   "treeName": "Events",
   "histAxisName": "tllq_private2022",

--- a/input_samples/sample_jsons/signal_samples/ND_SRskim2022EE/tllq_NDSkim_2022EE.json
+++ b/input_samples/sample_jsons/signal_samples/ND_SRskim2022EE/tllq_NDSkim_2022EE.json
@@ -1,5 +1,5 @@
 {
-  "xsec": 0.0758,
+  "xsec": 0.08,
   "year": "2022EE",
   "treeName": "Events",
   "histAxisName": "tllq_private2022EE",

--- a/input_samples/sample_jsons/signal_samples/ND_SRskim2023/tllq_NDSkim_2023.json
+++ b/input_samples/sample_jsons/signal_samples/ND_SRskim2023/tllq_NDSkim_2023.json
@@ -1,5 +1,5 @@
 {
-  "xsec": 0.0758,
+  "xsec": 0.08,
   "year": "2023",
   "treeName": "Events",
   "histAxisName": "tllq_private2023",

--- a/input_samples/sample_jsons/signal_samples/ND_SRskim2023BPix/tllq_NDSkim_2023BPix.json
+++ b/input_samples/sample_jsons/signal_samples/ND_SRskim2023BPix/tllq_NDSkim_2023BPix.json
@@ -1,5 +1,5 @@
 {
-  "xsec": 0.0758,
+  "xsec": 0.08,
   "year": "2023BPix",
   "treeName": "Events",
   "histAxisName": "tllq_private2023BPix",

--- a/input_samples/sample_jsons/signal_samples/ND_skim2022/TZQB-Zto2L-4FS_MLL-30_NDSkim_2022.json
+++ b/input_samples/sample_jsons/signal_samples/ND_skim2022/TZQB-Zto2L-4FS_MLL-30_NDSkim_2022.json
@@ -2,7 +2,7 @@
   "xsec": 0.08,
   "year": "2022",
   "treeName": "Events",
-  "histAxisName": " TZQB-Zto2L-4FS_MLL-30_central2022",
+  "histAxisName": "tZq_central2022",
   "options": "",
   "WCnames": [],
   "files": [

--- a/input_samples/sample_jsons/signal_samples/ND_skim2022/tllq_2022.json
+++ b/input_samples/sample_jsons/signal_samples/ND_skim2022/tllq_2022.json
@@ -1,5 +1,5 @@
 {
-    "xsec": 0.0758,
+    "xsec": 0.08,
     "year": "2022",
     "treeName": "Events",
     "histAxisName": "tllq_private2022",

--- a/input_samples/sample_jsons/signal_samples/ND_skim2022EE/TZQB-Zto2L-4FS_MLL-30_NDSkim_2022EE.json
+++ b/input_samples/sample_jsons/signal_samples/ND_skim2022EE/TZQB-Zto2L-4FS_MLL-30_NDSkim_2022EE.json
@@ -2,7 +2,7 @@
   "xsec": 0.08,
   "year": "2022EE",
   "treeName": "Events",
-  "histAxisName": " TZQB-Zto2L-4FS_MLL-30_central2022EE",
+  "histAxisName": "tZq_central2022EE",
   "options": "",
   "WCnames": [],
   "files": [

--- a/input_samples/sample_jsons/signal_samples/ND_skim2022EE/tllq_2022EE.json
+++ b/input_samples/sample_jsons/signal_samples/ND_skim2022EE/tllq_2022EE.json
@@ -1,5 +1,5 @@
 {
-    "xsec": 0.0758,
+    "xsec": 0.08,
     "year": "2022EE",
     "treeName": "Events",
     "histAxisName": "tllq_private2022EE",

--- a/input_samples/sample_jsons/signal_samples/ND_skim2023/TZQB-Zto2L-4FS_MLL-30_NDSkim_2023.json
+++ b/input_samples/sample_jsons/signal_samples/ND_skim2023/TZQB-Zto2L-4FS_MLL-30_NDSkim_2023.json
@@ -2,7 +2,7 @@
     "xsec": 0.08,
     "year": "2023",
     "treeName": "Events",
-    "histAxisName": " TZQB-Zto2L-4FS_MLL-30_central2023",
+    "histAxisName": "tZq_central2023",
     "options": "",
     "WCnames": [],
     "files": [

--- a/input_samples/sample_jsons/signal_samples/ND_skim2023/tllq_2023.json
+++ b/input_samples/sample_jsons/signal_samples/ND_skim2023/tllq_2023.json
@@ -1,5 +1,5 @@
 {
-    "xsec": 0.0758,
+    "xsec": 0.08,
     "year": "2023",
     "treeName": "Events",
     "histAxisName": "tllq_private2023",

--- a/input_samples/sample_jsons/signal_samples/ND_skim2023BPix/TZQB-Zto2L-4FS_MLL-30_NDSkim_2023BPix.json
+++ b/input_samples/sample_jsons/signal_samples/ND_skim2023BPix/TZQB-Zto2L-4FS_MLL-30_NDSkim_2023BPix.json
@@ -2,7 +2,7 @@
     "xsec": 0.08,
     "year": "2023BPix",
     "treeName": "Events",
-    "histAxisName": " TZQB-Zto2L-4FS_MLL-30_central2023BPix",
+    "histAxisName": "tZq_central2023BPix",
     "options": "",
     "WCnames": [],
     "files": [

--- a/input_samples/sample_jsons/signal_samples/ND_skim2023BPix/tllq_2023BPix.json
+++ b/input_samples/sample_jsons/signal_samples/ND_skim2023BPix/tllq_2023BPix.json
@@ -1,5 +1,5 @@
 {
-    "xsec": 0.0758,
+    "xsec": 0.08,
     "year": "2023BPix",
     "treeName": "Events",
     "histAxisName": "tllq_private2023BPix",

--- a/topeft/params/cr_sr_plots_metadata.yml
+++ b/topeft/params/cr_sr_plots_metadata.yml
@@ -648,7 +648,7 @@ REGION_PLOTTING:
       - Nonprompt
     - categories:
         prefixes:
-        - 1l_1tau_CRtt
+        - 1l_1tau
         - 2l
         - 3l
       groups:


### PR DESCRIPTION
### Summary

- Update eight private tllq sample JSONs to use the approved 0.08 cross section across the Run 3 ND and ND SR skims.
- Normalize the four central Run 3 tZq histogram process labels to the existing tZq_central year naming convention.
- Retain the control-region campaign helper settings, Work Queue master-name format, plotting metadata update, and four central/private input cfgs.

### Motivation

The sample metadata needs consistent private tllq normalization and central tZq process labels across the supported Run 3 periods. The retained helper, plotting, and cfg updates keep the associated analysis configuration aligned with those inputs.

### Implementation details

A. Sample metadata and input cfgs

- Updated eight private tllq JSON files from 0.0758 to 0.08.
- Updated four central Run 3 tZq histAxisName values to tZq_central2022, tZq_central2022EE, tZq_central2023, and tZq_central2023BPix.
- Added four cfgs for the central/private Run 2 and Run 3 input sample sets. These cfgs only resolve ordinary sample JSON inputs; no missing-parton implementation or DatacardMaker source is included.

B. Analysis configuration

- Retained the reviewed run_cr.sh campaign settings and the run_sow.py Work Queue master-name format.
- Updated the plotting metadata tau prefix while retaining the canonical 2los_CRtt 2j leaf.
- No main processor, main runner, acceptance diagnostic, DatacardMaker, or missing-parton implementation source changed.

### Testing

- Parsed all twelve changed JSON files and compared approved fields with the reference and frozen versions.
- Ran run_analysis.py cfg resolution in --pretend mode for all four cfgs; each resolved four samples without executing analysis processing.
- Ran bash -n analysis/topeft_run2/run_cr.sh.
- Ran python -m py_compile analysis/topeft_run2/run_sow.py and a source-level master-name check.
- Ran the focused CR metadata producer-truth test.

Targeted validation passed. Production campaign validation was not run.

### Review notes

- The four cfgs are input configuration only; the missing-parton implementation and DatacardMaker integration are intentionally out of scope.
- A separate forward-gate token assertion still fails on the base branch and is not changed by this PR.
