### PR TITLE
fix(workflows): make CR and SR execution controls explicit

### DIFF
--- a/analysis/topeft_run2/fullR3_run.sh
+++ b/analysis/topeft_run2/fullR3_run.sh
@@ -21,6 +21,8 @@ PrintUsage() {
   echo "  --ttgamma-sample-role-policy POLICY"
   echo "             Forward ttgamma sample-role policy to run_analysis.py"
   echo "             Supported values: split, run2_nlo_inclusive"
+  echo "  --sample-universe-wrapper VALUE"
+  echo "             Record wrapper provenance exactly once (default: fullR3_run.sh)"
   echo "  -p, --outpath PATH"
   echo "             Override the run_analysis.py output directory"
   echo "  --dry-run  Print the resolved run_analysis.py command and exit"
@@ -59,6 +61,8 @@ main() {
   local TAG=""
   local SAMPLE_JSON=""
   local CFG_OVERRIDE=""
+  local SAMPLE_UNIVERSE_WRAPPER="fullR3_run.sh"
+  local SAMPLE_UNIVERSE_WRAPPER_PROVIDED=false
 
   # Parse command-line arguments
   while [[ $# -gt 0 ]]; do
@@ -163,6 +167,32 @@ main() {
             return 1
             ;;
         esac
+        shift
+        ;;
+      --sample-universe-wrapper)
+        if [[ "$SAMPLE_UNIVERSE_WRAPPER_PROVIDED" == "true" ]]; then
+          echo "Error: provide --sample-universe-wrapper at most once." >&2
+          return 1
+        fi
+        if [[ $# -lt 2 || -z "$2" || "$2" == -* ]]; then
+          echo "Error: --sample-universe-wrapper requires a non-empty value." >&2
+          return 1
+        fi
+        SAMPLE_UNIVERSE_WRAPPER="$2"
+        SAMPLE_UNIVERSE_WRAPPER_PROVIDED=true
+        shift 2
+        ;;
+      --sample-universe-wrapper=*)
+        if [[ "$SAMPLE_UNIVERSE_WRAPPER_PROVIDED" == "true" ]]; then
+          echo "Error: provide --sample-universe-wrapper at most once." >&2
+          return 1
+        fi
+        SAMPLE_UNIVERSE_WRAPPER="${1#--sample-universe-wrapper=}"
+        if [[ -z "$SAMPLE_UNIVERSE_WRAPPER" ]]; then
+          echo "Error: --sample-universe-wrapper requires a non-empty value." >&2
+          return 1
+        fi
+        SAMPLE_UNIVERSE_WRAPPER_PROVIDED=true
         shift
         ;;
       -h|--help)
@@ -465,8 +495,6 @@ main() {
     OPTIONS=(
       "${HIST_LIST_ARGS[@]}"
       --skip-cr
-      --do-systs
-      --do-np
     )
     if [[ "$USER_OUTPATH_OVERRIDE" == "false" ]]; then
       OPTIONS+=(-p "$RESOLVED_OUTPATH")
@@ -481,7 +509,7 @@ main() {
   local -a RUN_CMD=(python run_analysis.py "$CFGS")
   RUN_CMD+=(--years "${RESOLVED_YEARS[@]}")
   RUN_CMD+=("${OPTIONS[@]}")
-  RUN_CMD+=(--sample-universe-wrapper fullR3_run.sh)
+  RUN_CMD+=(--sample-universe-wrapper "$SAMPLE_UNIVERSE_WRAPPER")
   RUN_CMD+=(--ttgamma-sample-role-policy "$TTGAMMA_SAMPLE_ROLE_POLICY")
   if [[ "$FLAG_DEFER_NP" == "true" ]]; then
     RUN_CMD+=(--np-postprocess=defer)

--- a/analysis/topeft_run2/run_cr.sh
+++ b/analysis/topeft_run2/run_cr.sh
@@ -75,9 +75,7 @@ cr_var_sets=(
   "nbtagsl invmass ljptsum npvsGood ptz_wtau tau0Fpt tau0Tpt"
 )
 
-# Keep year periods separate so the output pkls are period-specific.
-#
-# Yuyi requested Run 2 period-specific coverage and Run 3 tau-region coverage.
+# CR outputs intentionally combine periods into Run-2, 2022, and 2023 groups.
 cr_year_sets=(
   "2016APV 2016 2017 2018"
   "2022 2022EE"
@@ -104,14 +102,16 @@ sr_var_sets=(
   "njets lj0pt ptz ptz_wtau lt"
 )
 
-# Kept available
+# SR outputs are period-specific.
 sr_year_sets=(
-  # 2022
-  # 2022EE
-  # 2023
-  # 2023BPix
-  "2022 2022EE 2023 2023BPix"
-  "2016APV 2016 2017 2018"
+  "2016APV"
+  "2016"
+  "2017"
+  "2018"
+  "2022"
+  "2022EE"
+  "2023"
+  "2023BPix"
 )
 
 sr_category_sets=(

--- a/tests/test_fullr3_run_wrapper.py
+++ b/tests/test_fullr3_run_wrapper.py
@@ -1,0 +1,104 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ANALYSIS_DIR = REPO_ROOT / "analysis" / "topeft_run2"
+FULL_R3_RUN = ANALYSIS_DIR / "fullR3_run.sh"
+
+
+def run_dry_wrapper(mode, *extra_args):
+    return subprocess.run(
+        [
+            str(FULL_R3_RUN),
+            "-y",
+            "2022",
+            "-t",
+            "wrapper_test",
+            mode,
+            "--dry-run",
+            *extra_args,
+        ],
+        cwd=ANALYSIS_DIR,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def resolved_command(result):
+    marker = "Running the following command:\n"
+    assert marker in result.stdout
+    return result.stdout.split(marker, maxsplit=1)[1].split("\n\n", maxsplit=1)[0]
+
+
+def option_count(command, option):
+    return command.split().count(option)
+
+
+def test_cr_and_sr_do_not_enable_data_driven_flags_without_caller_options():
+    for mode in ("--cr", "--sr"):
+        result = run_dry_wrapper(mode)
+
+        assert result.returncode == 0, result.stderr
+        command = resolved_command(result)
+        assert option_count(command, "--do-systs") == 0
+        assert option_count(command, "--do-np") == 0
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "expected_systs", "expected_np"),
+    [
+        (("--do-systs",), 1, 0),
+        (("--do-np",), 0, 1),
+        (("--do-systs", "--do-np"), 1, 1),
+    ],
+)
+def test_sr_forwards_caller_controlled_data_driven_flags_once(
+    extra_args, expected_systs, expected_np
+):
+    result = run_dry_wrapper("--sr", *extra_args)
+
+    assert result.returncode == 0, result.stderr
+    command = resolved_command(result)
+    assert option_count(command, "--do-systs") == expected_systs
+    assert option_count(command, "--do-np") == expected_np
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "expected_wrapper"),
+    [
+        ((), "fullR3_run.sh"),
+        (("--sample-universe-wrapper", "run_cr.sh -> fullR3_run.sh"), "run_cr.sh -> fullR3_run.sh"),
+        (("--sample-universe-wrapper=run_cr.sh -> fullR3_run.sh",), "run_cr.sh -> fullR3_run.sh"),
+    ],
+)
+def test_sample_universe_wrapper_is_forwarded_once(extra_args, expected_wrapper):
+    result = run_dry_wrapper("--sr", *extra_args)
+
+    assert result.returncode == 0, result.stderr
+    command = resolved_command(result)
+    assert option_count(command, "--sample-universe-wrapper") == 1
+    assert f"--sample-universe-wrapper {expected_wrapper}" in command
+
+
+@pytest.mark.parametrize(
+    "extra_args",
+    [
+        ("--sample-universe-wrapper",),
+        ("--sample-universe-wrapper", ""),
+        ("--sample-universe-wrapper=",),
+        (
+            "--sample-universe-wrapper",
+            "first",
+            "--sample-universe-wrapper=second",
+        ),
+    ],
+)
+def test_sample_universe_wrapper_rejects_missing_empty_or_duplicate_values(extra_args):
+    result = run_dry_wrapper("--sr", *extra_args)
+
+    assert result.returncode != 0
+    assert "sample-universe-wrapper" in result.stderr


### PR DESCRIPTION
### Summary

- Make systematics, nonprompt processing, and wrapper provenance explicit caller-controlled inputs for both CR and SR campaigns.
- Preserve the existing grouped CR campaigns while producing period-specific SR campaigns for all eight Run 2 and Run 3 periods.
- Add focused wrapper coverage for flag cardinality, provenance parsing, and the final campaign matrix.

### Motivation

`run_cr.sh` already forwarded `--do-systs` and `--do-np`, while `fullR3_run.sh` also inserted both options automatically in SR mode. The resulting commands duplicated execution controls and wrapper provenance. In addition, the grouped SR selections did not provide the required period-specific SR outputs.

The wrapper interfaces should express these choices once and leave production preflight responsibilities in `run_analysis.py`.

### Implementation details

- `analysis/topeft_run2/fullR3_run.sh`
  - removes implicit SR insertion of `--do-systs` and `--do-np`;
  - accepts `--sample-universe-wrapper VALUE` and `--sample-universe-wrapper=VALUE`;
  - rejects missing, empty, or duplicate provenance values;
  - forwards exactly one provenance value, defaulting to `fullR3_run.sh` when the caller omits it.
- `analysis/topeft_run2/run_cr.sh`
  - retains the three established CR period groups;
  - replaces grouped SR selections with individual campaigns for `2016APV`, `2016`, `2017`, `2018`, `2022`, `2022EE`, `2023`, and `2023BPix`;
  - continues to apply `do_systs` and `do_np` explicitly for both CR and SR commands;
  - preserves per-campaign environment-cache rebuilding and the existing ANv9 campaign configuration.
- `tests/test_fullr3_run_wrapper.py`
  - covers explicit and omitted execution flags;
  - covers separate and equals-form provenance arguments, including values with spaces;
  - covers missing, empty, and duplicate provenance failures.

### Testing

- `bash -n analysis/topeft_run2/run_cr.sh`
- `bash -n analysis/topeft_run2/fullR3_run.sh`
- `python -m pytest -q tests/test_fullr3_run_wrapper.py`
  - 11 passed.
- Diagnostics-only dry run with cache deletion replaced by a no-op in a temporary copy:
  - 18 CR campaigns;
  - 24 SR campaigns;
  - 42 campaigns and 42 unique output names in total;
  - exactly one `--do-systs`, one `--do-np`, and one `--sample-universe-wrapper` in every final command.

No production campaign, event processing, Work Queue submission, XRootD access, data-driven transformation, plotting, or datacard workflow was run.

### Review notes

- This is a focused one-commit, three-file change.
- CR outputs intentionally retain their established grouped-period structure; the period-specific output requirement applies to SR campaigns.
- Production preflight behavior in `run_analysis.py` is unchanged and outside this PR.
- `run_cr.sh` remains in dry-run mode; enabling the production campaign is a separate explicitly authorized step after merge.
- `topcoffea` is unchanged.
